### PR TITLE
let make.js check itsself and comply to own standards

### DIFF
--- a/make.js
+++ b/make.js
@@ -64,23 +64,23 @@ target.lint = function () {
 		return;
 	}
 
+	var outputError = function (err) {
+		if (!err) {
+			return;
+		}
+
+		var line = "[L" + err.line + "]";
+		while (line.length < 10) {
+			line += " ";
+		}
+
+		echo(line, err.reason);
+		echo("\n");
+	};
+
 	for (var key in failures) {
 		cli.error(key);
-
-		failures[key].errors.forEach(function (err) {
-			if (!err) {
-				return;
-			}
-
-			var line = "[L" + err.line + "]";
-			while (line.length < 10) {
-				line += " ";
-			}
-
-			echo(line, err.reason);
-		});
-
-		echo("\n");
+		failures[key].errors.forEach(outputError);
 	}
 
 	exit(1);


### PR DESCRIPTION
I think it is only fair, that a program checking other files for correctness should apply these same standards to itself as well ;-)

I added top level *.js files to the list of files to check for target "lint" and also fixed the issues uncovered by this.
