### PR TITLE
Reset value `comma.first` on every run.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -2049,8 +2049,6 @@ loop:   for (;;) {
         nonadjacent(token, nexttoken);
     }
 
-    comma.first = true;
-
 
 // Functional constructors for making the symbols that will be inherited by
 // tokens.
@@ -4092,6 +4090,9 @@ loop:   for (;;) {
 
         // combine the passed globals after we've assumed all our options
         combine(predefined, g || {});
+
+        //reset values
+        comma.first = true;
 
         try {
             advance();

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1058,6 +1058,7 @@ exports.laxcomma = function () {
     // All errors.
     TestRun()
         .addError(1, "Bad line breaking before ','.")
+        .addError(2, "Comma warnings can be turned off with 'laxcomma'")
         .addError(2, "Bad line breaking before ','.")
         .addError(6, "Bad line breaking before ','.")
         .addError(10, "Bad line breaking before '&&'.")
@@ -1067,6 +1068,7 @@ exports.laxcomma = function () {
     // Allows bad line breaking, but not on commas.
     TestRun()
         .addError(1, "Bad line breaking before ','.")
+        .addError(2, "Comma warnings can be turned off with 'laxcomma'")
         .addError(2, "Bad line breaking before ','.")
         .addError(6, "Bad line breaking before ','.")
         .test(src, { laxbreak: true });


### PR DESCRIPTION
Shows the message _Comma warnings can be turned off with 'laxcomma'_ on every run.

Currently,
`expresso --match laxcomma tests/unit/options.js`
fails, while
`expresso tests/unit/options.js`
does not return any errors. The above warning is raised only once - in options.js, this is done in the `laxbreak` tests. 

I think every run should always return the same results - therefore this little fix.
