### PR TITLE
npmignore unneeded files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+examples
+res
+tests
+.travis.yml
+CONTRIBUTING.MD
+make.js


### PR DESCRIPTION
/res and /tests currently wastes 2.4MB for anyone having JSHint as a dep, in this case grunt-contrib-jshint.
