### PR TITLE
Fix functionparams result

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -3491,7 +3491,7 @@ loop:   for (;;) {
 
         if (nexttoken.id === ")") {
             advance(")");
-            return;
+            return params;
         }
 
         for (;;) {


### PR DESCRIPTION
When I started playing with _maxparams_ option, I suddenly started having internal jshint errors (provided via _raw.reason_). Exposed stack trace:

```
TypeError: Cannot read property 'length' of undefined
    at Object.verifyMaxParametersPerFunction (/Users/medikoo/Projects/jshint/jshint.js:3564:31)
    at doFunction (/Users/medikoo/Projects/jshint/jshint.js:3533:28)
    at Object.nud (/Users/medikoo/Projects/jshint/jshint.js:3868:9)
    at expression (/Users/medikoo/Projects/jshint/jshint.js:2146:30)
    at /Users/medikoo/Projects/jshint/jshint.js:2469:34
    at Object.x.led (/Users/medikoo/Projects/jshint/jshint.js:2399:24)
    at expression (/Users/medikoo/Projects/jshint/jshint.js:2186:34)
    at statement (/Users/medikoo/Projects/jshint/jshint.js:2649:13)
    at statements (/Users/medikoo/Projects/jshint/jshint.js:2701:24)
    at itself (/Users/medikoo/Projects/jshint/jshint.js:4579:17)
```

It's pretty clear that the reason for error is that `functionparams` doesn't return array in all cases
