### PR TITLE
Allow reserved words as property names under es5

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -1266,8 +1266,9 @@ var JSHINT = (function () {
 
 	// fnparam means that this identifier is being defined as a function
 	// argument
-	function identifier(fnparam) {
-		var i = optionalidentifier(fnparam);
+	// prop means that this identifier is that of an object property
+	function identifier(fnparam, prop) {
+		var i = optionalidentifier(fnparam, prop);
 		if (i) {
 			return i;
 		}
@@ -1981,7 +1982,7 @@ var JSHINT = (function () {
 	infix(".", function (left, that) {
 		adjacent(state.tokens.prev, state.tokens.curr);
 		nobreak();
-		var m = identifier();
+		var m = identifier(false, true);
 
 		if (typeof m === "string") {
 			countMember(m);

--- a/tests/stable/unit/core.js
+++ b/tests/stable/unit/core.js
@@ -522,7 +522,6 @@ exports.testReserved = function (test) {
 
 	TestRun(test)
 		.addError(10, "Expected an identifier and instead saw 'let' (a reserved word).")
-		.addError(14, "Expected an identifier and instead saw 'else' (a reserved word).")
 		.test(src, { es5: true });
 
 	test.done();
@@ -538,6 +537,7 @@ exports.testES5Reserved = function (test) {
 		.addError(5, "Expected an identifier and instead saw 'default' (a reserved word).")
 		.addError(6, "Expected an identifier and instead saw 'new' (a reserved word).")
 		.addError(7, "Expected an identifier and instead saw 'class' (a reserved word).")
+		.addError(8, "Expected an identifier and instead saw 'default' (a reserved word).")
 		.test(src);
 
 	TestRun(test)

--- a/tests/stable/unit/fixtures/es5Reserved.js
+++ b/tests/stable/unit/fixtures/es5Reserved.js
@@ -5,3 +5,4 @@ var x = {
 var default = 10;
 function new () {}
 function x(class) {}
+x.default = 5;


### PR DESCRIPTION
This fixes the es5 mode to properly allow reserved words to be used as property names. The issue was that the function emitting this warning was not being told it was checking a property in most cases.

Fixes #768
