### PR TITLE
Added missing Rhino options

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -632,6 +632,8 @@ var JSHINT = (function () {
             deserialize : false,
             gc          : false,
             help        : false,
+            importPackage: false,
+            java        : false,
             load        : false,
             loadClass   : false,
             print       : false,


### PR DESCRIPTION
Some Rhino global options were missing when using `rhino:true`, so I added them.
