### PR TITLE
fix command line args for env/rhino.js

### DIFF
--- a/env/rhino.js
+++ b/env/rhino.js
@@ -16,7 +16,16 @@ load("jshint.js");
     if (optstr) {
         optstr.split(',').forEach(function (arg) {
             var o = arg.split('=');
-            opts[o[0]] = o[1];
+            opts[o[0]] = (function (ov) {
+                switch (ov) {
+                case 'true':
+                    return true;
+                case 'false':
+                    return false;
+                default:
+                    return ov;
+                }
+            })(o[1]);
         });
     }
 


### PR DESCRIPTION
I've found that rhino interprets the command line args as strings. So given:

`java -jar path/to/rhino.jar env/rhino.js path/to/my.js white=false,maxerr=100`

The `false` was being interpreted as a truthy string and the strict whitespace rules were being applied. (Ditto `white=0` -- so that wasn't a workaround that could be recommended either.)

The command line arg for JSHINT options was introduced here: 9991adff54f1134b6c8ffc5ef2343feb92ad3e2b

just trying to give a little back,

-r
