### PR TITLE
Dom Level 2 items are failing: Node and NodeFilter

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -458,6 +458,8 @@ var JSHINT = (function () {
             moveBy                   :  false,
             moveTo                   :  false,
             name                     :  false,
+            Node                     :  false,
+            NodeFilter               :  false,
             navigator                :  false,
             onbeforeunload           :  true,
             onblur                   :  true,

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -297,6 +297,8 @@ exports.browser = function () {
           , 'moveBy'
           , 'moveTo'
           , 'name'
+          , 'Node'
+          , 'NodeFilter'
           , 'navigator'
           , 'onbeforeunload'
           , 'onblur'

--- a/tests/unit/fixtures/browser.js
+++ b/tests/unit/fixtures/browser.js
@@ -9,3 +9,7 @@ var dom = dp.parseFromString("<test>jshint</test>", "text/xml");
 // XMLSerializer
 var xs = new XMLSerializer();
 var dom_str = xs.serializeToString(dom);
+
+// node
+var filterAccept = NodeFilter.FILTER_ACCEPT;
+var elementNode = Node.ELEMENT_NODE;

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1096,6 +1096,8 @@ exports.browser = function () {
 		.addError(3, "'btoa' is not defined.")
 		.addError(6, "'DOMParser' is not defined.")
 		.addError(10, "'XMLSerializer' is not defined.")
+		.addError(14, "'NodeFilter' is not defined.")
+		.addError(15, "'Node' is not defined.")
 		.test(src, { undef: true });
 
 	TestRun().test(src, { browser: true, undef: true });


### PR DESCRIPTION
There are at least 2 DOM level 2 types that jshint is failing on, Node and NodeFilter

http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html

I added some broken tests, but not sure how to fix the issue.
