### PR TITLE
Fix for unnecessary semicolon + white

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -2125,6 +2125,9 @@ loop:   for (;;) {
         if (option.white) {
             left = left || token;
             right = right || nexttoken;
+            if (left.value === ";" && right.value === ";") {
+                return;
+            }
             if (left.line === right.line && left.character === right.from) {
                 left.from += (left.character - left.from);
                 warning("Missing space after '{a}'.",

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1156,3 +1156,20 @@ exports.browser = function () {
 	TestRun().test(src, { browser: true, undef: true });
 
 };
+
+exports.unnecessarysemicolon = function () {
+    var code = [
+        "function foo() {",
+        "    var a;;",
+        "}"
+    ];
+
+    TestRun()
+        .addError(2, "Unnecessary semicolon.")
+        .test(code);
+
+    TestRun()
+        .addError(2, "Unnecessary semicolon.")
+        .test(code, { white: true });
+
+};


### PR DESCRIPTION
With `white` option I get an incorrect warning about whitespace missing as well as an unnecessary semicolon.

Code that's broken:

```
function foo() {
  var a;;
}
```

Will tell me there's a missing space between each semicolon, and that there's an extra semicolon.

It should just tell me there's an extra semicolon.
