### PR TITLE
Fix #394: jsc.sh reports success when there are too much errors

### DIFF
--- a/env/jsc.js
+++ b/env/jsc.js
@@ -45,13 +45,25 @@ if (typeof(JSHINT) === 'undefined') {
         quit();
     }
 
-    if (!JSHINT(input, opts)) {
+    var ret, aborted;
+    try {
+        ret = JSHINT(input, opts);
+    } catch (ex) {
+        ret = false;
+        aborted = ex;
+    }
+    
+    if (!ret) {
         for (var i = 0, err; err = JSHINT.errors[i]; i++) {
             print(err.reason + ' (line: ' + err.line + ', character: ' + err.character + ')');
             print('> ' + (err.evidence || '').replace(/^\s*(\S*(\s+\S+)*)\s*$/, "$1"));
             print('');
         }
+        if (aborted) {
+            print(aborted.message + ' (line: ' + aborted.line + ', character: ' + aborted.character + ')');
+            print('> ');
+            print('');
+        }
     }
-
     quit();
 })(arguments);


### PR DESCRIPTION
Since jshint throws an error if there are more than maxerr errors, the call of `JSHINT()` has to be encapsulated in a try/catch-block.

This is a quick-fix. The somewhat better approach would be to remove every `throw` from jshint...

**I have no mac to test it entirely**!!
