### PR TITLE
Add support for indented "case" statements, empty lines of whitespace, and unescaped dashes at the end of regex.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -181,7 +181,7 @@
  XPathExpression, XPathNamespace, XPathNSResolver, XPathResult, "\\", a,
  addEventListener, address, alert, apply, applicationCache, arguments, arity,
  asi, b, bitwise, block, blur, boolOptions, boss, browser, c, call, callee,
- caller, cases, charAt, charCodeAt, character, clearInterval, clearTimeout,
+ caller, caseindent, cases, charAt, charCodeAt, character, clearInterval, clearTimeout,
  close, closed, closure, comment, condition, confirm, console, constructor,
  content, couch, create, css, curly, d, data, datalist, dd, debug, decodeURI,
  decodeURIComponent, defaultStatus, defineClass, deserialize, devel, document,
@@ -194,7 +194,7 @@
  isAlpha, isApplicationRunning, isArray, isDigit, isFinite, isNaN, join, jshint,
  JSHINT, json, jquery, jQuery, keys, label, labelled, last, laxbreak, latedef,
  lbp, led, left, length, line, load, loadClass, localStorage, location, log,
- loopfunc, m, match, maxerr, maxlen, member,message, meta, module, moveBy,
+ loopfunc, m, match, maxerr, maxlen, member, message, meta, module, moveBy,
  moveTo, mootools, name, navigator, new, newcap, noarg, node, noempty, nomen,
  nonew, nud, onbeforeunload, onblur, onerror, onevar, onfocus, onload, onresize,
  onunload, open, openDatabase, openURL, opener, opera, outer, param, parent,
@@ -207,7 +207,7 @@
  status, start, strict, sub, substr, supernew, shadow, supplant, sum, sync,
  test, toLowerCase, toString, toUpperCase, toint32, token, top, trailing, type,
  typeOf, Uint16Array, Uint32Array, Uint8Array, undef, unused, urls, value, valueOf,
- var, version, weakeqeq, WebSocket, white, whiteline, window, Worker, wsh*/
+ var, version, WebSocket, white, whiteline, window, Worker, wsh*/
 
 /*global exports: false */
 
@@ -245,6 +245,7 @@ var JSHINT = (function () {
             bitwise     : true, // if bitwise operators should not be allowed
             boss        : true, // if advanced usage of assignments should be allowed
             browser     : true, // if the standard browser globals should be predefined
+            caseindent  : true, // if case statements in switches should be indented
             couch       : true, // if CouchDB globals should be predefined
             curly       : true, // if curly braces around blocks should be required (even in if/for/while)
             debug       : true, // if debugger statements should be allowed
@@ -281,7 +282,6 @@ var JSHINT = (function () {
             sub         : true, // if all forms of subscript notation are tolerated
             supernew    : true, // if `new function () { ... };` and `new Object;` should be tolerated
             trailing    : true, // if trailing whitespace rules apply
-            weakeqeq    : true, // if === should be required for weak comparisons (ie. === 0)
             white       : true, // if strict whitespace rules apply
             wsh         : true, // if the Windows Scripting Host environment globals should be predefined
             whiteline   : true  // if empty lines with only whitespace are allowed (caused by auto-indenters)
@@ -2509,10 +2509,10 @@ loop:   for (;;) {
         if (!eqnull && option.eqeqeq) {
             warning("Expected '{a}' and instead saw '{b}'.",
                     this, '===', '==');
-        } else if (option.weakeqeq && isPoorRelation(left)) {
+        } else if (isPoorRelation(left)) {
             warning("Use '{a}' to compare with '{b}'.",
                 this, '===', left.value);
-        } else if (option.weakeqeq && isPoorRelation(right)) {
+        } else if (isPoorRelation(right)) {
             warning("Use '{a}' to compare with '{b}'.",
                 this, '===', right.value);
         }
@@ -2523,10 +2523,10 @@ loop:   for (;;) {
         if (option.eqeqeq) {
             warning("Expected '{a}' and instead saw '{b}'.",
                     this, '!==', '!=');
-        } else if (option.weakeqeq && isPoorRelation(left)) {
+        } else if (isPoorRelation(left)) {
             warning("Use '{a}' to compare with '{b}'.",
                     this, '!==', left.value);
-        } else if (option.weakeqeq && isPoorRelation(right)) {
+        } else if (isPoorRelation(right)) {
             warning("Use '{a}' to compare with '{b}'.",
                     this, '!==', right.value);
         }
@@ -3182,7 +3182,7 @@ loop:   for (;;) {
         t = nexttoken;
         advance('{');
         nonadjacent(token, nexttoken);
-        indent += option.indent;
+        indent += (option.caseindent ? option.indent * 2 : option.indent);
         this.cases = [];
         for (;;) {
             switch (nexttoken.id) {
@@ -3232,7 +3232,7 @@ loop:   for (;;) {
                 advance(':');
                 break;
             case '}':
-                indent -= option.indent;
+                indent -= (option.caseindent ? option.indent * 2 : option.indent);
                 indentation();
                 advance('}', t);
                 if (this.cases.length === 1 || this.condition.id === 'true' ||


### PR DESCRIPTION
Ahoy,

I've made a few changes that we needed for our coding standards at work:
1. "caseindent" -- We typically write switch-case statements with the cases indented once beyond the switch. This seems like the most common practice in languages.
2. "regexdash" -- There's a minor, valid optimization to not have to escape the "-" (dash) character in a regular expression if it's the last character in the set. ie. /[a-zA-Z-]/ So, I added an option to allow this.
3. "whiteline" -- A lot of auto-indenting editors automatically indent the following newline to match up, but not all of them _empty_ those lines upon saving. So, you end up with a lot of "invalid" lines because they're just full of whitespace. This option allows a line full of just whitespace to pass.

I'm thinking the caseindent option is one people will like, but I'm not sure about the rest. And I'm also not certain how well-implemented that option is; I recall people wanting more flexible spacing options. But, there they are! I hope these are useful to someone.
