### PR TITLE
Added recursive directory support to WSH wrapper

### DIFF
--- a/env/wsh.js
+++ b/env/wsh.js
@@ -71,7 +71,9 @@
 		var returnValue = 0;
 		var directory = fileSystem.GetFolder(path);
 
-		for (var filesEnumerator = new Enumerator(directory.Files); !filesEnumerator.atEnd(); filesEnumerator.moveNext()) {
+		for (var filesEnumerator = new Enumerator(directory.Files);
+				!filesEnumerator.atEnd();
+				 filesEnumerator.moveNext()) {
 			var file = filesEnumerator.item();
 
 			// If this is a JS file
@@ -89,9 +91,10 @@
 			}
 		}
 
-		for (var subDirectoriesEnumerator = new Enumerator(directory.Subfolders); !subDirectoriesEnumerator.atEnd(); subDirectoriesEnumerator.moveNext()) {
+		for (var subDirectoriesEnumerator = new Enumerator(directory.Subfolders);
+				!subDirectoriesEnumerator.atEnd();
+				 subDirectoriesEnumerator.moveNext()) {
 			var subDirectory = subDirectoriesEnumerator.item();
-
 			var subDirectoryReturnValue = processDirectory(subDirectory.Path);
 
 			if (subDirectoryReturnValue > returnValue) {


### PR DESCRIPTION
The WSH env now has support for passing in a directory name.

The only functional change that was made for single files is that the passed script name is spit out in the output just like when running against a directory. Let me know if that is a problem and I can make a change.
