### PR TITLE
Allow reserved words as property names in objects followed by commas

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -958,7 +958,7 @@ var JSHINT = (function () {
 			nonadjacent(state.tokens.curr, state.tokens.next);
 		}
 
-		if (state.tokens.next.identifier) {
+		if (state.tokens.next.identifier && !state.option.es5) {
 			// Keywords that cannot follow a comma operator.
 			switch (state.tokens.next.value) {
 			case "break":

--- a/tests/stable/unit/core.js
+++ b/tests/stable/unit/core.js
@@ -545,16 +545,21 @@ exports.testES5Reserved = function (test) {
 
 	TestRun(test)
 		.addError(2, "Expected an identifier and instead saw 'default' (a reserved word).")
-		.addError(5, "Expected an identifier and instead saw 'default' (a reserved word).")
-		.addError(6, "Expected an identifier and instead saw 'new' (a reserved word).")
-		.addError(7, "Expected an identifier and instead saw 'class' (a reserved word).")
-		.addError(8, "Expected an identifier and instead saw 'default' (a reserved word).")
+		.addError(3, "Unexpected 'in'.")
+		.addError(3, "Expected an identifier and instead saw 'in' (a reserved word).")
+		.addError(6, "Expected an identifier and instead saw 'default' (a reserved word).")
+		.addError(7, "Expected an identifier and instead saw 'new' (a reserved word).")
+		.addError(8, "Expected an identifier and instead saw 'class' (a reserved word).")
+		.addError(9, "Expected an identifier and instead saw 'default' (a reserved word).")
+		.addError(10, "Expected an identifier and instead saw 'in' (a reserved word).")
+		.addError(11, "Expected an identifier and instead saw 'in' (a reserved word).")
 		.test(src);
 
 	TestRun(test)
-		.addError(5, "Expected an identifier and instead saw 'default' (a reserved word).")
-		.addError(6, "Expected an identifier and instead saw 'new' (a reserved word).")
-		.addError(7, "Expected an identifier and instead saw 'class' (a reserved word).")
+		.addError(6, "Expected an identifier and instead saw 'default' (a reserved word).")
+		.addError(7, "Expected an identifier and instead saw 'new' (a reserved word).")
+		.addError(8, "Expected an identifier and instead saw 'class' (a reserved word).")
+		.addError(11, "Expected an identifier and instead saw 'in' (a reserved word).")
 		.test(src, { es5: true });
 
 	test.done();

--- a/tests/stable/unit/fixtures/es5Reserved.js
+++ b/tests/stable/unit/fixtures/es5Reserved.js
@@ -1,8 +1,11 @@
 var x = {
-	default: 10
+	default: 10,
+  in: 1
 };
 
 var default = 10;
 function new () {}
 function x(class) {}
 x.default = 5;
+x.in = 2;
+function in() {}


### PR DESCRIPTION
fixes #768 edge case.

When using reserved words as properties inside objects with ES5 enabled, any reserved word that comes after a comma throws  `Unexpected 'default'.`

Example case: 

``` javascript
var hello = {
  holla: 'world',
  default: 5
}
```
