### PR TITLE
'lastsemic' option to allow skipping semicolons in one-line blocks

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -192,9 +192,9 @@
  GLOBAL, global, globals, globalstrict, hasOwnProperty, help, history, i, id,
  identifier, immed, implieds, include, indent, indexOf, init, ins, instanceOf,
  isAlpha, isApplicationRunning, isArray, isDigit, isFinite, isNaN, join, jshint,
- JSHINT, json, jquery, jQuery, keys, label, labelled, last, laxbreak, latedef,
- lbp, led, left, length, line, load, loadClass, localStorage, location, log,
- loopfunc, m, match, maxerr, maxlen, member,message, meta, module, moveBy,
+ JSHINT, json, jquery, jQuery, keys, label, labelled, last, lastsemic, laxbreak,
+ latedef, lbp, led, left, length, line, load, loadClass, localStorage, location,
+ log, loopfunc, m, match, maxerr, maxlen, member,message, meta, module, moveBy,
  moveTo, mootools, name, navigator, new, newcap, noarg, node, noempty, nomen,
  nonew, nud, onbeforeunload, onblur, onerror, onevar, onfocus, onload, onresize,
  onunload, open, openDatabase, openURL, opener, opera, outer, param, parent,
@@ -2144,7 +2144,7 @@ loop:   for (;;) {
                 warning("Do not use 'new' for side effects.");
             }
             if (nexttoken.id !== ';') {
-                if (!option.asi) {
+                if (!option.asi && !(option.lastsemic && nexttoken.id == '}' && nexttoken.line == token.line)) {
                     warningAt("Missing semicolon.", token.line, token.from + token.value.length);
                 }
             } else {

--- a/tests/fixtures/lastsemic.js
+++ b/tests/fixtures/lastsemic.js
@@ -1,0 +1,6 @@
+function foo() {
+    open()
+    read();
+    [1, 2, 3].forEach(function(i) { print(i) });
+    close()
+}

--- a/tests/options.js
+++ b/tests/options.js
@@ -161,6 +161,35 @@ exports.asi = function () {
     assert.ok(JSHINT(code, { asi: true }));
 };
 
+/** Option `lastsemic` allows you to skip the semicolon after last statement in a block,
+  * if that statement is followed by the closing brace on the same line. */
+exports.lastsemic = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/lastsemic.js', 'utf8');
+
+    // without lastsemic
+    assert.eql(false, JSHINT(src));
+    assert.eql(JSHINT.errors.length, 3);
+    assert.eql(JSHINT.errors[0].line, 2);
+    assert.eql(JSHINT.errors[0].reason, 'Missing semicolon.');  // missing semicolon in the middle of a block
+    assert.eql(JSHINT.errors[1].line, 4);
+    assert.eql(JSHINT.errors[1].reason, 'Missing semicolon.');  // missing semicolon in a one-liner function
+    assert.eql(JSHINT.errors[2].line, 5);
+    assert.eql(JSHINT.errors[2].reason, 'Missing semicolon.');  // missing semicolon at the end of a block
+
+    // with lastsemic
+    assert.eql(false, JSHINT(src, { lastsemic: true }));
+    assert.eql(JSHINT.errors.length, 2);
+    assert.eql(JSHINT.errors[0].line, 2);
+    assert.eql(JSHINT.errors[0].reason, 'Missing semicolon.');
+    assert.eql(JSHINT.errors[1].line, 5);
+    assert.eql(JSHINT.errors[1].reason, 'Missing semicolon.');
+    // this line is valid now: [1, 2, 3].forEach(function(i) { print(i) });
+    // line 5 isn't, because the block doesn't close on the same line
+
+    // it shouldn't interfere with asi option
+    assert.eql(true, JSHINT(src, { lastsemic: true, asi: true }));
+};
+
 /**
  * Option `expr` allows you to use ExpressionStatement as a Program code.
  *


### PR DESCRIPTION
Some time ago I wrote a Ruby wrapper for running JSLint in Rails projects, [jslint_on_rails](/psionides/jslint_on_rails). I didn't completely agree with everything JSLint reported - there were a few things that I didn't want to change in my projects just to make JSLint pass (as someone said, "JSLint is not harmful. Bending over backwards to pass the JSLint test is"). That said, I still wanted it to pass in order to integrate it in my build process.

So I made a few tweaks to my JSLint copy, adding 3 options that disabled some types of warnings. The options were:
- 'newstat' to allow using `new` operator as a statement (as in: `new Ajax.Request(url);`)
- 'statinexp' to allow writing statements that seemed to be just expressions to JSLint, like `foo && foo.print();`
- 'lastsemic' to allow skipping semicolons inside one-line blocks, like `items.each(function(i) { print(i) });`

I updated JSLint a few times, but at some point I thought that the changes were going in a direction I didn't like and I stopped updating it (I gave up when `eqeqeq` was removed). And since now I have an option to switch to JSHint instead, I'm planning to do just that (I even have 2-3 forks with that change waiting to be merged).

As for the options I've added to my copy, 'newstat' is exactly what you've added as 'nonew' (or more precisely, the exact opposite of that). 'statinexp' is a subset of your option 'expr', and I guess I'm fine with just enabling 'expr' instead.

So this leaves just 'lastsemic', which is technically a subset of 'asi', but the 'asi' option has a much larger scope and I'd rather not turn it on (no flame intended, just my personal preference). Now, I can either add this option again to the JSHint copy I put inside jslint_on_rails, and keep merging the change manually as I did with JSLint, or I can try to convince you to include this option in the master copy. I decided to try the latter :) (I'm fine with changing the name of the option if you have a better idea).
