### PR TITLE
Always build jshint-rhino.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: rhino
+
 build_dir:
 	@mkdir -p "build"
 


### PR DESCRIPTION
JSHint claims to have Rhino support out of the box. So running make without arguments should build jshint-rhino.js by default. This change will help new users.

Also update documentation, see my pull request to jshint-site.
