### PR TITLE
SmartTabs

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -219,7 +219,7 @@
  readFile, readUrl, regexdash, removeEventListener, replace, report, require,
  reserved, resizeBy, resizeTo, resolvePath, resumeUpdates, respond, rhino, right,
  runCommand, scroll, screen, scripturl, scrollBy, scrollTo, scrollbar, search, seal,
- send, serialize, sessionStorage, setInterval, setTimeout, shift, slice, sort,spawn,
+ send, serialize, sessionStorage, setInterval, setTimeout, shift, slice, smarttabs, sort, spawn,
  split, stack, status, start, strict, sub, substr, supernew, shadow, supplant, sum,
  sync, test, toLowerCase, toString, toUpperCase, toint32, token, top, trailing, type,
  typeOf, Uint16Array, Uint32Array, Uint8Array, undef, unused, urls, validthis, value, valueOf,
@@ -256,6 +256,7 @@ var JSHINT = (function () {
 
         // These are the JSHint boolean options.
         boolOptions = {
+            smarttabs   : true, // if spaces alignment sequences should be ignored when tab-mixed
             asi         : true, // if automatic semicolon insertion should be tolerated
             bitwise     : true, // if bitwise operators should not be allowed
             boss        : true, // if advanced usage of assignments should be allowed
@@ -1006,7 +1007,7 @@ var JSHINT = (function () {
             character = 1;
             s = lines[line];
             line += 1;
-            at = s.search(/ \t|\t /);
+            at = s.search(option.smarttabs ? / \t/ : / \t|\t /);
 
             if (at >= 0)
                 warningAt("Mixed spaces and tabs.", line, at + 1);

--- a/tests/core.js
+++ b/tests/core.js
@@ -135,6 +135,20 @@ exports.testNewArray = function () {
         .test('new Array();');
 };
 
+/** Test that JSHint allows alignment spaces */
+exports.testAlignments = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/alignment.js', 'utf8');
+    TestRun()
+        .test(src, { smarttabs: true });
+    // But it must never tolerate these spaces if the option is not set
+    TestRun()
+        .addError(3, "Mixed spaces and tabs.")
+        .addError(4, "Mixed spaces and tabs.")
+        .addError(5, "Mixed spaces and tabs.")
+        .addError(6, "Mixed spaces and tabs.")
+        .test(src);
+};
+
 /**
  * Test that JSHint allows `undefined` to be a function parameter.
  * It is a common pattern to protect against the case when somebody


### PR DESCRIPTION
Hi,

Related to the issue #314, I've added an option in order to solve it.

In order to avoid the general problem of smart tabulation (see the ticket for more information), the option will prevent detecting this pattern : \t (but keeping the \t verification). So if there is tabs then spaces it won't trigger anything (assuming that these spaces have an alignment purpose).

If the spaces are trailing, errors will be trigger, as usual.

I've removed the Three.js and JS.Class support from the previous pull request, as requested (#341)

Sounds better ? :D
