### PR TITLE
#223 confused scope

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -215,7 +215,7 @@
  nonew, nonstandard, nud, onbeforeunload, onblur, onerror, onevar, onecase, onfocus,
  onload, onresize, onunload, open, openDatabase, openURL, opener, opera, options, outer, param,
  parent, parseFloat, parseInt, passfail, plusplus, predef, print, process, prompt,
- proto, prototype, prototypejs, push, quit, range, raw, reach, reason, regexp,
+ proto, prototype, prototypejs, pseudoscope, push, quit, range, raw, reach, reason, regexp,
  readFile, readUrl, regexdash, removeEventListener, replace, report, require,
  reserved, resizeBy, resizeTo, resolvePath, resumeUpdates, respond, rhino, right,
  runCommand, scroll, screen, scripturl, scrollBy, scrollTo, scrollbar, search, seal,
@@ -303,6 +303,7 @@ var JSHINT = (function () {
             proto       : true, // if the `__proto__` property should be disallowed
             prototypejs : true, // if Prototype and Scriptaculous globals should be
                                 // predefined
+            pseudoscope : true, // if scope checking uses every block
             regexdash   : true, // if unescaped last dash (-) inside brackets should be
                                 // tolerated
             regexp      : true, // if the . should not be allowed in regexp literals
@@ -2383,7 +2384,7 @@ loop:   for (;;) {
             t;
 
         inblock = ordinary;
-        if (!ordinary) scope = Object.create(scope);
+        if (!ordinary || option.pseudoscope) scope = Object.create(scope);
         nonadjacent(token, nexttoken);
         t = nexttoken;
 
@@ -2418,7 +2419,7 @@ loop:   for (;;) {
             noreach = false;
         }
         funct['(verb)'] = null;
-        if (!ordinary) scope = s;
+        if (!ordinary || option.pseudoscope) scope = s;
         inblock = b;
         if (ordinary && option.noempty && (!a || a.length === 0)) {
             warning("Empty block.");

--- a/tests/fixtures/scope.js
+++ b/tests/fixtures/scope.js
@@ -1,0 +1,43 @@
+/*jshint undef: true*/
+
+function repeatedloops() {
+    for (var i = 0; i < 1; i++) {
+        for (var j = 0; j < 1; j++) {
+            var x = 2;
+        }
+    }
+
+    for (i = 0; i < 1; i++) {
+        for (j = 0; j < 1; j++) {
+            x = i;
+        }
+    }
+    
+    while (true) {
+        var aa = true;
+    }
+    while (false) {
+        aa = false;
+    }
+    
+    if (true) {
+        var bb = true;
+    }
+    if (false) {
+        bb = false;
+    }
+    
+    function xx2() {
+        var cc = 3;
+        bb = true;
+    }
+    
+    function xx3() {
+        bb = true;
+        cc = 4;
+    }
+}
+
+function repeatedloops() {
+    bb = 2;
+}

--- a/tests/options.js
+++ b/tests/options.js
@@ -810,8 +810,19 @@ exports.strings = function() {
 exports.scope = function() {
     var src = fs.readFileSync(__dirname + '/fixtures/scope.js', 'utf8');
 
-    TestRun()
+    TestRun(1)
         .addError(37, "'cc' is not defined.")
         .addError(42, "'bb' is not defined.")
         .test(src);
+
+    TestRun(2)
+        .addError(11, "'j' used out of scope.") // 3x
+        .addError(12, "'x' used out of scope.")
+        .addError(20, "'aa' used out of scope.")
+        .addError(27, "'bb' used out of scope.")
+        .addError(32, "'bb' is not defined.")
+        .addError(36, "'bb' is not defined.")
+        .addError(37, "'cc' is not defined.")
+        .addError(42, "'bb' is not defined.")
+        .test(src, { pseudoscope: true });
 };


### PR DESCRIPTION
This fixes #223.

The second commit adds an option `pseudoscope` with which the old behavior is used.
Beside global, javascript has only one real scope, but I think one should be warned if something like

``` javascript
if (true) {
    var x = 2;
}

x = 3;
```

is used... Therefore the new option.
