### PR TITLE
use resolved paths when minimatch test is run in isIgnored

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -179,7 +179,7 @@ function loadIgnores() {
  */
 function isIgnored(fp, patterns) {
 	return patterns.some(function (ip) {
-		if (minimatch(fp, ip, { nocase: true })) {
+		if (minimatch(path.resolve(fp), ip, { nocase: true })) {
 			return true;
 		}
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -231,11 +231,13 @@ exports.group = {
 		sinon.stub(process, "cwd").returns(dir);
 		sinon.stub(shjs, "cat")
 			.withArgs(sinon.match(/file2?\.js$/)).returns("console.log('Hello');")
+			.withArgs(sinon.match(/ignore\/file\d\.js$/)).returns("console.log('Hello, ignore me');")
+			.withArgs(sinon.match(/ignore\/dir\/file\d\.js$/)).returns("console.log('Hello, ignore me');")
 			.withArgs(sinon.match(/\.jshintrc$/)).returns("{}")
-			.withArgs(sinon.match(/\.jshintignore$/)).returns("");
+			.withArgs(sinon.match(/\.jshintignore$/)).returns("ignore/**");
 
 		cli.interpret([
-			"node", "jshint", "file.js", "file2.js", ".hidden", "file4.json"
+			"node", "jshint", "file.js", "file2.js", ".hidden", "file4.json", "ignore/file1.js", "ignore/file2.js", "ignore/dir/file1.js"
 		]);
 
 		var args = shjs.cat.args.filter(function (arg) {


### PR DESCRIPTION
fixes #692
