### PR TITLE
Allow all function params to be checked by 'unused'

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -120,7 +120,6 @@ var JSHINT = (function () {
 			                    // predefined
 			rhino       : true, // if the Rhino environment globals should be predefined
 			undef       : true, // if variables should be declared before used
-			unused      : true, // if variables should be always used
 			scripturl   : true, // if script-targeted URLs should be tolerated
 			shadow      : true, // if variable shadowing should be tolerated
 			smarttabs   : true, // if smarttabs should be tolerated
@@ -158,7 +157,12 @@ var JSHINT = (function () {
 			maxstatements: false, // {int} max statements per function
 			maxdepth     : false, // {int} max nested block depth per function
 			maxparams    : false, // {int} max params per function
-			maxcomplexity: false  // {int} max cyclomatic complexity per function
+			maxcomplexity: false, // {int} max cyclomatic complexity per function
+			unused       : true // warn if variables are unused
+										//  false - don't check for unused variables
+										//  true - "vars" + check last function param
+										//  "vars" - skip checking unused function params
+										//  "strict" - "vars" + check all function params
 		},
 
 		// These are JSHint boolean options which are shared with JSLint
@@ -630,6 +634,24 @@ var JSHINT = (function () {
 						break;
 					default:
 						error("E002", nt);
+					}
+					return;
+				}
+
+				if (key === "unused") {
+					switch(val) {
+						case "true":
+							state.option.unused = true;
+							break;
+						case "false":
+							state.option.unused = false;
+							break;
+						case "vars":
+						case "strict":
+							state.option.unused = val;
+							break;
+						default:
+							error("E002", nt);
 					}
 					return;
 				}
@@ -2287,10 +2309,7 @@ var JSHINT = (function () {
 
 		funct["(metrics)"].verifyMaxStatementsPerFunction();
 		funct["(metrics)"].verifyMaxComplexityPerFunction();
-
-		if (state.option.unused === false) {
-			funct["(ignoreUnused)"] = true;
-		}
+		funct["(unusedOption)"] = state.option.unused;
 
 		scope = oldScope;
 		state.option = oldOption;
@@ -3441,11 +3460,23 @@ var JSHINT = (function () {
 					implied[name] = newImplied;
 			};
 
-			var warnUnused = function (name, tkn) {
+			var warnUnused = function (name, tkn, type, unused_opt) {
 				var line = tkn.line;
 				var chr  = tkn.character;
 
-				if (state.option.unused)
+				if (typeof(unused_opt) === 'undefined') {
+					unused_opt = state.option.unused;
+				}
+				if (unused_opt === true) {
+					unused_opt = "last-param";
+				}
+
+				var warnable_types = {
+					"vars": ["var"],
+					"last-param": ["var", "last-param"],
+					"strict": ["var", "param", "last-param"]};
+
+				if (unused_opt && (unused_opt in warnable_types) && warnable_types[unused_opt].indexOf(type) !== -1)
 					warningAt("W098", line, chr, name);
 
 				unuseds.push({
@@ -3474,7 +3505,7 @@ var JSHINT = (function () {
 					return;
 				}
 
-				warnUnused(key, tkn);
+				warnUnused(key, tkn, "var");
 			};
 
 			// Check queued 'x is not defined' instances to see if they're still undefined.
@@ -3489,7 +3520,7 @@ var JSHINT = (function () {
 			}
 
 			functions.forEach(function (func) {
-				if (func["(ignoreUnused)"]) {
+				if (func["(unusedOption)"] === false) {
 					return;
 				}
 
@@ -3504,10 +3535,11 @@ var JSHINT = (function () {
 
 				var params = func["(params)"].slice();
 				var param  = params.pop();
-				var type;
+				var type, unused_type;
 
 				while (param) {
 					type = func[param];
+					unused_type = (params.length === func["(params)"].length-1 ? "last-param" : "param");
 
 					// 'undefined' is a special case for (function (window, undefined) { ... })();
 					// patterns.
@@ -3515,17 +3547,17 @@ var JSHINT = (function () {
 					if (param === "undefined")
 						return;
 
-					if (type !== "unused" && type !== "unction")
-						return;
+					if (type === "unused" || type === "unction") {
+						warnUnused(param, func["(tokens)"][param], unused_type, func["(unusedOption)"]);
+					}
 
-					warnUnused(param, func["(tokens)"][param]);
 					param = params.pop();
 				}
 			});
 
 			for (var key in declared) {
 				if (_.has(declared, key) && !_.has(global, key)) {
-					warnUnused(key, declared[key]);
+					warnUnused(key, declared[key], "var");
 				}
 			}
 		} catch (err) {

--- a/tests/stable/unit/options.js
+++ b/tests/stable/unit/options.js
@@ -416,22 +416,77 @@ exports.unused = function (test) {
 
 	TestRun(test).test(src);
 
-	TestRun(test)
-		.addError(1, "'a' is defined but never used.")
-		.addError(6, "'f' is defined but never used.")
-		.addError(7, "'c' is defined but never used.")
-		.addError(15, "'foo' is defined but never used.")
-		.addError(20, "'bar' is defined but never used.")
-		.test(src, { unused: true });
+	var var_errors = [
+		[1, "'a' is defined but never used."],
+		[7, "'c' is defined but never used."],
+		[15, "'foo' is defined but never used."],
+		[20, "'bar' is defined but never used."]];
+
+	var last_param_errors = [[6, "'f' is defined but never used."]],
+		all_param_errors = [[15, "'err' is defined but never used."]];
+
+	var true_run = TestRun(test);
+	var_errors.concat(last_param_errors).forEach(function(e) {
+		true_run.addError.apply(true_run, e);
+	});
+	true_run.test(src, { unused: true });
 
 	test.ok(!JSHINT(src, { unused: true }));
 
+	// Test checking all function params via unused="strict"
+	var all_run = TestRun(test);
+	var_errors.concat(last_param_errors, all_param_errors).forEach(function(e) {
+		all_run.addError.apply(true_run, e);
+	});
+	all_run.test(src, {unused:"strict"});
+
+	// Test checking everything except function params
+	var vars_run = TestRun(test);
+	var_errors.forEach(function(e) { vars_run.addError.apply(vars_run, e); });
+	vars_run.test(src, {unused:"vars"});
+
 	var unused = JSHINT.data().unused;
-	test.equal(5, unused.length);
+	test.equal(6, unused.length);
 	test.ok(unused.some(function (err) { return err.line === 1 && err.name === "a"; }));
 	test.ok(unused.some(function (err) { return err.line === 6 && err.name === "f"; }));
 	test.ok(unused.some(function (err) { return err.line === 7 && err.name === "c"; }));
 	test.ok(unused.some(function (err) { return err.line === 15 && err.name === "foo"; }));
+
+	test.done();
+};
+
+// Regressions for "unused" getting overwritten via comment (GH-778)
+exports['unused overrides'] = function (test) {
+	var code;
+	
+	code = ['function foo(a) {', '/*jshint unused:false */', '}', 'foo();'];
+	TestRun(test).test(code, {unused:true});
+	
+	code = ['function foo(a, b) {', '/*jshint unused:vars */', 'var i = 3;', '}', 'foo();'];
+	TestRun(test)
+		.addError(3, "'i' is defined but never used.")
+		.test(code, {unused:true});
+
+	code = ['function foo(a, b) {', '/*jshint unused:true */', 'var i = 3;', '}', 'foo();'];
+	TestRun(test)
+		.addError(1, "'b' is defined but never used.")
+		.addError(3, "'i' is defined but never used.")
+		.test(code, {unused:"strict"});
+
+	code = ['function foo(a, b) {', '/*jshint unused:strict */', 'var i = 3;', '}', 'foo();'];
+	TestRun(test)
+		.addError(1, "'a' is defined but never used.")
+		.addError(1, "'b' is defined but never used.")
+		.addError(3, "'i' is defined but never used.")
+		.test(code, {unused:true});
+
+	code = ['/*jshint unused:vars */', 'function foo(a, b) {}', 'foo();'];
+	TestRun(test).test(code, {unused:"strict"});
+	
+	code = ['/*jshint unused:vars */', 'function foo(a, b) {', 'var i = 3;', '}', 'foo();'];
+	TestRun(test)
+		.addError(3, "'i' is defined but never used.")
+		.test(code, {unused:"strict"});
 
 	test.done();
 };


### PR DESCRIPTION
This allows passing a value other than true/false to the 'unused' option to allow for checking all function params.  For
example:

```
function foo(a, b) {
    return b;
}
```

If 'unused' === true, no warnings will be thrown, since 'b' is used.  If 'unused' === 'all', then a warning will be
thrown, since 'a' is not used.

References:
- Makes GH-607 the default, but optional, rather than mandatory
- Closes GH-778
