### PR TITLE
Added value "paramsignore" to options.unused.

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -4382,7 +4382,7 @@ loop:   for (;;) {
                     return;
 
                 // ignore function parameters
-                if (option.unused === "paramsignore") {
+                if (option.unused === "paramsignore" && params) {
                     for (p = 0; p < params.length; p++) {
                         if (key === params[p]) {
                             return;


### PR DESCRIPTION
This will make jshint ignore function parameters in warnings about unused variables.

It happens quite often that you do not need all parameters a function/callback offers. Think about $.ajax's success callback for example, which has the parameters data, statusText, xhr (in this order). It may happen that you need only the xhr parameter in your function body. In that case jshint would correctly (but for my taste unnecessarily) point out that the other two parameters are unused.

Usage is now:
options.unused = true: same as before
options.unused = "paramsigonre": same as true, just ignore function params
options.unused = false: same as before 
