### PR TITLE
Do not assume advance "end" if next token is ".". Fixes #334

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -4236,7 +4236,7 @@ loop:   for (;;) {
 
                 statements();
             }
-            advance('(end)');
+            advance((nexttoken && nexttoken.value !== '.')  ? '(end)' : undefined);
 
             var markDefined = function (name, context) {
                 do {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -393,3 +393,9 @@ exports.invalidOptions = function () {
         .addError(0, "Bad option: 'invalid'.")
         .test("function test() {}", { devel: true, invalid: true });
 };
+
+exports.multilineArray = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/gh-334.js', 'utf8');
+
+    TestRun().test(src);
+};

--- a/tests/unit/fixtures/gh-334.js
+++ b/tests/unit/fixtures/gh-334.js
@@ -1,0 +1,15 @@
+// Uncommenting this line makes the code below work??
+// var a;
+
+[ "Foo", "Bar", "Baz" ].forEach(function(item) {
+    console.log(item);
+});
+
+
+/*
+Fixing error:
+
+Line 6: ].forEach(function( item ) {
+Expected '(end)' and instead saw '.'.
+
+*/


### PR DESCRIPTION
``` bash

$ expresso tests/regression/*.js

   100% 3 tests

$ expresso tests/unit/*.js

   100% 109 tests

```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
