### PR TITLE
Problems with piping on windows

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -360,20 +360,12 @@ var exports = {
 			extensions: options["extra-ext"]
 		});
 
-		// Avoid stdout cutoff in Node 0.4.x, also supports 0.5.x.
-		// See https://github.com/joyent/node/issues/1669
-
-		function exit() { process.exit(passed ? 0 : 2); }
-
-		try {
-			if (!process.stdout.flush()) {
-				process.stdout.once("drain", exit);
-			} else {
-				exit();
-			}
-		} catch (err) {
-			exit();
-		}
+		var exiting = false;
+		process.on('exit', function() {
+			if (exiting) { return; }
+			exiting = true;
+			process.exit(passed ? 0 : 2);
+		});
 	}
 };
 


### PR DESCRIPTION
when you run ex.

```
jshint . > error.log
```

the output gets truncated if its longer
the boolean flag is needed if node version < 0.6.4 (if i have read the commit log correctly), after that it was patched so it doesn't run into a recursive loop ( see [discussion](http://groups.google.com/group/nodejs/browse_thread/thread/cc5ec61283dc72ac/daecd0824b2a8bd0) )
