### PR TITLE
Do not allow to duplicate a setter.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3277,6 +3277,9 @@ loop:   for (;;) {
                     if (!i) {
                         error("Missing property name.");
                     }
+                    if (acc[i] && acc[i].setter) {
+                        warning("Duplicate member '{a}'.", nexttoken, i);
+                    }
                     saveSetter(i, nexttoken);
                     seen[i] = false;
                     t = nexttoken;

--- a/tests/envs.js
+++ b/tests/envs.js
@@ -376,21 +376,24 @@ exports.wsh = function () {
 exports.es5 = function () {
     var src = fs.readFileSync(__dirname + "/fixtures/es5.js", "utf8");
 
+    // Basic ES5 tests
     TestRun()
         .addError(3, "Extra comma.")
         .addError(8, "Extra comma.")
         .addError(15, "get/set are ES5 features.")
         .addError(16, "get/set are ES5 features.")
-        .addError(20, "get/set are ES5 features.")
-        .addError(22, "get/set are ES5 features.")
-        .addError(26, "get/set are ES5 features.")
-        .addError(30, "get/set are ES5 features.")
-        .addError(31, "get/set are ES5 features.")
-        .addError(36, "get/set are ES5 features.")
         .test(src);
 
     TestRun()
-        .addError(36, "Setter is defined without getter.")
+        .test(src, { es5: true });
+
+    // Various getter and setter tests.
+    src = fs.readFileSync(__dirname + "/fixtures/es5.getset.js", "utf8");
+    TestRun()
+        .addError(21, "Setter is defined without getter.")
+        .addError(28, "Duplicate member 'x'.")
+        .addError(34, "Duplicate member 'x'.")
+        .addError(41, "Duplicate member 'x'.")
         .test(src, { es5: true });
 
     // Make sure that JSHint parses getters/setters as function expressions

--- a/tests/fixtures/es5.getset.js
+++ b/tests/fixtures/es5.getset.js
@@ -1,0 +1,42 @@
+(function () {
+    var _x;
+
+    var obj = {
+        set x(value) { _x = value; },
+        name: 'jshint',
+        get x() { return _x; }
+    };
+
+    var onlyGetter1 = {
+        get x() { return _x; }
+    };
+
+    var onlyGetter2 = {
+        get x() { return _x; },
+        get y() { return _x; },
+        a: 1
+    };
+
+    var onlySetter = { // bad
+        set x(value) { _x = value; }
+    };
+    
+    var doubleGetter = { // bad
+        get x() { return _x; },
+        name: 'jshint',
+        get x() { return _x; }
+    };
+
+    var doubleSetter = { // bad
+        get x() { return _x; },
+        set x(value) { _x = value; },
+        name: 'jshint',
+        set x(value) { _x = value; }
+    };
+    
+    var propertyAndGetter = { // bad
+        x: 42,
+        name: 'jshint',
+        get x() { return _x; }
+    };
+}());

--- a/tests/fixtures/es5.js
+++ b/tests/fixtures/es5.js
@@ -15,24 +15,4 @@ var b = {
         get x() { return _x; },
         set x(value) { _x = value; }
     };
-
-    var obj2 = {
-        get x() { return _x; },
-        name: 'jshint',
-        set x(value) { _x = value; }
-    };
-
-    var onlyGetter1 = {
-        get x() { return _x; }
-    };
-
-    var onlyGetter2 = {
-        get x() { return _x; },
-        get y() { return _x; },
-        a: 1
-    };
-
-    var onlySetter = {
-        set x(value) { _x = value; }
-    };
 }());


### PR DESCRIPTION
Currently is doesn't trigger an error:

``` javascript
var doubleSetter = {
    get x() { return _x; },
    set x(value) { _x = value; },
    name: 'jshint',
    set x(value) { _x = value; }
};
```

This push request is only a trivial patch and some unit tests to catch errors like this.
