### PR TITLE
Internally mutating the option argument causes unexpected behaviour.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -4091,7 +4091,10 @@ loop:   for (;;) {
 // The actual JSHINT function itself.
 
     var itself = function (s, o, g) {
-        var a, i, k;
+        var a, i, k, x,
+            optionKeys,
+            newOptionObj = {};
+
         JSHINT.errors = [];
         JSHINT.undefs = [];
         predefined = Object.create(standard);
@@ -4110,10 +4113,14 @@ loop:   for (;;) {
                     }
                 }
             }
-            option = o;
-        } else {
-            option = {};
+            optionKeys = Object.keys(o);
+            for (x = 0; x < optionKeys.length; x++) {
+                newOptionObj[optionKeys[x]] = o[optionKeys[x]];
+            }
         }
+
+        option = newOptionObj;
+
         option.indent = option.indent || 4;
         option.maxerr = option.maxerr || 50;
 


### PR DESCRIPTION
Example:

```
var options = {regexp: true};
JSHINT("/*jshint regexp: false */\nvar c = /a.b/;", options);
JSHINT("var a = /d.e/;", options);
```

In the second call, `options.regexp == false`, and no errors are logged.

---

This seemed like the best way to do this (from my perspective).

This was logged as an issue in the [node-jshint](https://github.com/jshint/node-jshint/issues/94) repository.

I also did not create a test for this (and apologize). I had issues installing expresso (which was odd) so, instead  I just quickly fixed it and tested it manually. Hopefully this is ok. :-)
