### PR TITLE
Added the ability to switch off indentation linting (issue #988)

### DIFF
--- a/src/shared/messages.js
+++ b/src/shared/messages.js
@@ -47,7 +47,7 @@ var errors = {
 	// Everything else
 	E030: "Expected an identifier and instead saw '{a}'.",
 	E031: "Bad assignment.", // FIXME: Rephrase
-	E032: "Expected a small integer and instead saw '{a}'.",
+	E032: "Expected a small integer or 'false' and instead saw '{a}'.",
 	E033: "Expected an operator and instead saw '{a}'.",
 	E034: "get/set are ES5 features.",
 	E035: "Missing property name.",

--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -627,22 +627,28 @@ var JSHINT = (function () {
 				}
 
 				if (numvals.indexOf(key) >= 0) {
-					val = +val;
 
-					if (typeof val !== "number" || !isFinite(val) || val <= 0 || Math.floor(val) !== val) {
-						if (val !== 0 || key !== "indent") {
+					// GH988 - numeric options can be disabled by setting them to `false`
+					if (val !== "false") {
+						val = +val;
+
+						if (typeof val !== "number" || !isFinite(val) || val <= 0 || Math.floor(val) !== val) {
 							error("E032", nt, g[1].trim());
-						} else if (key === "indent") {
-							state.option["(explicitIndent)"] = false;
+							return;
 						}
-						return;
+
+						if (key === "indent") {
+							state.option["(explicitIndent)"] = true;
+						}
+						state.option[key] = val;
+					} else {
+						if (key === "indent") {
+							state.option["(explicitIndent)"] = false;
+						} else {
+							state.option[key] = false;
+						}
 					}
 
-					if (key === "indent") {
-						state.option["(explicitIndent)"] = true;
-					}
-
-					state.option[key] = val;
 					return;
 				}
 

--- a/tests/stable/unit/core.js
+++ b/tests/stable/unit/core.js
@@ -599,10 +599,10 @@ exports.testCatchBlocks = function (test) {
 
 exports.testNumericParams = function (test) {
 	TestRun(test)
-		.test("/*jshint maxparams:4, indent:3 */");
+		.test("/*jshint maxparams:4, indent:3, maxlen:false */");
 
 	TestRun(test)
-		.addError(1, "Expected a small integer and instead saw 'face'.")
+		.addError(1, "Expected a small integer or 'false' and instead saw 'face'.")
 		.test("/*jshint maxparams:face */");
 
 	test.done();

--- a/tests/stable/unit/fixtures/gh988.js
+++ b/tests/stable/unit/fixtures/gh988.js
@@ -1,0 +1,58 @@
+function maxStatements() {
+    /*jshint maxstatements: 2 */
+    var x = 10;
+    return function () {
+        /*jshint maxstatements: false */
+        var y = 20;
+        var z = 30;
+        return x + y + z;
+    };
+}
+
+function maxParams() {
+    /*jshint maxparams: 1 */
+    return function (a) {
+        /*jshint maxparams: false */
+        return function (b, c) {
+            return true;
+        };
+    };
+}
+
+function maxDepth() {
+    /*jshint maxdepth: 1 */
+    return function () {
+        /*jshint maxdepth: false */
+        if (x) {
+            if (y) {}
+        }
+    };
+}
+
+function maxComplexity() {
+    /*jshint maxcomplexity: 1 */
+    return function () {
+        /*jshint maxcomplexity: false */
+        if (x) {
+            return true;
+        } else {
+            return false;
+        }
+    };
+}
+
+function maxLen() {
+    /*jshint maxlen: 40 */
+    return function () {
+        /*jshint maxlen: false */
+        return "a long string that would otherwise make the line too long";
+    };
+}
+
+function indent() {
+    /*jshint indent: 4 */
+    return function () {
+      /*jshint indent: false */
+      return true;
+    };
+}

--- a/tests/stable/unit/parser.js
+++ b/tests/stable/unit/parser.js
@@ -161,17 +161,20 @@ exports.options = function (test) {
 	var run = TestRun(test)
 		.addError(3, "Unexpected /*member 'c'.")
 		.addError(4, "Bad option: '++'.")
-		.addError(6, "Expected a small integer and instead saw '-2'.")
-		.addError(7, "Expected a small integer and instead saw '100.4'.")
-		.addError(8, "Expected a small integer and instead saw '200.4'.")
-		.addError(9, "Expected a small integer and instead saw '300.4'.")
-		.addError(10, "Expected a small integer and instead saw '0'.")
+		.addError(5, "Expected a small integer or 'false' and instead saw '0'.")
+		.addError(6, "Expected a small integer or 'false' and instead saw '-2'.")
+		.addError(7, "Expected a small integer or 'false' and instead saw '100.4'.")
+		.addError(8, "Expected a small integer or 'false' and instead saw '200.4'.")
+		.addError(9, "Expected a small integer or 'false' and instead saw '300.4'.")
+		.addError(10, "Expected a small integer or 'false' and instead saw '0'.")
 		.addError(13, "Bad option: 'd'.")
 		.addError(14, "Bad option value.")
 		.addError(16, "Read only.");
 	run.test(code, {es5: true});
 	run.test(code, {esnext: true});
 	run.test(code, {moz: true});
+
+	TestRun(test).test(fs.readFileSync(__dirname + "/fixtures/gh988.js", "utf8"));
 
 	test.done();
 };


### PR DESCRIPTION
This is a possible approach for switching off indentation linting (see #988) by setting the `indent` option to `0`. There may be a nicer way to handle this, so it's only a suggestion.

In particular, it may be preferable to handle all of the options in the `numvals` array in this way, in which case a more generic approach could be taken.
