### PR TITLE
Adds option camelcase

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -196,7 +196,7 @@
  XPathEvaluator, XPathException, XPathExpression, XPathNamespace, XPathNSResolver, XPathResult,
  "\\", a, addEventListener, address, alert, apply, applicationCache, arguments, arity, asi, atob,
  b, basic, basicToken, bitwise, block, blur, boolOptions, boss, browser, btoa, c, call, callee,
- caller, cases, charAt, charCodeAt, character, clearInterval, clearTimeout,
+ caller, camelcase, cases, charAt, charCodeAt, character, clearInterval, clearTimeout,
  close, closed, closure, comment, condition, confirm, console, constructor,
  content, couch, create, css, curly, d, data, datalist, dd, debug, decodeURI,
  decodeURIComponent, defaultStatus, defineClass, deserialize, devel, document,
@@ -260,6 +260,7 @@ var JSHINT = (function () {
             bitwise     : true, // if bitwise operators should not be allowed
             boss        : true, // if advanced usage of assignments should be allowed
             browser     : true, // if the standard browser globals should be predefined
+            camelcase   : true, // if identifiers should be required in camel case
             couch       : true, // if CouchDB globals should be predefined
             curly       : true, // if curly braces around all blocks should be required
             debug       : true, // if debugger statements should be allowed
@@ -1124,6 +1125,10 @@ var JSHINT = (function () {
                             (value !== '__dirname' && value !== '__filename')) {
                         warningAt("Unexpected {a} in '{b}'.", line, from, "dangling '_'", value);
                     }
+                } else if (option.camelcase && value.indexOf('_') > -1 &&
+                        !value.match(/^[A-Z0-9_]*$/)) {
+                    warningAt("Identifier '{a}' is not in camel case.",
+                        line, from, value);
                 }
             }
             t.value = value;

--- a/tests/unit/fixtures/camelcase.js
+++ b/tests/unit/fixtures/camelcase.js
@@ -1,0 +1,13 @@
+function FooBar(testMe) {
+  this.testMe = testMe;
+}
+
+function Foo_bar(test_me) {
+  this.test_me = test_me;
+}
+
+function Foo() {
+  this.TEST_ME = 2;
+}
+
+var TEST_1, test1, test_1;

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -170,6 +170,27 @@ exports.testProtoAndIterator = function () {
 };
 
 /**
+ * The `camelcase` option allows you to enforce use of the camel case convention.
+ */
+exports.testCamelcase = function () {
+    var source = fs.readFileSync(__dirname + '/fixtures/camelcase.js', 'utf8');
+
+    // By default, tolerate arbitrary identifiers
+    TestRun()
+        .test(source);
+
+    // Require identifiers in camel case if camelcase is true
+    TestRun()
+        .addError(5, "Identifier 'Foo_bar' is not in camel case.")
+        .addError(5, "Identifier 'test_me' is not in camel case.")
+        .addError(6, "Identifier 'test_me' is not in camel case.")
+        .addError(6, "Identifier 'test_me' is not in camel case.")
+        .addError(13, "Identifier 'test_1' is not in camel case.")
+        .test(source, { camelcase: true });
+
+};
+
+/**
  * Option `curly` allows you to enforce the use of curly braces around
  * control blocks. JavaScript allows one-line blocks to go without curly
  * braces but some people like to always use curly bracse. This option is


### PR DESCRIPTION
If option `camelcase` is `true`, all identifiers are required in camel case or in upper case with underscores.
