### PR TITLE
Assume globalstrict in the node environment.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -896,6 +896,7 @@ var JSHINT = (function () {
 
         if (option.node) {
             combine(predefined, node);
+            option.globalstrict = true;
         }
 
         if (option.devel) {

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -88,6 +88,19 @@ exports.node = function () {
         .addError(2, "Unexpected dangling '_' in '__filename'.")
         .addError(3, "Unexpected dangling '_' in '__hello'.")
         .test(asProps, { node: true, nomen: true });
+
+    // Node environment assumes `globalstrict`
+    var globalStrict = [
+        '"use strict";',
+        'function test() { return; }'
+    ].join('\n');
+
+    TestRun()
+        .addError(1, 'Use the function form of "use strict".')
+        .test(globalStrict);
+
+    TestRun()
+        .test(globalStrict, { node: true });
 };
 
 /** Option `jquery` predefines jQuery globals */


### PR DESCRIPTION
Fixes GH-377. Since there're no problems with using module level
"use strict" in Node programs we don't need to display a warning
about it.

Test plan: `make test`.
