### PR TITLE
indent option fix and ignore for NetBeans project files

### DIFF
--- a/env/rhino.js
+++ b/env/rhino.js
@@ -29,16 +29,20 @@
     if (optstr) {
         optstr.split(',').forEach(function (arg) {
             var o = arg.split('=');
-            opts[o[0]] = (function (ov) {
-                switch (ov) {
-                case 'true':
-                    return true;
-                case 'false':
-                    return false;
-                default:
-                    return ov;
-                }
-            }(o[1]));
+            if (o[0] === 'indent') {
+                opts[o[0]] = parseInt(o[1], 10);
+            } else {
+                opts[o[0]] = (function (ov) {
+                    switch (ov) {
+                    case 'true':
+                        return true;
+                    case 'false':
+                        return false;
+                    default:
+                        return ov;
+                    }
+                }(o[1]));
+            }
         });
     }
 


### PR DESCRIPTION
I have two trivial changes, one is simply an ignore rule for NetBeans project files the other is a fix for the indent option, it got passed to JSHint as a string, hence it didn't work.
