### PR TITLE
Ignore unrecognized JSLint options

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -244,7 +244,7 @@ var JSHINT = (function () {
 		}
 
 		if (valOptions[name] === undefined && boolOptions[name] === undefined) {
-			if (t.type !== "jslint" || renamedOptions[name] === undefined) {
+			if (t.type !== "jslint") {
 				error("E001", t, name);
 				return false;
 			}

--- a/tests/stable/unit/core.js
+++ b/tests/stable/unit/core.js
@@ -286,6 +286,16 @@ exports.jslintSloppy = function (test) {
 	test.done();
 };
 
+/** JSHint should ignore unrecognized jslint options */
+exports.jslintUnrecognized = function (test) {
+	var src = "/*jslint closure:true */ function test() { return 1; }";
+
+	TestRun(test)
+		.test(src);
+
+	test.done();
+};
+
 exports.caseExpressions = function (test) {
 	var src = fs.readFileSync(__dirname + '/fixtures/caseExpressions.js', 'utf8');
 	TestRun(test)


### PR DESCRIPTION
Currently JSHint reports an error when it encounters an option in a
/*jslint */ comment which is not either a jshint option or a renamed
jslint option.  This has the unfortunate side-effect that source files
which specify valid options to JSLint which aren't recognized by JSHint
produce errors in JSHint (e.g. the "continue" option or the new
"closure" option).

We could fix this by whitelisting all valid JSLint options, but this
would require updates to JSHint every time JSLint added an option and I
doubt JSHint really wants to waste resources validating options to
JSLint (since, presumably, people using the /*jslint */ syntax would run
JSLint, which would warn them anyway).

Instead, ignore unrecognized options in /*jslint */ option comments.

Signed-off-by: Kevin Locke kevin@kevinlocke.name
