### PR TITLE
Path to jshint inside wsh.js seems wrong

### DIFF
--- a/src/platforms/wsh.js
+++ b/src/platforms/wsh.js
@@ -166,7 +166,7 @@
 
 	// load JSHint if the two scripts have not been concatenated
 	if (typeof JSHINT === "undefined") {
-		eval(readFile(scriptPath + "..\\src\\stable\\jshint.js", 'utf-8'));
+		eval(readFile(scriptPath + "..\\stable\\jshint.js", 'utf-8'));
 
 		if (typeof JSHINT === "undefined") {
 			WScript.StdOut.WriteLine("ERROR: Could not find 'jshint.js'.");


### PR DESCRIPTION
When working with the wsh.js of jshint, the path pointing to jsHint seems to be wrong. By removing src in the path, I am able to run

C:>cscript src/platforms/wsh.js [PAHT TO MY JS FILES]

otherwise I get an error "could not find jshint.js"
