### PR TITLE
Fix tests for windows systems

### DIFF
--- a/tests/cli.js
+++ b/tests/cli.js
@@ -205,7 +205,7 @@ exports.group = {
 
 	testRcFile: function (test) {
 		sinon.stub(process, "cwd").returns(__dirname);
-		var localRc = __dirname + "/.jshintrc";
+		var localRc = path.normalize(__dirname + "/.jshintrc");
 		var testStub = sinon.stub(shjs, "test");
 		var catStub = sinon.stub(shjs, "cat");
 
@@ -283,7 +283,7 @@ exports.group = {
 	testTargetRelativeRcLookup: function (test) {
 		// working from outside the project
 		sinon.stub(process, "cwd").returns(process.env.HOME || process.env.HOMEPATH);
-		var projectRc = __dirname + "/.jshintrc";
+		var projectRc = path.normalize(__dirname + "/.jshintrc");
 		var srcFile = __dirname + "/sub/file.js";
 		var testStub = sinon.stub(shjs, "test");
 		var catStub = sinon.stub(shjs, "cat");


### PR DESCRIPTION
Currently tests are producing several failures on windows systems. This is happening because of two issues where cli test conditions do not match the functionality in the cli code being tested. This patch resolves the following issues:
1. **Add `process.env.HOMEPATH` fallback for .jshintrc files**
    The `testHomeRcFile` and `testTargetRelativeRcLookup` tests were only using `process.env.HOME`, which returns `undefined` on windows systems. It also does not match the functionality of `findConfig()` which [coalesces the `HOME` and `HOMEPATH`](https://github.com/jshint/jshint/blob/ff4953807c7d71572db95ffd002c305292af189c/src/cli/cli.js#L107) environmental variables to support both *nix and windows.
2. **Normalize paths for stubbed .jshintrc files**
    The `testHomeRcFile` and `testTargetRelativeRcLookup` tests were stubbing the .jshintrc files with hard coded forward slashes for path separators, which does not match the paths that the `findConfig()` will try to open. The `findConfig()` function [runs the file paths through the `path.resolve()` method](https://github.com/jshint/jshint/blob/ff4953807c7d71572db95ffd002c305292af189c/src/cli/cli.js#L105) which returns a normalized path string. So the stubbed file commands were never actually being executed on windows systems.

Please note that I only fixed the _failing_ tests in this patch. It might be a good idea to go through all of the tests at some point and make sure that paths are normalized across the board.
