### PR TITLE
fix for issue # 547 - // block comments on indented code

### DIFF
--- a/jshint.js
+++ b/jshint.js
@@ -1108,6 +1108,7 @@ var JSHINT = (function () {
 
         function nextLine() {
             var at,
+                match,
                 tw; // trailing whitespace check
 
             if (line >= lines.length)
@@ -1120,10 +1121,13 @@ var JSHINT = (function () {
             // If smarttabs option is used check for spaces followed by tabs only.
             // Otherwise check for any occurence of mixed tabs and spaces.
             // Tabs and one space followed by block comment is allowed.
-            if (option.smarttabs)
-                at = s.search(/ \t/);
-            else
+            if (option.smarttabs) {
+                // negative look-behind for "//"
+                match = s.match(/(\/\/)? \t/);
+                at = match && !match[1] ? 0 : -1;
+            } else {
                 at = s.search(/ \t|\t [^\*]/);
+            }
 
             if (at >= 0)
                 warningAt("Mixed spaces and tabs.", line, at + 1);

--- a/tests/unit/fixtures/smarttabs.js
+++ b/tests/unit/fixtures/smarttabs.js
@@ -8,3 +8,7 @@ function hello() {
 	/**
 	 * Allowed space after tab before block comment
 	 */
+
+// function commentedOut() {
+// 	console.log('space followed by tab after a // comment');
+// }

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1139,6 +1139,7 @@ exports.smarttabs = function () {
     TestRun()
         .addError(4, "Mixed spaces and tabs.")
         .addError(5, "Mixed spaces and tabs.")
+        .addError(13, "Mixed spaces and tabs.")
         .test(src);
 
     TestRun()


### PR DESCRIPTION
pull request for [issue 547](https://github.com/jshint/jshint/issues/547)

This update allows for the following if the smarttabs option has been enabled:

```
//[space]if(something) {
//[space][tab]doSomething();
//[space]}
```

... which is the result of block commenting out the following code in some text editors:

```
if(something) {
[tab]doSomething();
}
```

The smarttabs regex is now doing a negative look-behind for a "//" prior to a [space][tab], and allowing it in that case.  Test cases have been updated to account for this addition as well.  

Please let me know if you feel anything should be adusted.  Thanks.
