### PR TITLE
Check the entire scope chain before concluding a 'for' var is global.

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -3578,22 +3578,24 @@ var JSHINT = (function () {
 				funct["(blockscope)"].stack();
 				state.syntax["let"].fud.call(state.syntax["let"].fud, true);
 			} else {
-				switch (funct[state.tokens.next.value]) {
-				case "unused":
-					funct[state.tokens.next.value] = "var";
-					break;
-				case "var":
-					break;
-				default:
-					for (var f = funct; true; f = f["(context)"]) {
-						if (f["(global)"]) {
-							warning("W088", state.tokens.next, state.tokens.next.value);
-							break;
-						}
-						if (f[state.tokens.next.value] === "unused") {
-							break;
+				for (var f = funct; true; f = f["(context)"]) {
+					if (f["(global)"] && f !== funct) {
+						warning("W088", state.tokens.next, state.tokens.next.value);
+						break;
+					}
+					switch (f[state.tokens.next.value]) {
+					case "unused":
+						funct[state.tokens.next.value] = "var";
+						break;
+					case "var":
+						console.log(f[state.tokens.next.value]);
+						break;
+					default:
+						if (!f["(blockscope)"].getlabel(state.tokens.next.value)) {
+							continue;
 						}
 					}
+					break;
 				}
 				advance();
 			}


### PR DESCRIPTION
This should fix #1016. The question is whether there are other similar bugs. I didn't notice any other likely error messages, so maybe not.

``` bash
cat > check-global-var-in-for.js <<"END"
(function(){
    'use strict';
    var myList = [];
    function something(){
        var key;
        function sub(){
            for(key in myList){}
        }
    }
})();
END
./bin/jshint check-global-var-in-for.js
```
