### PR TITLE
Support \0 in strings

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -1240,6 +1240,9 @@ unclosedString:     for (;;) {
                             case 't':
                                 c = '\t';
                                 break;
+                            case '0':
+                                c = '\0';
+                                break;
                             case 'u':
                                 esc(4);
                                 break;

--- a/tests/unit/fixtures/strings.js
+++ b/tests/unit/fixtures/strings.js
@@ -14,3 +14,5 @@ this is not a multiline string in javascript";
 test = "hallo world\
 
 this is a faulty multiline string in javascript";
+
+test = "\033\t";


### PR DESCRIPTION
Quick fix from @marianoguerra (#464). Does not support octals, but I don't think this is needed (before we get the new parser).

"\033" is not parsed as "\x1B", but as "\0" + "33".
