### PR TITLE
make.js: mkdir 'dist' if it doesn't exist

### DIFF
--- a/make.js
+++ b/make.js
@@ -93,13 +93,15 @@ target.build = function () {
 	var bundle = browserify({ debug: true, exports: [ "require" ] });
 
 	bundle.addEntry("./src/stable/jshint.js");
-	bundle.bundle().to("./dist/jshint.js");
-	cli.ok("Bundle");
+	require('fs').mkdir('dist', function () {
+		bundle.bundle().to("./dist/jshint.js");
+		cli.ok("Bundle");
 
-	// Rhino
-	var rhino = cat("./dist/jshint.js", "./src/platforms/rhino.js");
-	rhino = "#!/usr/bin/env rhino\n\n" + rhino;
-	rhino.to("./dist/jshint-rhino.js");
-	exec("chmod +x dist/jshint-rhino.js");
-	cli.ok("Rhino");
+		// Rhino
+		var rhino = cat("./dist/jshint.js", "./src/platforms/rhino.js");
+		rhino = "#!/usr/bin/env rhino\n\n" + rhino;
+		rhino.to("./dist/jshint-rhino.js");
+		exec("chmod +x dist/jshint-rhino.js");
+		cli.ok("Rhino");
+	});
 };


### PR DESCRIPTION
Here's another dumb one: I went to build jshint, and it failed because `dist/` didn't exist. I figured the build process could just create it if needed.
