### PR TITLE
Make jshint-rhino.js runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ build_dir:
 
 rhino: build_dir
 	@echo "Building JSHint for Rhino"
-	@cat "jshint.js" > "build/jshint-rhino.js" && \
-		cat "env/rhino.js" >> "build/jshint-rhino.js" && \
-		echo "Done"
+	@echo "#!/usr/bin/env rhino" > "build/jshint-rhino.js"
+	@cat "jshint.js" "env/rhino.js" >> "build/jshint-rhino.js"
+	-@chmod +x "build/jshint-rhino.js"
+	@echo "Done"
 
 test:
 	@echo "Running unit tests"


### PR DESCRIPTION
As a convenience to users, it would be nice if `jshint-rhino.js` were directly runnable rather than requiring the user to invoke rhino and pass the script as an argument for every use of JSHint.  To that end, these commits add a shebang line and mark `jshint-rhino.js` executable during build.
