### PR TITLE
Fixes GH-249 Allows exception catch args to be reused in other try-catches

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -1676,7 +1676,7 @@ klass:                                  do {
                 if (option.latedef)
                     warning("'{a}' was used before it was defined.", nexttoken, t);
             } else {
-                if (!option.shadow)
+                if (!option.shadow && type !== "exception")
                     warning("'{a}' is already defined.", nexttoken, t);
             }
         }

--- a/tests/core.js
+++ b/tests/core.js
@@ -230,3 +230,12 @@ exports.caseExpressions = function () {
         .addError(2, "This 'switch' should be an 'if'.")
         .test(src);
 };
+
+exports.argsInCatchReused = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/trycatch.js', 'utf8');
+    TestRun()
+        .addError(6, "'e' is already defined.")
+        .addError(12, "Do not assign to the exception parameter.")
+        .test(src);
+
+};

--- a/tests/fixtures/trycatch.js
+++ b/tests/fixtures/trycatch.js
@@ -1,0 +1,14 @@
+function foo() {
+    try {
+        // try something
+    } catch (e) {
+        // catch any throws
+        var e = 10;
+    }
+
+    try {
+        // do something
+    } catch (e) {
+        e = 12;
+    }
+}


### PR DESCRIPTION
Still throws an error if you try to redeclare `e` or if you try to assign something to `e`.
