### PR TITLE
Fix issue #811

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -2637,7 +2637,7 @@ var JSHINT = (function () {
 		if (i) {
 			adjacent(state.tokens.curr, state.tokens.next);
 		} else {
-			if (option.anon) {
+			if (state.option.anon) {
 				adjacent(state.tokens.curr, state.tokens.next);
             } else {
 				nonadjacent(state.tokens.curr, state.tokens.next);


### PR DESCRIPTION
Adds support for the anon flag found in jslint, which is specific to allowing an immediate left paren after the function keyword. This patch allows code to pass cleanly through both JSHint and the Google Closure Linter (which is useful to run since it checks for JSDoc compliance).
