### PR TITLE
Disallows the use of reserved words as variable or function declaration ...

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -1206,10 +1206,11 @@ loop:
 
 	// fnparam means that this identifier is being defined as a function
 	// argument (see identifier())
-	function optionalidentifier(fnparam) {
+	// prop means that this identifier is that of an object property
+	function optionalidentifier(fnparam, prop) {
 		if (state.tokens.next.identifier) {
 			advance();
-			if (state.tokens.curr.reserved && !state.option.es5) {
+			if (state.tokens.curr.reserved && (!prop || !state.option.es5)) {
 				// `undefined` as a function param is a common pattern to protect
 				// against the case when somebody does `undefined = true` and
 				// help with minification. More info: https://gist.github.com/315916
@@ -2109,7 +2110,7 @@ loop:
 
 
 	function property_name() {
-		var id = optionalidentifier(true);
+		var id = optionalidentifier(false, true);
 		if (!id) {
 			if (state.tokens.next.id === "(string)") {
 				id = state.tokens.next.value;


### PR DESCRIPTION
...identifiers. Currently, no warning is given for such use of reserved words when the es5 option is set to true. See issue #744 for more details.
