### PR TITLE
Output filename on error and use stricter self-tests

### DIFF
--- a/env/jshint-rhino.js
+++ b/env/jshint-rhino.js
@@ -1,4 +1,5 @@
-/*jshint boss: true */
+/*jshint boss: true, rhino: true */
+/*globals JSHINT*/
 
 load("jshint.js");
 
@@ -26,7 +27,7 @@ load("jshint.js");
                 default:
                     return ov;
                 }
-            })(o[1]);
+            }(o[1]));
         });
     }
 
@@ -36,7 +37,7 @@ load("jshint.js");
             var global = arg.split('=');
             opts.predef[global[0]] = (function (override) {
                 return (override === 'false') ? false : true;
-            })(global[1]);
+            }(global[1]));
         });
     }
 
@@ -48,7 +49,7 @@ load("jshint.js");
     }
 
     if (!JSHINT(input, opts)) {
-        for (var i = 0, err; err = JSHINT.errors[i]; i++) {
+        for (var i = 0, err; err = JSHINT.errors[i]; i += 1) {
             print(err.reason + ' (' + name + ':' + err.line + ':' + err.character + ')');
             print('> ' + (err.evidence || '').replace(/^\s*(\S*(\s+\S+)*)\s*$/, "$1"));
             print('');

--- a/jshint.js
+++ b/jshint.js
@@ -1010,10 +1010,10 @@ var JSHINT = (function () {
                 warningAt("Line too long.", line, s.length);
 
             // Check for trailing whitespaces
-            tw = s.search(/\s+$/);
-            if (option.trailing && ~tw && !~s.search(/^\s+$/))
+            tw = /\s+$/.test(s);
+            if (option.trailing && tw && !/^\s+$/.test(s)) {
                 warningAt("Trailing whitespace.", line, tw);
-
+            }
             return true;
         }
 
@@ -2366,10 +2366,6 @@ loop:   for (;;) {
                         warningAt("Missing semicolon.", token.line, token.from +
                             token.value.length);
                     }
-                }
-                if (!option.asi && !(option.lastsemic && nexttoken.id == '}' &&
-                        nexttoken.line == token.line)) {
-
                 }
             } else {
                 adjacent(token, nexttoken);

--- a/tests/core.js
+++ b/tests/core.js
@@ -7,10 +7,28 @@ var JSHINT  = require('../jshint.js').JSHINT,
 
 /** JSHint must pass its own check */
 exports.checkJSHint = function () {
-    var res = JSHINT(fs.readFileSync(__dirname + "/../jshint.js", "utf8"));
+    var res = JSHINT(fs.readFileSync(__dirname + "/../jshint.js", "utf8"), {
+            bitwise: true,
+            eqeqeqe: true,
+            forin: true,
+            immed: true,
+            latedef: true,
+            newcap: true,
+            noarg: true,
+            noempty: true,
+            nonew: true,
+            plusplus: true,
+            regexp: true,
+            undef: true,
+            strict: true,
+            trailing: true,
+            white: true
+        });
 
-    if (!res)
+    if (!res) {
+        console.log("file: jshint.js");
         console.log(JSHINT.errors);
+    }
 
     assert.ok(res);
     assert.isUndefined(JSHINT.data().implieds);
@@ -19,22 +37,56 @@ exports.checkJSHint = function () {
 /** Rhino wrapper must pass JSHint check */
 exports.checkRhino = function () {
     var src = fs.readFileSync(__dirname + "/../env/jshint-rhino.js", "utf8");
-    TestRun().test(src, { rhino: true });
+    TestRun("jshint-rhino").test(src, {
+            bitwise: true,
+            eqeqeqe: true,
+            forin: true,
+            immed: true,
+            latedef: true,
+            newcap: true,
+            noarg: true,
+            noempty: true,
+            nonew: true,
+            plusplus: true,
+            regexp: true,
+            undef: true,
+            strict: false,
+            trailing: true,
+            white: true
+        });
 };
 
 /** All test files must pass JSHint check */
 exports.checkTestFiles = function () {
-    var files = fs.readdirSync(__dirname + '/../tests/').filter( function (e) {
-        return e.length > 2 && e.substr(e.length-3, 3) === '.js';
+    var files = fs.readdirSync(__dirname + '/../tests/').filter(function (e) {
+        return e.length > 2 && e.substr(e.length - 3, 3) === '.js';
     });
 
-    for (var i = 0, name; name = files[i]; i++) {
+    for (var i = 0, name; name = files[i]; i += 1) {
         var src = fs.readFileSync(__dirname + '/../tests/' + name, 'utf8'),
-            res = JSHINT(src);
+            res = JSHINT(src, {
+                bitwise: true,
+                eqeqeqe: true,
+                forin: true,
+                immed: true,
+                latedef: true,
+                newcap: false,
+                noarg: true,
+                noempty: true,
+                nonew: true,
+                plusplus: true,
+                regexp: true,
+                undef: true,
+                strict: false,
+                trailing: true,
+                white: true
+            });
 
-        if (!res)
+        if (!res) {
+            console.log("file: " + name);
             console.log(JSHINT.errors);
-
+        }
+        
         assert.ok(res);
         assert.isUndefined(JSHINT.data().implieds);
     }
@@ -55,10 +107,10 @@ exports.testCustomGlobals = function () {
     assert.eql(report.globals.length, 2);
 
     var dict = {};
-    for (var i = 0, g; g = report.globals[i]; i++)
+    for (var i = 0, g; g = report.globals[i]; i += 1)
         dict[g] = true;
 
-    for (i = 0, g = null; g = custom[i]; i++)
+    for (i = 0, g = null; g = custom[i]; i += 1)
         assert.ok(g in dict);
 };
 
@@ -140,12 +192,12 @@ exports.functionScopedOptions = function () {
 };
 
 /** JSHint should not only read jshint, but also jslint options */
-exports.jslintOptions = function() {
+exports.jslintOptions = function () {
     var src = fs.readFileSync(__dirname + '/fixtures/jslintOptions.js', 'utf8');
     TestRun().test(src);
 };
 
-exports.caseExpressions = function() {
+exports.caseExpressions = function () {
     var src = fs.readFileSync(__dirname + '/fixtures/caseExpressions.js', 'utf8');
     TestRun()
         .addError(2, "This 'switch' should be an 'if'.")

--- a/tests/envs.js
+++ b/tests/envs.js
@@ -22,10 +22,10 @@ assert.globalsKnown = function (globals, options) {
     assert.eql(report.globals.length, globals.length);
 
     var dict = {};
-    for (var i = 0, g; g = report.globals[i]; i++)
+    for (var i = 0, g; g = report.globals[i]; i += 1)
         globals[g] = true;
 
-    for (i = 0, g = null; g = globals[i]; i++)
+    for (i = 0, g = null; g = globals[i]; i += 1)
         assert.ok(g in globals);
 };
 
@@ -37,7 +37,7 @@ assert.globalsImplied = function (globals, options) {
     assert.isUndefined(report.globals, 0);
 
     var implieds = [];
-    for (var i = 0, warn; warn = report.implieds[i]; i++)
+    for (var i = 0, warn; warn = report.implieds[i]; i += 1)
         implieds.push(warn.name);
 
     assert.eql(implieds.length, globals.length);
@@ -63,14 +63,14 @@ exports.node = function () {
 
     // Make sure that the `node` option doesn't conflict with `nomen`
     var asGlobals = [
-      'console.log(__dirname);',
-      'console.log(__filename);'
+        'console.log(__dirname);',
+        'console.log(__filename);'
     ];
 
     var asProps = [
-      'console.log(a.__dirname);',
-      'console.log(a.__filename);',
-      'console.log(__hello);'
+        'console.log(a.__dirname);',
+        'console.log(a.__filename);',
+        'console.log(__hello);'
     ];
 
     TestRun().test(asGlobals, { node: true, nomen: true });
@@ -425,31 +425,31 @@ exports.mootools = function () {
           , 'typeOf'
           , 'URI'
           , 'Window'
-    ];
+        ];
 
     assert.globalsImplied(globals);
     assert.globalsKnown(globals, { mootools: true });
 };
 
 exports.dojo = function () {
-  var globals = [
-      'dojo'
-    , 'dijit'
-    , 'dojox'
-    , 'define'
-    , 'require'
-  ];
+    var globals = [
+        'dojo'
+      , 'dijit'
+      , 'dojox'
+      , 'define'
+      , 'require'
+    ];
 
-  assert.globalsImplied(globals);
-  assert.globalsKnown(globals, { dojo: true });
+    assert.globalsImplied(globals);
+    assert.globalsKnown(globals, { dojo: true });
 };
 
 exports.nonstandard = function () {
-  var globals = [
-      'escape'
-    , 'unescape'
-  ];
+    var globals = [
+        'escape'
+      , 'unescape'
+    ];
 
-  assert.globalsImplied(globals);
-  assert.globalsKnown(globals, { nonstandard: true });
+    assert.globalsImplied(globals);
+    assert.globalsKnown(globals, { nonstandard: true });
 };

--- a/tests/options.js
+++ b/tests/options.js
@@ -246,13 +246,13 @@ exports.expr = function () {
         "+function () {};"
     ];
 
-    for (var i = 0, exp; exp = exps[i]; i++) {
+    for (var i = 0, exp; exp = exps[i]; i += 1) {
         TestRun()
             .addError(1, 'Expected an assignment or function call and instead saw an expression.')
             .test(exp);
     }
 
-    for (i = 0, exp = null; exp = exps[i]; i++) {
+    for (i = 0, exp = null; exp = exps[i]; i += 1) {
         TestRun().test(exp, { expr: true });
     }
 };
@@ -272,7 +272,7 @@ exports.undef = function () {
 };
 
 /** Option `scripturl` allows the use of javascript-type URLs */
-exports.scripturl = function() {
+exports.scripturl = function () {
     var code = "var foo = { 'count': 12, 'href': 'javascript:' };",
         src = fs.readFileSync(__dirname + '/fixtures/scripturl.js', 'utf8');
 
@@ -405,15 +405,15 @@ exports.supernew = function () {
 
 /** Option `bitwise` disallows the use of bitwise operators. */
 exports.bitwise = function () {
-    var ops = [ '&', '|', '^', '<<' , '>>', '>>>' ];
+    var ops = [ '&', '|', '^', '<<', '>>', '>>>' ];
 
     // By default allow bitwise operators
-    for (var i = 0, op; op = ops[i]; i++) {
+    for (var i = 0, op; op = ops[i]; i += 1) {
         TestRun().test('var c = a ' + op + ' b;');
     }
     TestRun().test('var c = ~a;');
 
-    for (i = 0, op = null; op = ops[i]; i++) {
+    for (i = 0, op = null; op = ops[i]; i += 1) {
         TestRun()
             .addError(1, "Unexpected use of '" + op + "'.")
             .test('var c = a ' + op + ' b;', { bitwise: true });
@@ -492,11 +492,11 @@ exports.immed = function () {
 exports.nomen = function () {
     var names = [ '_hey', 'hey_' ];
 
-    for (var i = 0, name; name = names[i]; i++) {
+    for (var i = 0, name; name = names[i]; i += 1) {
         TestRun().test('var ' + name + ';');
     }
 
-    for (i = 0, name = null; name = names[i]; i++) {
+    for (i = 0, name = null; name = names[i]; i += 1) {
         TestRun()
             .addError(1, "Unexpected dangling '_' in '" + name + "'.")
             .test('var ' + name + ';', { nomen: true });
@@ -543,12 +543,12 @@ exports.onevar = function () {
 exports.plusplus = function () {
     var ops = [ '++', '--' ];
 
-    for (var i = 0, op; op = ops[i]; i++) {
+    for (var i = 0, op; op = ops[i]; i += 1) {
         TestRun().test('var i = j' + op + ';');
         TestRun().test('var i = ' + op + 'j;');
     }
 
-    for (i = 0, op = null; op = ops[i]; i++) {
+    for (i = 0, op = null; op = ops[i]; i += 1) {
         TestRun()
             .addError(1, "Unexpected use of '" + op + "'.")
             .test('var i = j' + op + ';', { plusplus: true });
@@ -645,7 +645,7 @@ exports.regexp = function () {
       , 'var a = /h[^...]/;'
     ];
 
-    for (var i = 0, st; st = code[i]; i++) {
+    for (var i = 0, st; st = code[i]; i += 1) {
         TestRun().test(code);
     }
 
@@ -672,7 +672,7 @@ exports.laxbreak = function () {
     var ops = [ '||', '&&', '*', '/', '%', '+', '-', '>=',
                 '==', '===', '!=', '!==', '>', '<', '<=', 'instanceof' ];
 
-    for (var i = 0, op, code; op = ops[i]; i++) {
+    for (var i = 0, op, code; op = ops[i]; i += 1) {
         code = ['var a = b ', op + ' c;'];
         TestRun()
             .addError(2, "Bad line breaking before '" + op + "'.")
@@ -815,7 +815,7 @@ exports.indentation = function () {
  * Test string relevant options
  *   multistr    allows multiline strings
  */
-exports.strings = function() {
+exports.strings = function () {
     var src = fs.readFileSync(__dirname + '/fixtures/strings.js', 'utf8');
 
     TestRun()


### PR DESCRIPTION
Update tests and according files to pass all tests with option

```
bitwise
eqeqeqe
forin
immed
latedef,
newcap (partially)
noarg
noempty
nonew
plusplus
regexp
undef
strict (partially)
trailing
white
```

on.
