### PR TITLE
Include error codes in reports

### DIFF
--- a/src/reporters/default.js
+++ b/src/reporters/default.js
@@ -18,7 +18,7 @@ module.exports = {
 			prevfile = file;
 
 			str += file  + ': line ' + error.line + ', col ' +
-				error.character + ', ' + error.reason;
+				error.character + ', ' + error.reason + (error.code ? ' (' + error.code + ')' : '');
 
 			if (opts.verbose) {
 				str += ' (' + error.code + ')';

--- a/src/reporters/jslint_xml.js
+++ b/src/reporters/jslint_xml.js
@@ -42,9 +42,12 @@ module.exports =
 			out.push("\t<file name=\"" + file + "\">");
 			for (i = 0; i < files[file].length; i++) {
 				issue = files[file][i];
-				out.push("\t\t<issue line=\"" + issue.line + "\" char=\"" +
-					issue.character + "\" reason=\"" + encode(issue.reason) +
-					"\" evidence=\"" + encode(issue.evidence) + "\" />");
+				out.push("\t\t<issue line=\"" + issue.line
+					+ "\" char=\"" + issue.character
+					+ "\" reason=\"" + encode(issue.reason)
+					+ "\" evidence=\"" + encode(issue.evidence)
+					+ (issue.code ? "\" severity=\"" + encode(issue.code.charAt(0)) : "")
+					+ "\" />");
 			}
 			out.push("\t</file>");
 		}


### PR DESCRIPTION
Hello, i noticed that JSHint has a nice system of error codes and messages divided into **E**rror, **W**arning and **I**nfo. I wondered why it would not be included print out on the command line, so i first added it to the _default_ reporter.

I also wanted to use this with my Jenkins setup, so i also added it as "severity" attribute to the _jslint_xml_ reporter. I use this in conjunction with my patched Jenkins violations-plugin:
https://github.com/croensch/violations-plugin/commit/7f2c5457fad0745554cbed31c8c4dae588d29f85

Only thing missing is the _checkstyle_ reporter now, as i had no need for it. The other two run fine in production. So let me hear how to move this forward.
