### PR TITLE
Fixes GH-351

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3153,7 +3153,6 @@ loop:   for (;;) {
         nospace();
         if (nexttoken.id === ')') {
             advance(')');
-            nospace(prevtoken, token);
             return;
         }
         for (;;) {

--- a/tests/fixtures/white.js
+++ b/tests/fixtures/white.js
@@ -51,3 +51,7 @@ var name2 = (function () { var x = 2;
 function inspectPrefiltersOrTransports(dataType/* internal */, inspected /* internal */) {
     return 2;
 }
+
+function nodblwarnings ( ) {
+    return 1;
+}

--- a/tests/options.js
+++ b/tests/options.js
@@ -721,6 +721,8 @@ exports.white = function () {
         .addError(15, "Missing space after ':'.")
         .addError(18, "Unexpected space after '('.", { character: 9 })
         .addError(18, "Unexpected space after 'ex'.", { character: 12 })
+        .addError(55, "Unexpected space after 'nodblwarnings'.", { character: 23 })
+        .addError(55, "Unexpected space after '('.", { character: 25 })
         .test(src, { white: true });
 };
 


### PR DESCRIPTION
I feel uneasy about deleting those kind of lines.

Logically, it doesn't make sense why it's there...I'm trying to think of a potential use case where applying this fix will break JSHint but I can't think of any.

The `nospace` is already handled prior to checking if the nexttoken is `)` so I'm not sure why we need to call `nospace` again. Just advancing the token and returning should be fine.
