### PR TITLE
Console-browerify should be a hard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"underscore": "1.4.x",
 		"peakle":     "0.0.x",
 		"cli":        "0.4.x",
-		"minimatch":  "0.x.x"
+		"minimatch":  "0.x.x",
+		"console-browserify": "0.1.x"
 	},
 
 	"devDependencies": {
@@ -36,8 +37,7 @@
 		"browserify": "1.16.1",
 		"coveraje":   "0.2.x",
 		"nodeunit":   "0.7.x",
-		"sinon":      "1.6.x",
-		"console-browserify": "0.1.x"
+		"sinon":      "1.6.x"
 	},
 
 	"preferGlobal": true


### PR DESCRIPTION
Console-browserify is set a dev dependency but is referenced `stable/jshint.js` https://github.com/jshint/jshint/blob/master/src/stable/jshint.js#L47

This results the error below if you're using jshint's api rather than the bin, as you would within grunt plugins for example.

`Error: Cannot find module 'console-browserify'`

This is because npm doesn't automatically install dev dependencies for project dependencies.
