### PR TITLE
Added support for /*exported ... */ directive

### DIFF
--- a/tests/stable/unit/fixtures/exported.js
+++ b/tests/stable/unit/fixtures/exported.js
@@ -1,0 +1,18 @@
+/*global Cat */
+/*exported isCat, isDog */
+/*exported cannotBeExported */
+
+function isCat(obj) {
+	var unused,
+		isDog;
+	return obj instanceof Cat;
+}
+
+var isDog = function () {};
+
+function unusedDeclaration() {}
+var unusedExpression = function () {};
+
+(function () {
+	function cannotBeExported() {}
+}());

--- a/tests/stable/unit/parser.js
+++ b/tests/stable/unit/parser.js
@@ -458,3 +458,17 @@ exports.functionCharaterLocation = function (test) {
 
 	test.done();
 };
+
+exports.exported = function (test) {
+	var src = fs.readFileSync(__dirname + "/fixtures/exported.js", "utf8");
+
+	TestRun(test)
+		.addError(6, "'unused' is defined but never used.")
+		.addError(7, "'isDog' is defined but never used.")
+		.addError(13, "'unusedDeclaration' is defined but never used.")
+		.addError(14, "'unusedExpression' is defined but never used.")
+		.addError(17, "'cannotBeExported' is defined but never used.")
+		.test(src, {unused: true});
+
+	test.done();
+};


### PR DESCRIPTION
This patch introduces a new `/*exported … */` directive that is intended for use with the `unused` option. This directive will suppress warnings about unused function declarations and expressions if they are defined in the global scope but not used.

The following should run without warnings:

``` javascript
    /*exported cats */
    function cats() {}
```

If the function declaration or expression is not in the global scope, it should throw a warning:

``` javascript
    /*exported cats */
    function isCat() {
        var cats; // Warning: 'cats' is defined but never used.
    }
    isCat();
```

References:

Closes GH-659
