### PR TITLE
latedef now plays nice with undef Fixes GH-133 and GH-347

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -222,8 +222,8 @@
  send, serialize, sessionStorage, setInterval, setTimeout, shift, slice, sort,spawn,
  split, stack, status, start, strict, sub, substr, supernew, shadow, supplant, sum,
  sync, test, toLowerCase, toString, toUpperCase, toint32, token, top, trailing, type,
- typeOf, Uint16Array, Uint32Array, Uint8Array, undef, unused, urls, validthis, value, valueOf,
- var, version, WebSocket, white, window, Worker, wsh*/
+ typeOf, Uint16Array, Uint32Array, Uint8Array, undef, undefs, unused, urls, validthis,
+ value, valueOf, var, version, WebSocket, white, window, Worker, wsh*/
 
 /*global exports: false */
 
@@ -936,6 +936,10 @@ var JSHINT = (function () {
             character: chr,
             message: message + " (" + percentage + "% scanned)."
         };
+    }
+
+    function isundef(scope, m, t, a) {
+        return JSHINT.undefs.push([scope, m, t, a]);
     }
 
     function warning(m, t, a, b, c, d) {
@@ -1670,7 +1674,6 @@ klass:                                  do {
         }
 
 // Define t in the current function in the current scope.
-
         if (is_own(funct, t) && !funct['(global)']) {
             if (funct[t] === true) {
                 if (option.latedef)
@@ -2644,7 +2647,7 @@ loop:   for (;;) {
                 // if we're inside of typeof or delete.
                 if (anonname != 'typeof' && anonname != 'delete' &&
                     option.undef && typeof predefined[v] !== 'boolean') {
-                    warning("'{a}' is not defined.", token, v);
+                    isundef(funct, "'{a}' is not defined.", token, v);
                 }
                 note_implied(token);
             } else {
@@ -2677,10 +2680,9 @@ loop:   for (;;) {
                         // if the base object of a reference is null so no need to
                         // display warning if we're inside of typeof or delete.
                         if (anonname != 'typeof' && anonname != 'delete' && option.undef) {
-                            warning("'{a}' is not defined.", token, v);
-                        } else {
-                            funct[v] = true;
+                            isundef(funct, "'{a}' is not defined.", token, v);
                         }
+                        funct[v] = true;
                         note_implied(token);
                     } else {
                         switch (s[v]) {
@@ -3945,6 +3947,7 @@ loop:   for (;;) {
     var itself = function (s, o, g) {
         var a, i, k;
         JSHINT.errors = [];
+        JSHINT.undefs = [];
         predefined = Object.create(standard);
         combine(predefined, g || {});
         if (o) {
@@ -4030,6 +4033,17 @@ loop:   for (;;) {
                 }, null);
             }
         }
+
+        for (i = 0; i < JSHINT.undefs.length; i += 1) {
+            k = JSHINT.undefs[i].slice(0);
+            scope = k.shift();
+            a = k[2];
+
+            if (typeof scope[a] !== 'string' && typeof funct[a] !== 'string') {
+                warning.apply(warning, k);
+            }
+        }
+
         return JSHINT.errors.length === 0;
     };
 

--- a/tests/core.js
+++ b/tests/core.js
@@ -374,3 +374,43 @@ exports.argsInCatchReused = function () {
         .addError(23, "'e' is not defined.")
         .test(src, { undef: true });
 };
+
+exports.latedefwundef = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/latedefundef.js', 'utf8');
+
+    // Assures that when `undef` is set to true, it'll report undefined variables
+    // and late definitions won't be reported as `latedef` is set to false.
+    TestRun()
+        .addError(29, "'hello' is not defined.")
+        .addError(35, "'world' is not defined.")
+        .test(src, { latedef: false, undef: true });
+
+    // When we suppress `latedef` and `undef` then we get no warnings.
+    TestRun()
+        .test(src, { latedef: false, undef: false });
+
+    // If we warn on `latedef` but supress `undef` we only get the
+    // late definition warnings.
+    TestRun()
+        .addError(5, "'func2' was used before it was defined.")
+        .addError(12, "'foo' was used before it was defined.")
+        .addError(18, "'fn1' was used before it was defined.")
+        .addError(26, "'baz' was used before it was defined.")
+        .addError(34, "'fn' was used before it was defined.")
+        .addError(41, "'q' was used before it was defined.")
+        .addError(46, "'h' was used before it was defined.")
+        .test(src, { latedef: true, undef: false });
+
+    // If we warn on both options we get all the warnings.
+    TestRun()
+        .addError(5, "'func2' was used before it was defined.")
+        .addError(12, "'foo' was used before it was defined.")
+        .addError(18, "'fn1' was used before it was defined.")
+        .addError(26, "'baz' was used before it was defined.")
+        .addError(29, "'hello' is not defined.")
+        .addError(34, "'fn' was used before it was defined.")
+        .addError(35, "'world' is not defined.")
+        .addError(41, "'q' was used before it was defined.")
+        .addError(46, "'h' was used before it was defined.")
+        .test(src, { latedef: true, undef: true });
+};

--- a/tests/fixtures/latedefundef.js
+++ b/tests/fixtures/latedefundef.js
@@ -1,0 +1,46 @@
+function func1() {
+    h = func2();
+}
+
+function func2() {
+    return 2;
+}
+
+
+foo();
+
+function foo() { }
+
+
+(function () {
+    "use strict";
+    fn1();
+    function fn1() {}
+}());
+
+
+function bar() {
+    baz();
+}
+
+function baz() {}
+
+
+hello();
+
+
+(function () {
+    fn();
+    function fn() {}
+    world();
+}());
+
+
+(function () {
+    q = 2;
+    var q;
+    return q;
+}());
+
+
+var h;


### PR DESCRIPTION
I added all the test cases that were present in the comments as well as a few others.

Squashed commit of the following:

commit 1b1f31b31f45a6b3d7d06b0531ecf45ea04b6758
Author: Josh Perez josh@goatslacker.com
Date:   Sat Nov 19 16:22:06 2011 -0800

```
Using for loop instead of filter/forEach
```

commit e399e55c580057010e4ec49e46e24ed6b2e462f7
Author: Josh Perez josh@goatslacker.com
Date:   Sat Nov 19 16:11:09 2011 -0800

```
Now works with vars, fixes other possible issue

* I have reason to believe latedef was not working properly
  on an anonymous function. Will have to verify.
```

commit ed4631158630a734353fc9050ac7d74739f5cee1
Author: Josh Perez josh@goatslacker.com
Date:   Sat Nov 19 15:57:22 2011 -0800

```
Fixes anonfuncs for GH-133
```

commit 38ec2b22d2b458498b2c075b0477136229137443
Author: Josh Perez josh@goatslacker.com
Date:   Sat Nov 19 15:16:09 2011 -0800

```
Fixes GH-133
```

commit 539420dad9560926d611b825bb663aeeccc0e495
Author: Josh Perez josh@goatslacker.com
Date:   Sat Nov 19 15:13:06 2011 -0800

```
Fixes GH-133 by checking if variables were defined

* Runs a post-check to see if variables were defined before
  reporting them as undefined.
```
