### PR TITLE
Adds option quotmark

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -215,7 +215,7 @@
  nonew, nonstandard, nud, onbeforeunload, onblur, onerror, onevar, onecase, onfocus,
  onload, onresize, onunload, open, openDatabase, openURL, opener, opera, options, outer, param,
  parent, parseFloat, parseInt, passfail, plusplus, predef, print, process, prompt,
- proto, prototype, prototypejs, provides, push, quit, range, raw, reach, reason, regexp,
+ proto, prototype, prototypejs, provides, push, quit, quotmark, range, raw, reach, reason, regexp,
  readFile, readUrl, regexdash, removeEventListener, replace, report, require,
  reserved, resizeBy, resizeTo, resolvePath, resumeUpdates, respond, rhino, right,
  runCommand, scroll, screen, scripturl, scrollBy, scrollTo, scrollbar, search, seal,
@@ -334,7 +334,8 @@ var JSHINT = (function () {
             maxlen: false,
             indent: false,
             maxerr: false,
-            predef: false
+            predef: false,
+            quotmark: false //'single'|'double'|true
         },
 
         // These are JSHint boolean options which are shared with JSLint
@@ -680,6 +681,8 @@ var JSHINT = (function () {
             Sound             : false,
             Scriptaculous     : false
         },
+
+        quotmark,
 
         rhino = {
             defineClass  : false,
@@ -1213,6 +1216,22 @@ var JSHINT = (function () {
                     if (jsonmode && x !== '"') {
                         warningAt("Strings must use doublequote.",
                                 line, character);
+                    }
+
+                    if (option.quotmark) {
+                        if (option.quotmark === 'single' && x !== "'") {
+                            warningAt("Strings must use singlequote.",
+                                    line, character);
+                        } else if (option.quotmark === 'double' && x !== '"') {
+                            warningAt("Strings must use doublequote.",
+                                    line, character);
+                        } else if (option.quotmark === true) {
+                            quotmark = quotmark || x;
+                            if (quotmark !== x) {
+                                warningAt("Mixed double and single quotes.",
+                                        line, character);
+                            }
+                        }
                     }
 
                     function esc(n) {
@@ -4199,6 +4218,7 @@ loop:   for (;;) {
 
         //reset values
         comma.first = true;
+        quotmark = undefined;
 
         try {
             advance();

--- a/tests/unit/fixtures/quotes.js
+++ b/tests/unit/fixtures/quotes.js
@@ -1,0 +1,3 @@
+// inconsistent quotation marks
+var test1 = 'string';
+var test2 = "string";

--- a/tests/unit/fixtures/quotes2.js
+++ b/tests/unit/fixtures/quotes2.js
@@ -1,0 +1,3 @@
+// inconsistent quotation marks
+var test1 = "string";
+var test2 = 'string';

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -986,6 +986,37 @@ exports.strings = function () {
         .test(src);
 };
 
+/*
+ * Test the `quotmark` option
+ *   quotmark    quotation mark or true (=ensure consistency)
+ */
+exports.quotes = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/quotes.js', 'utf8');
+    var src2 = fs.readFileSync(__dirname + '/fixtures/quotes2.js', 'utf8');
+
+    TestRun()
+        .test(src);
+
+    TestRun()
+        .addError(3, "Mixed double and single quotes.")
+        .test(src, { quotmark: true });
+
+    TestRun()
+        .addError(3, "Strings must use singlequote.")
+        .test(src, { quotmark: 'single' });
+
+    TestRun()
+        .addError(2, "Strings must use doublequote.")
+        .test(src, { quotmark: 'double' });
+
+    // test multiple runs (must have the same result)
+    var run = TestRun();
+    run.addError(3, "Mixed double and single quotes.")
+        .test(src, { quotmark: true });
+    run.addError(3, "Mixed double and single quotes.")
+        .test(src2, { quotmark: true });
+};
+
 exports.scope = function () {
     var src = fs.readFileSync(__dirname + '/fixtures/scope.js', 'utf8');
 


### PR DESCRIPTION
``` javascript
{quotmark: true} // ensures consistency of quotation marks
```

``` javascript
{quotmark: "single"} // requires single quotes as quotation marks
```

``` javascript
{quotmark: "double"} // requires double quotes as quotation marks
```
