### PR TITLE
pull request for issue 719

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -1530,7 +1530,7 @@ klass:
 												}
 												break;
 											case "/":
-												warningAt("Unescaped '{a}'.",
+												warningAt("'{a}' in character sets should be escaped.",
 														line, from + l - 1, "/");
 
 												if (isInRange) {


### PR DESCRIPTION
Message recognizes that / is allowed in regex char sets, but should still be escaped.
