### PR TITLE
Correctly identify duplicate object properties (2)

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3279,9 +3279,6 @@ loop:   for (;;) {
                     t = nexttoken;
                     adjacent(token, nexttoken);
                     f = doFunction();
-                    if (!option.loopfunc && funct['(loopage)']) {
-                        warning("Don't make functions within a loop.", t);
-                    }
                     p = f['(params)'];
                     if (p) {
                         warning("Unexpected parameter '{a}' in get {b} function.", t, p[0], i);
@@ -3301,8 +3298,8 @@ loop:   for (;;) {
                     adjacent(token, nexttoken);
                     f = doFunction();
                     p = f['(params)'];
-                    if (!p || p.length !== 1 || p[0] !== 'value') {
-                        warning("Expected (value) in set {a} function.", t, i);
+                    if (!p || p.length !== 1) {
+                        warning("Expected a single parameter in set {a} function.", t, i);
                     }
                 } else {
                     i = property_name();

--- a/tests/envs.js
+++ b/tests/envs.js
@@ -397,8 +397,22 @@ exports.es5 = function () {
         .addError(53, "get/set are ES5 features.")
         .addError(54, "get/set are ES5 features.")
         .addError(54, "Duplicate member 'x'.")
+        .addError(58, "get/set are ES5 features.")
+        .addError(58, "Unexpected parameter 'a' in get x function.")
+        .addError(59, "get/set are ES5 features.")
+        .addError(59, "Unexpected parameter 'a' in get y function.")
         .addError(60, "get/set are ES5 features.")
-        .addError(61, "get/set are ES5 features.")
+        .addError(62, "get/set are ES5 features.")
+        .addError(62, "Expected a single parameter in set x function.")
+        .addError(63, "get/set are ES5 features.")
+        .addError(64, "get/set are ES5 features.")
+        .addError(64, "Expected a single parameter in set z function.")
+        .addError(68, "get/set are ES5 features.")
+        .addError(69, "get/set are ES5 features.")
+        .addError(68, "Missing property name.")
+        .addError(69, "Missing property name.")
+        .addError(75, "get/set are ES5 features.")
+        .addError(76, "get/set are ES5 features.")
         .test(src);
 
     TestRun()
@@ -406,6 +420,12 @@ exports.es5 = function () {
         .addError(43, "Duplicate member 'x'.")
         .addError(48, "Duplicate member 'x'.")
         .addError(54, "Duplicate member 'x'.")
+        .addError(58, "Unexpected parameter 'a' in get x function.")
+        .addError(59, "Unexpected parameter 'a' in get y function.")
+        .addError(62, "Expected a single parameter in set x function.")
+        .addError(64, "Expected a single parameter in set z function.")
+        .addError(68, "Missing property name.")
+        .addError(69, "Missing property name.")
         .test(src, { es5: true });
 
     // Make sure that JSHint parses getters/setters as function expressions

--- a/tests/fixtures/es5.js
+++ b/tests/fixtures/es5.js
@@ -54,6 +54,21 @@ var b = {
         set x(value) { _x = value - 1; }
     };
 
+    var parameters = {
+        get x(a) { return _x; },
+        get y(a, b) { return _x; },
+        get z() { return _x; },
+        
+        set x() { _x = 1; },
+        set y(a) { _x = a; },
+        set z(a, b) { _x = a; }
+    };
+    
+    var nameless = {
+        get () { return _x; },
+        set (value) { _x = value; }
+    };
+    
     // Regression test for a bug when a getter followed a setter produced a faulty
     // Duplicate Member warning.
     var setThenGet = {


### PR DESCRIPTION
This is the pull request #401 plus some minor changes
- Remove "Don't make functions within a loop." on getters
- Don't force "value" as parameter name of setters
- Extend tests (coverage)

---

JSHint was incorrectly identifying duplicate properties because of numerous unsafe assumptions such as that setters always follow getters and others.

This patch removes these assumptions and makes sure that we understand that 'get x, set x is okay' but 'get x, x' is not.

Also, added tests for duplicate members and a regression test for the aforementioned bug.

This is a response to #382 and a faulty merge 63382c7.
