### PR TITLE
Test to verify that jshint survives parsing some html

### DIFF
--- a/tests/stable/unit/parser.js
+++ b/tests/stable/unit/parser.js
@@ -537,6 +537,17 @@ exports["regression for GH-910"] = function (test) {
 	test.done();
 };
 
+exports.testHtml = function (test) {
+	var html = "<html><body>Hello World</body></html>";
+	TestRun(test)
+		.addError(1, "Expected an identifier and instead saw '<'.")
+		.addError(1, "Expected an assignment or function call and instead saw an expression.")
+		.addError(1, "Missing semicolon.")
+		.addError(1, "Expected an identifier and instead saw '<'.")
+		.test(html, {});
+	test.done();
+};
+
 exports.testDestructuringVarFuncScope = function (test) {
 	var code = [
 		"function foobar() {",


### PR DESCRIPTION
This was actually solved at the same time than https://github.com/jshint/jshint/issues/910
However it hits me more than twice now so I added a test specifically for this case.

It is only marginally useful.

Maybe the true feature I would like to see would be:
1. crash the parser
2. report the file where the crashed occurred
3. suggest that it is either one of the 2 situations:
   - the content of the file does not remotely looking like javascript.
   - an opportunity to file a bug for jshint

Let me know.
