### PR TITLE
Option to override mediawiki pain in the ass issues

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -262,6 +262,7 @@ var JSHINT = (function () {
             laxbreak    : true, // if line breaks should not be checked
             loopfunc    : true, // if functions should be allowed to be defined within loops
             mootools    : true, // if MooTools globals should be predefined
+            mediawiki   : true, // if MediaWiki is to be expected to be the target, ignores certain string escapes like [\~\{\}]
             newcap      : true, // if constructor names must be capitalized
             noarg       : true, // if arguments.caller and arguments.callee should be disallowed
             node        : true, // if the Node.js environment globals should be predefined
@@ -1073,6 +1074,15 @@ var JSHINT = (function () {
                                 }
                                 esc(2);
                                 break;
+                            case '~':
+                            case '{':
+                            case '}':
+                            case '[':
+                            case ']':
+                                if(option.mediawiki) {
+                                    esc(2);
+                                    break;
+                                }
                             default:
                                 warningAt("Bad escapement.", line, character);
                             }


### PR DESCRIPTION
One issue when using javascript under Mediawiki (i.e. Wikipedia et al),
is that it will expand certain constructs and autolinkage others. One
common way to prevent this is to escape characters like ~, {, }, [, and
] in strings. This might be forbidden, but it doesn't seem to prevent
any browser to parse and use the javascript anyway.

Thus adding a boolean flag "mediawiki" that won't spit out errors when
encounter said strings escaped in strings.
