### PR TITLE
Warn about future reserved keyword 'native'

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3848,6 +3848,7 @@ loop:   for (;;) {
     reserve('protected');
     reserve('public');
     reserve('static');
+    reserve('native');
 
 
 // Parse JSON


### PR DESCRIPTION
The future reserved keyword "native" causes an error when used as an identifier in certain browsers (observed in several versions of the android browser).

Should there be a warning for other future reserved keywords as well?
