### PR TITLE
Add JSHint license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,12 @@
 		"console-browserify": "0.1.x"
 	},
 
+	"licenses": [
+		{
+			"type": "MIT",
+			"url": "https://github.com/jshint/jshint/blob/master/LICENSE"
+		}
+	],
+
 	"preferGlobal": true
 }


### PR DESCRIPTION
NPM spec allows for the JSHint license in the package.json. For completeness, I added it in :)

https://npmjs.org/doc/json.html
