### PR TITLE
Add missing comma in members list

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -180,7 +180,7 @@
  HTMLQuoteElement, HTMLScriptElement, HTMLSelectElement, HTMLStyleElement,
  HtmlTable, HTMLTableCaptionElement, HTMLTableCellElement, HTMLTableColElement,
  HTMLTableElement, HTMLTableRowElement, HTMLTableSectionElement,
- HTMLTextAreaElement, HTMLTitleElement, HTMLUListElement, HTMLVideoElement
+ HTMLTextAreaElement, HTMLTitleElement, HTMLUListElement, HTMLVideoElement,
  Iframe, IframeShim, Image, Int16Array, Int32Array, Int8Array,
  Insertion, InputValidator, JSON, Keyboard, Locale, LN10, LN2, LOG10E, LOG2E,
  MAX_VALUE, MIN_VALUE, Mask, Math, MenuItem, MoveAnimation, MooTools, Native,


### PR DESCRIPTION
Trivial patch to the `/*members` list in jshint.js.
