### PR TITLE
Ignore newline on parsing return statement

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3594,19 +3594,17 @@ loop:   for (;;) {
 
 
     stmt('return', function () {
-        if (!option.asi)
-            nolinebreak(this);
+        if (this.line === nexttoken.line) {
+            if (nexttoken.id === '(regexp)')
+                warning("Wrap the /regexp/ literal in parens to disambiguate the slash operator.");
 
-        if (nexttoken.id === '(regexp)')
-            warning("Wrap the /regexp/ literal in parens to disambiguate the slash operator.");
-
-        if (this.line === nexttoken.line || !option.asi) {
             if (nexttoken.id !== ';' && !nexttoken.reach) {
                 nonadjacent(token, nexttoken);
                 this.first = expression(20);
             }
+        } else if (!option.asi) {
+            nolinebreak(this); // always warn (Line breaking error)
         }
-
         reachable('return');
         return this;
     }).exps = true;

--- a/tests/fixtures/asi.js
+++ b/tests/fixtures/asi.js
@@ -1,3 +1,5 @@
+/*jshint undef: true*/
+
 function foo () {
     if (true) return
     var x = 1
@@ -5,7 +7,19 @@ function foo () {
 
 for (var i = 0; i < 10; i++) {
     if (i === 0) continue
+    var y = 2
     if (i === 1) break
+    var z = 3
+    
+    switch (z) {
+        case 3:
+            var m = ""
+            return
+        case 2:
+            break
+        default:
+            break
+    }
 }
 
 foo()

--- a/tests/options.js
+++ b/tests/options.js
@@ -182,18 +182,27 @@ exports.nonew = function () {
 exports.asi = function () {
     var src = fs.readFileSync(__dirname + '/fixtures/asi.js', 'utf8');
 
-    TestRun()
-        .addError(2, "Line breaking error 'return'.")
-        .addError(3, "Expected an identifier and instead saw 'var'.")
-        .addError(3, "Missing semicolon.") // TODO: Why there are two Missing semicolon warnings?
-        .addError(7, "Line breaking error 'continue'.")
-        .addError(7, "Missing semicolon.")
-        .addError(8, "Line breaking error 'break'.")
-        .addError(8, "Missing semicolon.")
+    TestRun(1)
+        .addError(4, "Line breaking error 'return'.")
+        .addError(4, "Missing semicolon.")
+        .addError(5, "Missing semicolon.")
+        .addError(9, "Line breaking error 'continue'.")
+        .addError(9, "Missing semicolon.")
+        .addError(10, "Missing semicolon.")
+        .addError(11, "Line breaking error 'break'.")
         .addError(11, "Missing semicolon.")
+        .addError(12, "Missing semicolon.")
+        .addError(16, "Missing semicolon.")
+        .addError(17, "Line breaking error 'return'.")
+        .addError(17, "Missing semicolon.")
+        .addError(19, "Line breaking error 'break'.")
+        .addError(19, "Missing semicolon.")
+        .addError(21, "Line breaking error 'break'.")
+        .addError(21, "Missing semicolon.")
+        .addError(25, "Missing semicolon.")
         .test(src);
 
-    TestRun().test(src, { asi: true });
+    TestRun(2).test(src, { asi: true });
 };
 
 /** Option `lastsemic` allows you to skip the semicolon after last statement in a block,


### PR DESCRIPTION
Statements like

```
return
var x = 2;
```

currently raises many errors because it's interpreted as

```
return var;
x = 2
```

and therefore a valid var statement is missing (which results in "undefined x")
This commit fixes this.
