### PR TITLE
Fix "TypeError: Cannot read property 'use strict' of undefined".

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -1759,20 +1759,18 @@ var JSHINT = (function () {
 			indent = old_indent;
 		} else if (!ordinary) {
 			if (isfunc) {
+				m = {};
 				if (stmt && !isfatarrow && !state.option.inMoz(true)) {
 					error("W118", state.tokens.curr, "function closure expressions");
 				}
 
 				if (!stmt) {
-					m = {};
 					for (d in state.directive) {
 						if (_.has(state.directive, d)) {
 							m[d] = state.directive[d];
 						}
 					}
 				}
-				m = m || {};
-
 				expression(0);
 
 				if (state.option.strict && funct["(context)"]["(global)"]) {


### PR DESCRIPTION
Fixes a crash with this input:

``` bash
cat > use-strict-undefined.js <<"END"
// jshint esnext: true, globalstrict: true
"use strict";
var a = () => 42;
END
./bin/jshint use-strict-undefined.js
```
