### PR TITLE
do not require `new` with constructors in strict mode.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -2478,8 +2478,7 @@ loop:   for (;;) {
                     warning("Unnecessary directive \"{a}\".", token, token.value);
                 }
 
-                if (token.value === "use strict") {
-                    option.newcap = true;
+                if (token.value === "use strict") {                
                     option.undef = true;
                 }
 


### PR DESCRIPTION
As mentioned in #438, I don't think 'use strict' should require use of `new`.
