### PR TITLE
allow _underscorePrefixes for camelcase option

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -1149,7 +1149,7 @@ var JSHINT = (function () {
                             (value !== '__dirname' && value !== '__filename')) {
                         warningAt("Unexpected {a} in '{b}'.", line, from, "dangling '_'", value);
                     }
-                } else if (option.camelcase && value.indexOf('_') > -1 &&
+                } else if (option.camelcase && value.replace(/^_+/, '').indexOf('_') > -1 &&
                         !value.match(/^[A-Z0-9_]*$/)) {
                     warningAt("Identifier '{a}' is not in camel case.",
                         line, from, value);

--- a/tests/unit/fixtures/camelcase.js
+++ b/tests/unit/fixtures/camelcase.js
@@ -11,3 +11,7 @@ function Foo() {
 }
 
 var TEST_1, test1, test_1;
+
+function _FooBar(_testMe) {
+  this.___testMe = _testMe;
+}


### PR DESCRIPTION
I love the new `'camelcase'` option but I often use `_` prefixes for camelcase pesudo-private variables & members and I suspect this is a relatively common pattern. This change loosen the `'camelcase'` check to ignore any `_` prefixes, which would allow `_fooBar` and `__fooBar` etc.

Whaddya reckon?
