### PR TITLE
Add 'unnecessary' to escaping message to make it clearer.

### DIFF
--- a/src/shared/messages.js
+++ b/src/shared/messages.js
@@ -105,7 +105,7 @@ var warnings = {
 	W041: "Use '{a}' to compare with '{b}'.",
 	W042: "Avoid EOL escaping.",
 	W043: "Bad escaping of EOL. Use option multistr if needed.",
-	W044: "Bad escaping.",
+	W044: "Bad or unnecessary escaping.",
 	W045: "Bad number '{a}'.",
 	W046: "Don't use extra leading zeros '{a}'.",
 	W047: "A trailing decimal point can be confused with a dot: '{a}'.",

--- a/tests/stable/unit/core.js
+++ b/tests/stable/unit/core.js
@@ -499,7 +499,7 @@ exports.NumberNaN = function (test) {
 exports.htmlEscapement = function (test) {
 	TestRun(test).test("var a = '<\\!--';");
 	TestRun(test)
-		.addError(1, "Bad escaping.")
+		.addError(1, "Bad or unnecessary escaping.")
 		.test("var a = '\\!';");
 
 	test.done();

--- a/tests/stable/unit/parser.js
+++ b/tests/stable/unit/parser.js
@@ -336,7 +336,7 @@ exports.strings = function (test) {
 	TestRun(test)
 		.addError(1, "Control character in string: <non-printable>.", {character: 10})
 		.addError(1, "This character may get silently deleted by one or more browsers.")
-		.addError(2, "Bad escaping.")
+		.addError(2, "Bad or unnecessary escaping.")
 		.addError(5, "Unclosed string.")
 		.addError(5, "Missing semicolon.")
 		.test(code);


### PR DESCRIPTION
I think this makes the warning) message clearer for the common case when there is a correct (but unnecessary) usage of backslash.
