### PR TITLE
Update link to jQuery.browser documentation.

### DIFF
--- a/tests/stable/regression/libs/jquery-1.7.js
+++ b/tests/stable/regression/libs/jquery-1.7.js
@@ -862,7 +862,7 @@ jQuery.extend({
 	},
 
 	// Use of jQuery.browser is frowned upon.
-	// More details: http://docs.jquery.com/Utilities/jQuery.browser
+	// More details: http://api.jquery.com/jQuery.browser/
 	uaMatch: function( ua ) {
 		ua = ua.toLowerCase();
 


### PR DESCRIPTION
docs.jquery.com is deprecated and will go away soon.
