### PR TITLE
Use absolute path in JSLint XML reporter

### DIFF
--- a/src/reporters/jslint_xml.js
+++ b/src/reporters/jslint_xml.js
@@ -1,5 +1,7 @@
 // Author: Vasili Sviridov
 // http://github.com/vsviridov
+var path = require("path");
+
 module.exports =
 {
 	reporter: function (results)
@@ -28,7 +30,7 @@ module.exports =
 
 
 		results.forEach(function (result) {
-			result.file = result.file.replace(/^\.\//, '');
+			result.file = path.join(process.cwd(), result.file);
 			if (!files[result.file]) {
 				files[result.file] = [];
 			}


### PR DESCRIPTION
Hi, we're using JSHint with Jenkins' [Violation](https://wiki.jenkins-ci.org/display/JENKINS/Violations) plugin. Recently we just upgraded JSHint from 0.7.1 to 1.1.0 and we cannot view per-file violations anymore(clicking filename gives a blank page).

It seems the only difference is that JSLint reporter used to print absolute paths and now it's all relative. Thus this patch.

This patch is by no means a ready-to-merge one, just a rough start to tackle the problem. Feel free to tell me what more to do to get this merged.
