### PR TITLE
Fix for trivial, referencing undefined object error

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -2115,7 +2115,7 @@ var JSHINT = (function () {
 
 		advance(")", this);
 		nospace(state.tokens.prev, state.tokens.curr);
-		if (state.option.immed && exprs[0].id === "function") {
+		if (state.option.immed && exprs[0] && exprs[0].id === "function") {
 			if (state.tokens.next.id !== "(" &&
 			  (state.tokens.next.id !== "." || (peek().value !== "call" && peek().value !== "apply"))) {
 				warning("W068", this);


### PR DESCRIPTION
I caught "TypeError: Cannot read property 'foobar' of undefined" on
"immed" related sections of jshint code,
when I applyed fixmyjs to minified js code by mistake.

(Got no error for other js files.)
