### PR TITLE
Parse directives more precise

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -191,9 +191,9 @@
  ScriptEngineMajorVersion, ScriptEngineMinorVersion, Scriptaculous, Scroller,
  Slick, Slider, Selector, SharedWorker, String, Style, SyntaxError, Sortable, Sortables,
  SortableObserver, Sound, Spinner, System, Swiff, Text, TextArea, Template,
- Timer, Tips, Type, TypeError, Toggle, Try, unescape, URI, URIError, URL, VBArray, WSH,
- WScript, XDomainRequest, Web, Window, XMLDOM, XMLHttpRequest, XPathEvaluator, XPathException,
- XPathExpression, XPathNamespace, XPathNSResolver, XPathResult, "\\", a,
+ Timer, Tips, Type, TypeError, Toggle, Try, "use strict", unescape, URI, URIError, URL,
+ VBArray, WSH, WScript, XDomainRequest, Web, Window, XMLDOM, XMLHttpRequest, XPathEvaluator,
+ XPathException, XPathExpression, XPathNamespace, XPathNSResolver, XPathResult, "\\", a,
  addEventListener, address, alert, apply, applicationCache, arguments, arity,
  asi, b, bitwise, block, blur, boolOptions, boss, browser, c, call, callee,
  caller, cases, charAt, charCodeAt, character, clearInterval, clearTimeout,
@@ -709,7 +709,7 @@ var JSHINT = (function () {
             SQRT2               : true
         },
 
-        strict_mode,
+        directive,
         syntax = {},
         tab,
         token,
@@ -2392,28 +2392,6 @@ loop:   for (;;) {
     }
 
 
-    function use_strict() {
-        if (nexttoken.value === 'use strict') {
-            if (strict_mode) {
-                warning("Unnecessary \"use strict\".");
-            }
-            advance();
-            if (token.line === nexttoken.line && nexttoken.id === ';') {
-                advance(';');
-            } else {
-                warningAt("Missing semicolon.", token.line, token.from +
-                    token.value.length + 1);
-            }
-            strict_mode = true;
-            option.newcap = true;
-            option.undef = true;
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-
     function statements(startLine) {
         var a = [], f, p;
 
@@ -2430,20 +2408,81 @@ loop:   for (;;) {
 
 
     /*
+     * read all directives
+     * recognizes a simple form of asi, but always
+     * warns, if it is used
+     */
+    function directives() {
+        var i, p, pn;
+
+        for (;;) {
+            if (nexttoken.id === "(string)") {
+                p = peek(0);
+                if (p.id === "(endline)") {
+                    i = 1;
+                    do {
+                        pn = peek(i);
+                        i = i + 1;
+                    } while (pn.id === "(endline)");
+
+                    if (pn.id !== ";") {
+                        if (pn.id !== "(string)" && pn.id !== "(number)" &&
+                            pn.id !== "(regexp)" && pn.identifier !== true &&
+                            pn.id !== "}") {
+                            break;
+                        }
+                        warning("Missing semicolon.", nexttoken);
+                    } else {
+                        p = pn;
+                    }
+                } else if (p.id === "}") {
+                    // directive with no other statements, warn about missing semicolon
+                    warning("Missing semicolon.", p);
+                } else if (p.id !== ";") {
+                    break;
+                }
+
+                indentation();
+                advance();
+                if (directive[token.value]) {
+                    warning("Unnecessary directive \"{a}\".", token, token.value);
+                }
+
+                if (token.value === "use strict") {
+                    option.newcap = true;
+                    option.undef = true;
+                }
+
+                // there's no directive negation, so always set to true
+                directive[token.value] = true;
+
+                if (p.id === ";") {
+                    advance(";");
+                }
+                continue;
+            }
+            break;
+        }
+    }
+
+
+    /*
      * Parses a single block. A block is a sequence of statements wrapped in
      * braces.
      *
      * ordinary - true for everything but function bodies and try blocks.
      * stmt     - true if block can be a single statement (e.g. in if/for/while).
+     * isfunc   - true if block is a function body
      */
-    function block(ordinary, stmt) {
+    function block(ordinary, stmt, isfunc) {
         var a,
             b = inblock,
             old_indent = indent,
-            m = strict_mode,
+            m,
             s = scope,
             t,
-            line;
+            line,
+            d;
 
         inblock = ordinary;
         if (!ordinary || !option.funcscope) scope = Object.create(scope);
@@ -2453,21 +2492,40 @@ loop:   for (;;) {
         if (nexttoken.id === '{') {
             advance('{');
             line = token.line;
-            if (nexttoken.id !== '}' || line !== nexttoken.line) {
+            if (nexttoken.id !== '}') {
                 indent += option.indent;
                 while (!ordinary && nexttoken.from > indent) {
                     indent += option.indent;
                 }
-                if (!ordinary && !use_strict() && !m && option.strict &&
-                        funct['(context)']['(global)']) {
-                    warning("Missing \"use strict\" statement.");
+
+                if (isfunc) {
+                    m = {};
+                    for (d in directive) {
+                        if (is_own(directive, d)) {
+                            m[d] = directive[d];
+                        }
+                    }
+                    directives();
+
+                    if (option.strict && funct['(context)']['(global)']) {
+                        if (!m["use strict"] && !directive["use strict"]) {
+                            warning("Missing \"use strict\" statement.");
+                        }
+                    }
                 }
+
                 a = statements(line);
-                strict_mode = m;
+
+                if (isfunc) {
+                    directive = m;
+                }
+
                 indent -= option.indent;
                 if (line !== nexttoken.line) {
                     indentation();
                 }
+            } else if (line !== nexttoken.line) {
+                indentation();
             }
             advance('}', t);
             indent = old_indent;
@@ -2679,7 +2737,7 @@ loop:   for (;;) {
     reserve('default').reach = true;
     reserve('finally');
     reservevar('arguments', function (x) {
-        if (strict_mode && funct['(global)']) {
+        if (directive['use strict'] && funct['(global)']) {
             warning("Strict violation.", x);
         }
     });
@@ -2689,7 +2747,7 @@ loop:   for (;;) {
     reservevar('NaN');
     reservevar('null');
     reservevar('this', function (x) {
-        if (strict_mode && !option.validthis && ((funct['(statement)'] &&
+        if (directive['use strict'] && !option.validthis && ((funct['(statement)'] &&
                 funct['(name)'].charAt(0) > 'Z') || funct['(global)'])) {
             warning("Possible strict violation.", x);
         }
@@ -2905,7 +2963,7 @@ loop:   for (;;) {
         if (left && left.value === 'arguments' && (m === 'callee' || m === 'caller')) {
             if (option.noarg)
                 warning("Avoid arguments.{a}.", left, m);
-            else if (strict_mode)
+            else if (directive['use strict'])
                 error('Strict violation.');
         } else if (!option.evil && left && left.value === 'document' &&
                 (m === 'write' || m === 'writeln')) {
@@ -3131,7 +3189,7 @@ loop:   for (;;) {
         }
         funct['(params)'] = functionparams();
 
-        block(false);
+        block(false, false, true);
         scope = oldScope;
         option = oldOption;
         funct['(last)'] = token.line;
@@ -3923,7 +3981,7 @@ loop:   for (;;) {
         warnings = 0;
         lex.init(s);
         prereg = true;
-        strict_mode = false;
+        directive = {};
 
         // if esnext option is set, we can use esnext syntax
         if (option.esnext) {
@@ -3943,10 +4001,9 @@ loop:   for (;;) {
                 jsonValue();
                 break;
             default:
-                if (nexttoken.value === 'use strict') {
-                    if (!option.globalstrict)
-                        warning("Use the function form of \"use strict\".");
-                    use_strict();
+                directives();
+                if (directive["use strict"] && !option.globalstrict) {
+                    warning("Use the function form of \"use strict\".", prevtoken);
                 }
 
                 statements();

--- a/tests/fixtures/strict_incorrect.js
+++ b/tests/fixtures/strict_incorrect.js
@@ -1,0 +1,59 @@
+/*jshint white: true*/
+(function (t) {
+    var w = t;
+    "use strict";
+
+}(this));
+
+function s1() {
+    "use strict"
+}
+
+function s2() {
+    /*everything ok here*/
+    "fdfdsf";
+    /* */
+    "ddasfgggg";
+    
+    /*
+    */
+    /**///xsxsx
+    "" //zeze
+    ;
+    "use strict";
+}
+
+function s3() {
+    if (this) {
+        "use strict";
+        s2(1);
+    } else {
+        s2(2);
+    }
+}
+
+function s4() {
+    "use stict"; // typo
+    // comments and other directives are allowed
+    "xyz";
+    "use strict";
+        
+    if (true) {
+        s3(1);
+    }
+}
+
+function s5() {
+    "use stict"; // typo
+    // comments and other directives are allowed
+    "xyz";
+    // here is no "use strict"...
+        
+    try {
+        "use strict";
+        s4(1);
+    } catch (ex) {
+        s4(2);
+    }
+
+}

--- a/tests/options.js
+++ b/tests/options.js
@@ -604,6 +604,7 @@ exports.strict = function () {
     var code  = "(function () { return; }());";
     var code1 = '(function () { "use strict"; return; }());';
     var src = fs.readFileSync(__dirname + '/fixtures/strict_violations.js', 'utf8');
+    var src2 = fs.readFileSync(__dirname + '/fixtures/strict_incorrect.js', 'utf8');
 
     TestRun().test(code);
     TestRun().test(code1);
@@ -620,6 +621,13 @@ exports.strict = function () {
         .addError(7, 'Strict violation.')
         .addError(8, 'Strict violation.')
         .test(src, { strict: true });
+
+    TestRun()
+        .addError(4, 'Expected an assignment or function call and instead saw an expression.')
+        .addError(9, 'Missing semicolon.')
+        .addError(28, 'Expected an assignment or function call and instead saw an expression.')
+        .addError(53, 'Expected an assignment or function call and instead saw an expression.')
+        .test(src2, { strict: false });
 };
 
 /** Option `globalstrict` allows you to use global "use strict"; */


### PR DESCRIPTION
This patch changes the way, directives are parsed - all strings at the beginning of a scope are treated as directive. Kind of asi is implemented there (still not perfect but it should fit the most needs) - but even with option asi on, there will be warnings (as proposed in #300).

Now it's allowed to add comments and other directives..
It fixes #168
