### PR TITLE
Fixes #936. "volatile" is not a reserved word (among many)

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -3575,37 +3575,25 @@ var JSHINT = (function () {
 		return this;
 	}).exps = true;
 
-	// Future Reserved Words
-
-	FutureReservedWord("abstract");
-	FutureReservedWord("boolean");
-	FutureReservedWord("byte");
-	FutureReservedWord("char");
+	// ES-262, 5.1 - 7.6.1.2 Future Reserved Words
 	FutureReservedWord("class", { es5: true });
-	FutureReservedWord("double");
+	// FutureReservedWord("const", { es5: true });
 	FutureReservedWord("enum", { es5: true });
 	FutureReservedWord("export", { es5: true });
 	FutureReservedWord("extends", { es5: true });
-	FutureReservedWord("final");
-	FutureReservedWord("float");
-	FutureReservedWord("goto");
-	FutureReservedWord("implements", { es5: true, strictOnly: true });
 	FutureReservedWord("import", { es5: true });
-	FutureReservedWord("int");
-	FutureReservedWord("interface");
-	FutureReservedWord("long");
-	FutureReservedWord("native");
+	FutureReservedWord("super", { es5: true });
+
+	// ES-262, 5.1 - 7.6.1.2 Future Reserved Words, Strict Mode Only
+	FutureReservedWord("implements", { es5: true, strictOnly: true });
+	FutureReservedWord("interface", { es5: true, strictOnly: true });
+	// FutureReservedWord("let", { es5: true, strictOnly: true });
 	FutureReservedWord("package", { es5: true, strictOnly: true });
 	FutureReservedWord("private", { es5: true, strictOnly: true });
 	FutureReservedWord("protected", { es5: true, strictOnly: true });
 	FutureReservedWord("public", { es5: true, strictOnly: true });
-	FutureReservedWord("short");
 	FutureReservedWord("static", { es5: true, strictOnly: true });
-	FutureReservedWord("super", { es5: true });
-	FutureReservedWord("synchronized");
-	FutureReservedWord("throws");
-	FutureReservedWord("transient");
-	FutureReservedWord("volatile");
+	// FutureReservedWord("yield", { es5: true, strictOnly: true });
 
 	// this function is used to determine wether a squarebracket or a curlybracket
 	// expression is a comprehension array, destructuring assignment or a json value.

--- a/tests/stable/unit/core.js
+++ b/tests/stable/unit/core.js
@@ -526,7 +526,6 @@ exports.testReserved = function (test) {
 	var src = fs.readFileSync(__dirname + "/fixtures/reserved.js", "utf8");
 
 	TestRun(test)
-		.addError(1, "Expected an identifier and instead saw 'volatile' (a reserved word).")
 		.addError(5, "Expected an identifier and instead saw 'let' (a reserved word).")
 		.addError(10, "Expected an identifier and instead saw 'let' (a reserved word).")
 		.addError(14, "Expected an identifier and instead saw 'else' (a reserved word).")


### PR DESCRIPTION
Removes erroneously listed "future reserved words" and puts the correct lists in order and marked under the section of ES5 that they are defined.

`const`, `let` and `yield` are commented out until a proper mechanism for flipping them from FutureReservedWord (ES5) to Keyword (ES6/moz) is established

Signed-off-by: Rick Waldron waldron.rick@gmail.com
