### PR TITLE
Drop the {} from jsc.sh usage -- they will not be interpreted as expected

### DIFF
--- a/env/jsc.sh
+++ b/env/jsc.sh
@@ -2,7 +2,7 @@
 # usage (run from any directory) :
 #   env/jsc.sh /path/to/script.js
 # or with jshint options:
-#   env/jsc.sh /path/to/script.js "{option1:true,option2:false,option3:25}"
+#   env/jsc.sh /path/to/script.js "option1:true,option2:false,option3:25"
 
 alias jsc="/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc"
 FILE="${1}"


### PR DESCRIPTION
If you actually type "{option1:true,option2:true}" as your parameter, then it will be parsed as:

```
{
  '{option1': true,
  'option2': 'true}'
}
```

which is probably not what you want.
