### PR TITLE
It is not required to define both getter and setter for a property.

### DIFF
--- a/tests/envs.js
+++ b/tests/envs.js
@@ -379,6 +379,10 @@ exports.es5 = function () {
         .addError(3, "Extra comma.")
         .addError(8, "Extra comma.")
         .addError(15, "get/set are ES5 features.")
+        .addError(16, "get/set are ES5 features.")
+        .addError(20, "get/set are ES5 features.")
+        .addError(24, "get/set are ES5 features.")
+        .addError(25, "get/set are ES5 features.")
         .test(src);
     TestRun().test(src, { es5: true });
 

--- a/tests/fixtures/es5.funcexpr.js
+++ b/tests/fixtures/es5.funcexpr.js
@@ -7,7 +7,7 @@
 var test = (function() {
     var func = function() {},
     innerTest = {
-        get func() { return func;},
+        get func() { return func; },
         set func(value) { func = value; }
     };
     innerTest = func;

--- a/tests/fixtures/es5.js
+++ b/tests/fixtures/es5.js
@@ -15,4 +15,15 @@ var b = {
         get x() { return _x; },
         set x(value) { _x = value; }
     };
+
+    var onlyGetter1 = {
+        get x() { return _x; }
+    };
+
+    var onlyGetter2 = {
+        get x() { return _x; },
+        get y() { return _x; },
+        a: 1
+    };
+
 }());


### PR DESCRIPTION
In ECMAScript5 it is not required to define both getter and setter for a property. We use a lot of getter without setter. (For the calculated values of the rows.)

With this patch you can use:
- getter + setter, as now
- only getter
