### PR TITLE
add PhantomJS support

### DIFF
--- a/src/shared/vars.js
+++ b/src/shared/vars.js
@@ -239,6 +239,12 @@ exports.node = {
 	clearInterval: false
 };
 
+exports.phantom = {
+	phantom      : true,
+	require      : true,
+	WebPage      : true
+};
+
 exports.rhino = {
 	defineClass  : false,
 	deserialize  : false,

--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -112,6 +112,7 @@ var JSHINT = (function () {
 			onevar      : true, // if only one var statement per function should be
 			                    // allowed
 			passfail    : true, // if the scan should stop on first error
+			phantom     : true, // if PhantomJS symbols should be allowed
 			plusplus    : true, // if increment/decrement should not be allowed
 			proto       : true, // if the `__proto__` property should be allowed
 			prototypejs : true, // if Prototype and Scriptaculous globals should be
@@ -304,6 +305,10 @@ var JSHINT = (function () {
 
 		if (state.option.rhino) {
 			combine(predefined, vars.rhino);
+		}
+
+		if (state.option.phantom) {
+			combine(predefined, vars.phantom);
 		}
 
 		if (state.option.prototypejs) {

--- a/tests/stable/unit/envs.js
+++ b/tests/stable/unit/envs.js
@@ -638,3 +638,16 @@ exports.yui = function (test) {
 
 	test.done();
 };
+
+exports.phantom = function (test) {
+	var globals = [
+		'phantom',
+		'require',
+		'WebPage',
+	];
+
+	globalsImplied(test, globals);
+	globalsKnown(test, globals, { phantom: true });
+
+	test.done();
+};


### PR DESCRIPTION
I've been working with PhantomJS a fair amount recently and noticed that PhantomJS is not currently one of the supported platforms/environments in JSHint. Considering that it's becoming a fairly popular and widespread tool, I thought this would be useful for the community. This pull request adds that support, and also the test coverage.

It adds `phantom` as the option, which will acknowledge the following symbols:
- `phantom`
- `require`
- `WebPage`

Relevant commit:

7963ba2
