### PR TITLE
Add XPathResult to browser enviroment

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -435,6 +435,11 @@ var JSHINT = (function () {
             window          : false,
             Worker          : false,
             XMLHttpRequest  : false,
+            XPathEvaluator  : false,
+            XPathException  : false,
+            XPathExpression  : false,
+            XPathNamespace  : false,
+            XPathNSResolver  : false,
             XPathResult  : false
         },
 


### PR DESCRIPTION
XPathResult is a w3 standard, see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult

Related issue #108
