### PR TITLE
enable requiring npm module in node (rebased)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"lint": "node ./make.js lint"
 	},
 
+	"main": "./src/stable/jshint.js",
+
 	"dependencies": {
 		"esprima":    "https://github.com/ariya/esprima/tarball/master",
 		"shelljs":    "*",

--- a/tests/stable/regression/npm.js
+++ b/tests/stable/regression/npm.js
@@ -1,0 +1,8 @@
+"use strict";
+
+exports.npm = function (test) {
+	var jshint;
+	test.ok(jshint = require(__dirname + '/../../../'));
+	test.equal(typeof(jshint.JSHINT), 'function');
+	test.done();
+};


### PR DESCRIPTION
Continuing from #715, this pr includes just the tab-fixes for package.json, the inclusion of "main" for require() via npm, and the test.
