### PR TITLE
Added support for /*jslint options

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -611,7 +611,7 @@ var JSHINT = (function () {
 // unsafe characters that are silently deleted by one or more browsers
         cx = /[\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/,
 // token
-        tx = /^\s*([(){}\[.,:;'"~\?\]#@]|==?=?|\/(\*(jshint|members?|global)?|=|\/)?|\*[\/=]?|\+(?:=|\++)?|-(?:=|-+)?|%=?|&[&=]?|\|[|=]?|>>?>?=?|<([\/=!]|\!(\[|--)?|<=?)?|\^=?|\!=?=?|[a-zA-Z_$][a-zA-Z0-9_$]*|[0-9]+([xX][0-9a-fA-F]+|\.[0-9]*)?([eE][+\-]?[0-9]+)?)/,
+        tx = /^\s*([(){}\[.,:;'"~\?\]#@]|==?=?|\/(\*(jshint|jslint|members?|global)?|=|\/)?|\*[\/=]?|\+(?:=|\++)?|-(?:=|-+)?|%=?|&[&=]?|\|[|=]?|>>?>?=?|<([\/=!]|\!(\[|--)?|<=?)?|\^=?|\!=?=?|[a-zA-Z_$][a-zA-Z0-9_$]*|[0-9]+([xX][0-9a-fA-F]+|\.[0-9]*)?([eE][+\-]?[0-9]+)?)/,
 // characters in strings that need escapement
         nx = /[\u0000-\u001f&<"\/\\\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/,
         nxg = /[\u0000-\u001f&<"\/\\\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
@@ -1162,6 +1162,7 @@ var JSHINT = (function () {
                         case '/*members':
                         case '/*member':
                         case '/*jshint':
+                        case '/*jslint':
                         case '/*global':
                         case '*/':
                             return {
@@ -1480,6 +1481,7 @@ klass:                                  do {
             obj = membersOnly;
             break;
         case '/*jshint':
+        case '/*jslint':
             obj = option;
             filter = boolOptions;
             break;
@@ -1511,7 +1513,7 @@ loop:   for (;;) {
                     error("Expected '{a}' and instead saw '{b}'.",
                             t, '*/', ':');
                 }
-                if (t.value === 'indent' && o === '/*jshint') {
+                if (t.value === 'indent' && (o === '/*jshint' || o === '/*jslint')) {
                     b = +v.value;
                     if (typeof b !== 'number' || !isFinite(b) || b <= 0 ||
                             Math.floor(b) !== b) {
@@ -1520,7 +1522,7 @@ loop:   for (;;) {
                     }
                     obj.white = true;
                     obj.indent = b;
-                } else if (t.value === 'maxerr' && o === '/*jshint') {
+                } else if (t.value === 'maxerr' && (o === '/*jshint' || o === '/*jslint')) {
                     b = +v.value;
                     if (typeof b !== 'number' || !isFinite(b) || b <= 0 ||
                             Math.floor(b) !== b) {
@@ -1528,7 +1530,7 @@ loop:   for (;;) {
                                 v, v.value);
                     }
                     obj.maxerr = b;
-                } else if (t.value === 'maxlen' && o === '/*jshint') {
+                } else if (t.value === 'maxlen' && (o === '/*jshint' || o === '/*jslint')) {
                     b = +v.value;
                     if (typeof b !== 'number' || !isFinite(b) || b <= 0 ||
                             Math.floor(b) !== b) {
@@ -1545,7 +1547,7 @@ loop:   for (;;) {
                 }
                 t = lex.token();
             } else {
-                if (o === '/*jshint') {
+                if (o === '/*jshint' || o === '/*jslint') {
                     error("Missing option value.", t);
                 }
                 obj[t.value] = false;

--- a/tests/fixtures/jslintOptions.js
+++ b/tests/fixtures/jslintOptions.js
@@ -1,0 +1,9 @@
+/*jslint evil: true */
+/*jshint boss: true */
+
+if (e = 1)
+    doSomething();
+
+eval('function() {}');
+
+

--- a/tests/options.js
+++ b/tests/options.js
@@ -625,3 +625,12 @@ exports.white = function () {
     assert.eql(JSHINT.errors[0].line, 2);
     assert.eql(JSHINT.errors[0].reason, "Trailing whitespace.");
 };
+
+/**
+ * jshint should not only read jshint, but also jslint options
+ */
+exports.jslintOptions = function() {
+    var src = fs.readFileSync(__dirname + '/fixtures/jslintOptions.js', 'utf8');
+
+    assert.ok(JSHINT(src));
+};


### PR DESCRIPTION
jshint options can now be set by either /_jshint or /_jslint. This can
be useful if you are working on a project that uses jslint, but you want
to use jshint instead, i.e. by using jshint.vim.

I added a basic test in options.js and added a fixture. 

Let me know if you have any further questions or if you want me to change the anything.

Cheers,

Gilles Ruppert
