### PR TITLE
Strip spaces from option names in jsc.js

### DIFF
--- a/env/jsc.js
+++ b/env/jsc.js
@@ -29,7 +29,7 @@ if (typeof(JSHINT) === 'undefined') {
                 arg = arg.split(',');
                 for (var i = 0, ii = arg.length; i < ii; i++) {
                     item = arg[i].split(':');
-                    opts[item[0]] = eval(item[1]);
+                    opts[item[0].replace(/(^\s*)|(\s*$)/g, '')] = eval(item[1]);
                 }
                 return opts;
             }


### PR DESCRIPTION
Not doing this leads to some surprising situations, e.g. 

./env/jsc.sh test.js 'browser: true, devel:true'

fails, but

./env/jsc.sh test.js 'browser: true,devel:true'

passes (the difference is the space before "devel"). See issue 395.
