### PR TITLE
No report newcap errors for globally defined variables

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3187,7 +3187,7 @@ loop:   for (;;) {
                 default:
                     if (c.id !== "function") {
                         i = c.value.substr(0, 1);
-                        if (option.newcap && (i < "A" || i > "Z")) {
+                        if (option.newcap && (i < "A" || i > "Z") && !is_own(global, c.value)) {
                             warning("A constructor name should start with an uppercase letter.",
                                 token);
                         }

--- a/tests/unit/fixtures/newcap.js
+++ b/tests/unit/fixtures/newcap.js
@@ -2,4 +2,12 @@ var dog = new animal();
 var cat = new Animal();
 
 dog = animal();
-doc = Animal();
+cat = Animal();
+
+/*global iAnimal*/
+
+var rat = new iAnimal();
+var bat = new myAnimal();
+
+rat = iAnimal();
+bat = myAnimal();

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -758,6 +758,7 @@ exports.newcap = function () {
     TestRun()
         .addError(1, 'A constructor name should start with an uppercase letter.')
         .addError(5, "Missing 'new' prefix when invoking a constructor.")
+        .addError(10, "A constructor name should start with an uppercase letter.")
         .test(src, { newcap: true });
 };
 
@@ -804,7 +805,6 @@ exports.strict = function () {
         .test(src2, { strict: false });
 
     TestRun()
-        .addError(7, "A constructor name should start with an uppercase letter.")
         .test(src3, {});
 };
 


### PR DESCRIPTION
Useful for third parity objects witch does not pass newcap flag (passing it globally does not report newcap errors).
