### PR TITLE
Subscripting null references

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -2652,9 +2652,15 @@ loop:   for (;;) {
                 // Operators typeof and delete do not raise runtime errors even if
                 // the base object of a reference is null so no need to display warning
                 // if we're inside of typeof or delete.
-                if (anonname !== 'typeof' && anonname !== 'delete' &&
-                    option.undef && typeof predefined[v] !== 'boolean') {
-                    isundef(funct, "'{a}' is not defined.", token, v);
+                if (option.undef && typeof predefined[v] !== 'boolean') {
+                    // Attempting to subscript a null reference will throw an
+                    // error, even within the typeof and delete operators
+                    if (!(anonname === 'typeof' || anonname === 'delete') ||
+                        (nexttoken &&
+                            (nexttoken.value === '.' || nexttoken.value === '['))) {
+
+                        isundef(funct, "'{a}' is not defined.", token, v);
+                    }
                 }
                 note_implied(token);
             } else {
@@ -2686,8 +2692,15 @@ loop:   for (;;) {
                         // Operators typeof and delete do not raise runtime errors even
                         // if the base object of a reference is null so no need to
                         // display warning if we're inside of typeof or delete.
-                        if (anonname !== 'typeof' && anonname !== 'delete' && option.undef) {
-                            isundef(funct, "'{a}' is not defined.", token, v);
+                        if (option.undef) {
+                            // Attempting to subscript a null reference will throw an
+                            // error, even within the typeof and delete operators
+                            if (!(anonname === 'typeof' || anonname === 'delete') ||
+                                (nexttoken &&
+                                    (nexttoken.value === '.' || nexttoken.value === '['))) {
+
+                                isundef(funct, "'{a}' is not defined.", token, v);
+                            }
                         }
                         funct[v] = true;
                         note_implied(token);

--- a/tests/fixtures/undef.js
+++ b/tests/fixtures/undef.js
@@ -2,9 +2,15 @@ undef(); // this line will generate a warning
 if (typeof undef) {} // this line won't because typeof accepts a reference
                      // even when the base object of that reference is null
 
+if (typeof undef['attr' + 0]) {}
+if (typeof undef.attr) {}
+
 var fn = function () {
     localUndef();
 
     if (typeof localUndef)
         return;
+
+    if (typeof localUndef['attr' + 0]) {}
+    if (typeof localUndef.attr) {}
 };

--- a/tests/options.js
+++ b/tests/options.js
@@ -318,7 +318,11 @@ exports.undef = function () {
     // Make sure it fails when undef is true
     TestRun()
         .addError(1, "'undef' is not defined.")
-        .addError(6, "'localUndef' is not defined.")
+        .addError(5, "'undef' is not defined.")
+        .addError(6, "'undef' is not defined.")
+        .addError(9, "'localUndef' is not defined.")
+        .addError(14, "'localUndef' is not defined.")
+        .addError(15, "'localUndef' is not defined.")
         .test(src, { undef: true });
 };
 


### PR DESCRIPTION
Currently, JSHint accepts any undefined references as operands to "typeof" and "delete". While the "typeof" and "delete" operators can operate on null references, a runtime error will be thrown if an undefined variable is de-referenced. With this commit, JSHint will continue to ignore undefined variables as operands _unless_ they are de-referenced (in which case, it will throw a "not defined" error).

Example (assuming `undef` is undefined):

``` javascript
// should pass
typeof undef;

// currently passes, but should not
typeof undef.attr;
```
