### PR TITLE
Fix for issue #903

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -320,6 +320,14 @@ var exports = {
 		return results.length === 0;
 	},
 
+	/** 
+	 * Helper exposed for testing.
+	 * Used to determine is stdout has any buffered output before exiting the program
+	 */
+	getProcessStdOutBufferSize: function () {
+		return process.stdout.bufferSize; 
+	},
+	
 	/**
 	 * Main entrance function. Parses arguments and calls 'run' when
 	 * its done. This function is called from bin/jshint file.
@@ -378,19 +386,19 @@ var exports = {
 			verbose: options.verbose
 		});
 
-    // smozely patch as per https://github.com/visionmedia/mocha/issues/333
-    // fixes issues with piped output on Windows.
-    // Root issue is here https://github.com/joyent/node/issues/3584
-    function exit() { process.exit(passed ? 0 : 2); }
-    try {
-        if (process.stdout.bufferSize) {
-          process.stdout.once('drain', exit);
-        } else {
-          exit();
-        }
-      } catch (err) {
-        exit();
-      }
+		// Patch as per https://github.com/visionmedia/mocha/issues/333
+		// fixes issues with piped output on Windows.
+		// Root issue is here https://github.com/joyent/node/issues/3584
+		function exit() { process.exit(passed ? 0 : 2); }    
+		try {
+			if (exports.getProcessStdOutBufferSize()) {
+				process.stdout.once('drain', exit);
+			} else {
+				exit();
+			}
+		} catch (err) {
+			exit();
+		}
 	}
 };
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -413,12 +413,11 @@ exports.group = {
 		test.done();
 	},
 
-/*	Test commented by smozely, because it doesn't seem possible to stub the call to bufferSize
-	testDrain: function (test) {
+	testDrainCalledWhenThereIsBufferedOutput: function (test) {
 		var dir = __dirname + "/../examples/";
 		sinon.stub(cli, "run").returns(false);
-		sinon.stub(process, "cwd").returns(dir);
-		process.stdout.bufferSize = 1; // This doesn't work because buffer size is read only.
+		sinon.stub(cli, "getProcessStdOutBufferSize").returns(1);
+		sinon.stub(process, "cwd").returns(dir);		
 		sinon.stub(process.stdout, "on", function (name, func) {
 			func();
 		});
@@ -427,14 +426,39 @@ exports.group = {
 		sinon.stub(process, "exit");
 
 		cli.interpret(["node", "jshint", "reporter.js"]);
+		test.equal(process.stdout.on.callCount, 1);
 		test.equal(process.stdout.on.args[0][0], "drain");
 		test.strictEqual(process.exit.args[0][0], 2);
 
 		process.cwd.restore();
-		process.stdout.flush.restore();
 		process.stdout.on.restore();
 		cli.run.restore();
+		cli.getProcessStdOutBufferSize.restore();
 
 		test.done();
-	}*/
+	},
+	
+	testDrainNotCalledWhenThereIsNoBufferedOutput: function (test) {
+		var dir = __dirname + "/../examples/";
+		sinon.stub(cli, "run").returns(false);
+		sinon.stub(cli, "getProcessStdOutBufferSize").returns(0);
+		sinon.stub(process, "cwd").returns(dir);		
+		sinon.stub(process.stdout, "on", function (name, func) {
+			func();
+		});
+
+		process.exit.restore();
+		sinon.stub(process, "exit");
+
+		cli.interpret(["node", "jshint", "reporter.js"]);
+		test.equal(process.stdout.on.callCount, 0);
+		test.strictEqual(process.exit.args[0][0], 2);
+
+		process.cwd.restore();
+		process.stdout.on.restore();
+		cli.run.restore();
+		cli.getProcessStdOutBufferSize.restore();
+
+		test.done();
+	}
 };


### PR DESCRIPTION
This fixes Issue #903 ... changes the check to use the bufferSize rather than the return value from flush.

Unfortunately was not able to get the cli test working agin because of not
being able to stub the return value from process.stdout.bufferSize.
