### PR TITLE
Correctly identify duplicate object properties.

### DIFF
--- a/tests/envs.js
+++ b/tests/envs.js
@@ -387,10 +387,25 @@ exports.es5 = function () {
         .addError(30, "get/set are ES5 features.")
         .addError(31, "get/set are ES5 features.")
         .addError(36, "get/set are ES5 features.")
+        .addError(41, "get/set are ES5 features.")
+        .addError(42, "get/set are ES5 features.")
+        .addError(43, "Duplicate member 'x'.")
+        .addError(47, "get/set are ES5 features.")
+        .addError(48, "get/set are ES5 features.")
+        .addError(48, "Duplicate member 'x'.")
+        .addError(52, "get/set are ES5 features.")
+        .addError(53, "get/set are ES5 features.")
+        .addError(54, "get/set are ES5 features.")
+        .addError(54, "Duplicate member 'x'.")
+        .addError(60, "get/set are ES5 features.")
+        .addError(61, "get/set are ES5 features.")
         .test(src);
 
     TestRun()
         .addError(36, "Setter is defined without getter.")
+        .addError(43, "Duplicate member 'x'.")
+        .addError(48, "Duplicate member 'x'.")
+        .addError(54, "Duplicate member 'x'.")
         .test(src, { es5: true });
 
     // Make sure that JSHint parses getters/setters as function expressions

--- a/tests/fixtures/es5.js
+++ b/tests/fixtures/es5.js
@@ -35,4 +35,29 @@ var b = {
     var onlySetter = {
         set x(value) { _x = value; }
     };
+
+    // Check for duplicate members
+    var dup = {
+        get x() { return _x; },
+        set x(value) { _x = value; },
+        x: 'sup?'
+    };
+
+    var dup2 = {
+        get x() { return _x; },
+        get x() { return _x + 1; }
+    };
+
+    var dup3 = {
+        get x() { return _x; },
+        set x(value) { _x = value; },
+        set x(value) { _x = value - 1; }
+    };
+
+    // Regression test for a bug when a getter followed a setter produced a faulty
+    // Duplicate Member warning.
+    var setThenGet = {
+        set x(value) { _x = value; },
+        get x() { return _x; }
+    };
 }());


### PR DESCRIPTION
JSHint was incorrectly identifying duplicate properties because of numerous unsafe assumptions such as that setters always follow getters and others.

This patch removes these assumptions and makes sure that we understand that 'get x, set x is okay' but 'get x, x' is not.

Also, added tests for duplicate members and a regression test for the aforementioned bug.

This is a response to #382 and a faulty merge 63382c7fcc17d5bfe86441f0ec5d8ef651138eff.
