### PR TITLE
Bug fix, give proper character count for supernew and return identifier

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3155,7 +3155,8 @@ loop:   for (;;) {
         }
         adjacent(token, nexttoken);
         if (nexttoken.id !== '(' && !option.supernew) {
-            warning("Missing '()' invoking a constructor.");
+            warning("Missing '()' invoking a constructor.",
+                token, token.value);
         }
         this.first = c;
         return this;

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -515,8 +515,10 @@ exports.supernew = function () {
 
     TestRun()
         .addError(1, "Weird construction. Delete 'new'.")
-        .addError(9, "Missing '()' invoking a constructor.")
-        .addError(11, "Missing '()' invoking a constructor.")
+        .addError(9, "Missing '()' invoking a constructor.", { character: 1 })
+        .addError(11, "Missing '()' invoking a constructor.", {
+            character: 13
+        })
         .test(src);
 
     TestRun().test(src, { supernew: true });


### PR DESCRIPTION
Nothing broken, just missing some useful information. Would like proper character count and the identifier.
