### PR TITLE
Don't skip directories when searching for .jshintrc.

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -145,7 +145,7 @@ function findFile(name, dir) {
 	dir = dir || process.cwd();
 
 	var filename = path.normalize(path.join(dir, name));
-	var parent = path.resolve(dir, "../../");
+	var parent = path.resolve(dir, "../");
 
 	if (shjs.test("-e", filename)) {
 		return filename;

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -229,6 +229,29 @@ exports.group = {
 		run.restore();
 		test.done();
 	},
+    
+	testRcLookup: function (test) {
+		var run = sinon.stub(cli, "run");
+		var srcDir = __dirname + "../src/";
+		var confPath = path.join(srcDir, ".jshintrc");
+		var cliDir = path.join(srcDir, "cli/");
+		var conf = shjs.cat(path.join(__dirname + "/../examples/", ".jshintrc"));
+
+		sinon.stub(process, "cwd").returns(cliDir);
+		sinon.stub(shjs, "test").withArgs("-e", confPath).returns(true);
+		sinon.stub(shjs, "cat").withArgs(confPath).returns(conf);
+
+		cli.interpret([
+			"node", "jshint", "file.js"
+		]);
+		test.equal(run.args[0][0].config.strict, true);
+
+		shjs.test.restore();
+		shjs.cat.restore();
+		process.cwd.restore();
+		run.restore();
+		test.done();
+	},
 
 	testIgnoreFile: function (test) {
 		var run = sinon.stub(cli, "run");


### PR DESCRIPTION
Instead of moving on to the parent directory when a .jshintrc
file was not found, the cli script was checking the
'grandparent' directory. A test was added to demonstrate the
issue / prevent regressions.

References:
    Fixes GH-850
