### PR TITLE
Add support for knockoutjs globals

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -568,7 +568,7 @@ var JSHINT = (function () {
             jQuery : false
         },
         
-        knockout {
+        knockout = {
             ko     : false
         },
 


### PR DESCRIPTION
I currently use JsHint and knockoutjs in my application and would prefer not to add the /_global_/ to the top of every knockout file.

Very easy, quick fix to add support for knockoutjs global 'ko'.  
