### PR TITLE
Adding option `indentswitch` to allow two indents in switches.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3707,7 +3707,9 @@ loop:   for (;;) {
         t = nexttoken;
         advance('{');
         nonadjacent(token, nexttoken);
-        indent += option.indent;
+        if (!option.indentswitch) {
+            indent += option.indent;
+        }
         this.cases = [];
         for (;;) {
             switch (nexttoken.id) {
@@ -3730,7 +3732,9 @@ loop:   for (;;) {
                             token);
                     }
                 }
-                indentation(-option.indent);
+                if (!option.indentswitch) {
+                    indentation(-option.indent);
+                }
                 advance('case');
                 this.cases.push(expression(20));
                 g = true;
@@ -3751,13 +3755,17 @@ loop:   for (;;) {
                             token);
                     }
                 }
-                indentation(-option.indent);
+                if (!option.indentswitch) {
+                    indentation(-option.indent);
+                }
                 advance('default');
                 g = true;
                 advance(':');
                 break;
             case '}':
-                indent -= option.indent;
+                if (!option.indentswitch) {
+                    indent -= option.indent;
+                }
                 indentation();
                 advance('}', t);
                 if (this.cases.length === 1 || this.condition.id === 'true' ||

--- a/tests/unit/fixtures/indentswitch.js
+++ b/tests/unit/fixtures/indentswitch.js
@@ -1,0 +1,8 @@
+switch (2 + 2) {
+    case 4:
+        var t = true;
+        break;
+    case 5:
+        var f = false;
+        break;
+}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1101,3 +1101,20 @@ exports.browser = function () {
 	TestRun().test(src, { browser: true, undef: true });
 
 };
+
+/*
+ * Tests the `indentswitch` option
+ */
+exports.indentswitch = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/indentswitch.js', 'utf8');
+
+    TestRun().test(src, { white: true, indentswitch: true });
+    TestRun()
+        .addError(2, "Expected 'case' to have an indentation at 1 instead at 5.")
+        .addError(3, "Expected 'var' to have an indentation at 5 instead at 9.")
+        .addError(4, "Expected 'break' to have an indentation at 5 instead at 9.")
+        .addError(5, "Expected 'case' to have an indentation at 1 instead at 5.")
+        .addError(6, "Expected 'var' to have an indentation at 5 instead at 9.")
+        .addError(7, "Expected 'break' to have an indentation at 5 instead at 9.")
+        .test(src, { white: true });
+};


### PR DESCRIPTION
As discussed in https://groups.google.com/d/msg/jshint/q9YNf4ETCOc/ES_iBEu3Ih4J

As before, since I can't run the tests on Windows, please let me know if I need to fix anything to get them passing :-/
