### PR TITLE
Do not require BOTH getter and setter

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -2999,6 +2999,8 @@ loop:   for (;;) {
                     i = property_name();
                     if (!i) {
                         error("Missing property name.");
+                    } else {
+                        i = 'get ' + i;
                     }
                     t = nexttoken;
                     adjacent(token, nexttoken);
@@ -3008,22 +3010,26 @@ loop:   for (;;) {
                     }
                     p = f['(params)'];
                     if (p) {
-                        warning("Unexpected parameter '{a}' in get {b} function.", t, p[0], i);
+                        warning("Unexpected parameter '{a}' in {b} function.", t, p[0], i);
                     }
                     adjacent(token, nexttoken);
-                    advance(',');
-                    indentation();
+                } else if (nexttoken.value === 'set' && peek().id !== ':') {
                     advance('set');
-                    j = property_name();
-                    if (i !== j) {
-                        error("Expected {a} and instead saw {b}.", token, i, j);
+                    if (!option.es5) {
+                        error("get/set are ES5 features.");
+                    }
+                    i = property_name();
+                    if (!i) {
+                        error("Missing property name.");
+                    } else {
+                        i = 'set ' + i;
                     }
                     t = nexttoken;
                     adjacent(token, nexttoken);
                     f = doFunction();
                     p = f['(params)'];
                     if (!p || p.length !== 1 || p[0] !== 'value') {
-                        warning("Expected (value) in set {a} function.", t, i);
+                        warning("Expected (value) in {a} function.", t, i);
                     }
                 } else {
                     i = property_name();


### PR DESCRIPTION
It is annoying that JSHint requires to use BOTH getter and setter.
I think, it isn't necessary, so please make it possible to use only a getter or only a setter.
Here is a simple implementation…
