### PR TITLE
Remove trailing space from 'Stopping.' message.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -1024,7 +1024,7 @@ var JSHINT = (function () {
         w.reason = m.supplant(w);
         JSHINT.errors.push(w);
         if (option.passfail) {
-            quit('Stopping. ', l, ch);
+            quit('Stopping.', l, ch);
         }
         warnings += 1;
         if (warnings >= option.maxerr) {


### PR DESCRIPTION
This commit removes a trailing space from the 'Stopping.' message.
