### PR TITLE
Include 'raw' property when "Too many errors" is thrown to keep messages consistent.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -4029,7 +4029,7 @@ loop:   for (;;) {
                     reason    : e.message,
                     line      : e.line || nt.line,
                     character : e.character || nt.from
-                }, null);
+                });
             }
         }
 

--- a/tests/core.js
+++ b/tests/core.js
@@ -374,3 +374,10 @@ exports.argsInCatchReused = function () {
         .addError(23, "'e' is not defined.")
         .test(src, { undef: true });
 };
+
+exports.testrawonerror = function () {
+    JSHINT(";", { maxerr: 1 });
+    var errors = JSHINT.errors;
+    var tme = errors.pop();
+    assert.equal(tme.raw, "Too many errors.");
+};


### PR DESCRIPTION
It's a trivial fix.

I also removed the `, null` bit from L4030. Not sure why it's there but it's been there since JSLint's first commit:

https://github.com/douglascrockford/JSLint/commit/ca120a731db548c0014320fa0c196edc613536ae#L1R5509

I don't think we should be including null errors in the reports.
