### PR TITLE
Fixes #671

### DIFF
--- a/env/wsh.js
+++ b/env/wsh.js
@@ -223,6 +223,9 @@
 			}
 		} else {
 			options[option] = value === "true" ? true : value === "false" ? false : value;
+			if (!isNaN(Number(value))) {
+				options[option] = parseInt(value, 10);
+			}
 		}
 	}
 


### PR DESCRIPTION
Command line parameters to wsh.js are converted from "string" to "number" (if applicable) and passed on to jshint
