### PR TITLE
lexer is not returning a token when '/' is by itself at beginning of line

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -1384,7 +1384,7 @@ var JSHINT = (function () {
                                     case '':
                                         errorAt("Unclosed regular expression.",
                                                 line, from);
-                                        return;
+                                        return it('(regexp)', c);
                                     case '/':
                                         if (depth > 0) {
                                             warningAt("Unescaped '{a}'.",


### PR DESCRIPTION
A file that consists of only '/' as the first character generates an error because no token is returned. This patch fixes that.
