### PR TITLE
Added recursive directory support to WSH wrapper

### DIFF
--- a/env/wsh.js
+++ b/env/wsh.js
@@ -178,17 +178,19 @@
 	var unnamed = WScript.Arguments.Unnamed;
 
 	if (unnamed.length !== 1) {
-		WScript.StdOut.WriteLine("    usage: cscript " + scriptName + " [options] <script>");
+		WScript.StdOut.WriteLine("    usage: cscript " + scriptName + " [options] <script | directory>");
 		WScript.StdOut.WriteLine("");
 		WScript.StdOut.WriteLine("Scans the specified script with JSHint and reports any errors encountered.  If");
 		WScript.StdOut.WriteLine("the script name is \"-\", it will be read from standard input instead.");
+		WScript.StdOut.WriteLine("If a directory is passed, all .js files in that directory and subdirectories");
+		WScript.StdOut.WriteLine("will be scanned.");
 		WScript.StdOut.WriteLine("");
 		WScript.StdOut.WriteLine("JSHint configuration options can be passed in via optional, Windows-style");
 		WScript.StdOut.WriteLine("arguments.  For example:");
 		WScript.StdOut.WriteLine("    cscript " + scriptName + " /jquery:true myscript.js");
 		WScript.StdOut.WriteLine("    cscript " + scriptName + " /global:QUnit:false,_:false,foo:true foo.js");
 		WScript.StdOut.WriteLine("");
-		WScript.StdOut.WriteLine("By default, we assume that your file is encoded if UTF-8. You can change that");
+		WScript.StdOut.WriteLine("By default, we assume that your file is encoded in UTF-8. You can change that");
 		WScript.StdOut.WriteLine("by providing a custom charset option:");
 		WScript.StdOut.WriteLine("    cscript " + scriptName + " /charset:ascii myscript.js");
 


### PR DESCRIPTION
The WSH env now has support for passing in a directory name.

The only functional change that was made for single files is that the passed script name is spit out in the output just like when running against a directory. Let me know if that is a problem and I can make a change.
