### PR TITLE
Correct "unuseds" -> "unused" in comment to match reality.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -128,7 +128,7 @@
      member: {
          STRING: NUMBER
      },
-     unuseds: [
+     unused: [
          {
              name: STRING,
              line: NUMBER


### PR DESCRIPTION
This comment is the only occurrence of "unuseds" in jshint.js. The field is actually called "unused" (singular).
