### PR TITLE
Fix false warning for smarttabs and indentation within multiline comment blocks

### DIFF
--- a/src/stable/lex.js
+++ b/src/stable/lex.js
@@ -1316,7 +1316,7 @@ Lexer.prototype = {
 
 		if (state.option.smarttabs) {
 			// Negative look-behind for "//"
-			match = this.input.match(/(\/\/)? \t/);
+			match = this.input.match(/(\/\/|^\s?\*)? \t/);
 			at = match && !match[1] ? 0 : -1;
 		} else {
 			at = this.input.search(/ \t|\t [^\*]/);


### PR DESCRIPTION
When indenting with tabs, lines within comment blocks are prefixed with a space (for alignment) and an asterisk, followed by another space.  Pretty standard pattern.

This causes a false alarm when indenting within comment blocks (e.g. for a code sample in a Markdown-flavored doc engine).
### Example:

```
/**
.*.Usage:
.*
.*.---->do.something();
.*/
```

Throws:

> Mixed spaces and tabs.
### Notes:

The patch is a little hacky to look for `*` since it's in a comment block and syntactically meaningless, but at a glance it looks like [line 1322](https://github.com/jshint/jshint/blob/master/src/stable/lex.js#L1322) (right below my patch) is doing the same thing.

This might be irrelevant with changes to -next, especially if that has a better concept of multiline statements, but [package.json](https://github.com/jshint/jshint/blob/master/package.json#L18) is still referring to -stable.
### Related issues:
#644
