### PR TITLE
Add some more granular unit tests regarding the 'unused' option

### DIFF
--- a/tests/unit/fixtures/unused_first_arg.js
+++ b/tests/unit/fixtures/unused_first_arg.js
@@ -1,0 +1,5 @@
+var resize = function (event, ui) {
+	return ui.bar;
+};
+
+resize({}, {bar: 5});

--- a/tests/unit/fixtures/unused_second_arg.js
+++ b/tests/unit/fixtures/unused_second_arg.js
@@ -1,0 +1,5 @@
+var resize = function (event, ui) {
+	return event.bar;
+};
+
+resize({bar: 5}, {});

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -396,6 +396,26 @@ exports.unused = function () {
     assert.ok(unused.some(function (err) { return err.line === 15 && err.name === "foo"; }));
 };
 
+// unused should complain when the second of two arguments is unused
+exports.unused_second_arg = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/unused_second_arg.js', 'utf8');
+
+    TestRun()
+		.addError(1, "'ui' is defined but never used.")
+		.test(src, { unused: true });
+
+	assert.ok(!JSHINT(src, { unused: true }));
+};
+
+// unused shouldn't complain when an unused argument is followed by a used one
+exports.unused_first_arg = function () {
+    var src = fs.readFileSync(__dirname + '/fixtures/unused_first_arg.js', 'utf8');
+
+    TestRun().test(src, { unused: true });
+
+	assert.ok(JSHINT(src, { unused: true }));
+};
+
 // Regression test for `undef` to make sure that ...
 exports['undef in a function scope'] = function () {
     var src = fixture('undef_func.js');


### PR DESCRIPTION
While thinking about issue #660, I added these tests to solidify my understanding of how the `unused` option currently works. I think the `unused_second_arg` test is somewhat redundant, but it is quite small, so it shouldn't be a problem in terms of maintenance or refactoring.
