### PR TITLE
License in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,38 @@ Core Team members:
 
 Maintainer: Anton Kovalyov
 
+License
+-------
+
+JSHint is licensed under the same slightly modified MIT license that JSLint is.
+It stops evil-doers everywhere.
+
+JSHint is a derivative work of JSLint:
+
+Copyright (c) 2002 Douglas Crockford  (www.JSLint.com)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+The Software shall be used for Good, not Evil.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+JSHint was forked from the 2010-12-16 edition of JSLint.
+
 Thank you!
 ----------
 

--- a/jshint.js
+++ b/jshint.js
@@ -28,7 +28,7 @@
  *   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  *   DEALINGS IN THE SOFTWARE.
  *
- * JSHint was forked from 2010-12-16 edition of JSLint.
+ * JSHint was forked from the 2010-12-16 edition of JSLint.
  *
  */
 


### PR DESCRIPTION
The license for this software was hidden in the comment of the JS
file. It should be easier to find, so I put it in the README.
