### PR TITLE
Adding "provides" as a global member of the CouchDB environment

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -215,7 +215,7 @@
  nonew, nonstandard, nud, onbeforeunload, onblur, onerror, onevar, onecase, onfocus,
  onload, onresize, onunload, open, openDatabase, openURL, opener, opera, options, outer, param,
  parent, parseFloat, parseInt, passfail, plusplus, predef, print, process, prompt,
- proto, prototype, prototypejs, push, quit, range, raw, reach, reason, regexp,
+ proto, prototype, prototypejs, provides, push, quit, range, raw, reach, reason, regexp,
  readFile, readUrl, regexdash, removeEventListener, replace, report, require,
  reserved, resizeBy, resizeTo, resolvePath, resumeUpdates, respond, rhino, right,
  runCommand, scroll, screen, scripturl, scrollBy, scrollTo, scrollbar, search, seal,
@@ -467,7 +467,8 @@ var JSHINT = (function () {
             sum       : false,
             log       : false,
             exports   : false,
-            module    : false
+            module    : false,
+            provides  : false
         },
 
         devel = {

--- a/tests/envs.js
+++ b/tests/envs.js
@@ -111,6 +111,7 @@ exports.couch = function () {
           , "log"
           , "exports"
           , "module"
+          , "provides"
         ];
 
     assert.globalsImplied(globals);


### PR DESCRIPTION
Just a minor thing I came across running my own tests for a CouchDB API I have.

`provides` is provided in the case of both [`_show` and `_list` functions](http://wiki.apache.org/couchdb/Formatting_with_Show_and_List), so I added it as part of the `couch` environment. Included are also the applicable changes to the unit tests. :)
