### PR TITLE
Add support for `do` statement bodies that are not block statements

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -3515,7 +3515,7 @@ var JSHINT = (function () {
 			funct["(loopage)"] += 1;
 			increaseComplexityCount();
 
-			this.first = block(true);
+			this.first = block(true, true);
 			advance("while");
 			var t = state.tokens.next;
 			nonadjacent(state.tokens.curr, t);

--- a/tests/stable/regression/thirdparty.js
+++ b/tests/stable/regression/thirdparty.js
@@ -238,7 +238,6 @@ exports.codemirror3 = function (test) {
 		.addError(4093, "Unnecessary semicolon.")
 		.addError(4168, "Wrap the /regexp/ literal in parens to disambiguate the slash operator.")
 		.addError(4277, "'range' is defined but never used.")
-		.addError(4357, "Expected '{' and instead saw 'pos'.")
 		.test(src, opt, { CodeMirror: true });
 
 	test.done();

--- a/tests/stable/unit/fixtures/curly.js
+++ b/tests/stable/unit/fixtures/curly.js
@@ -6,3 +6,7 @@ for (;;)
 
 while (true)
     doSomething();
+
+do
+    doSomething();
+while (true);

--- a/tests/stable/unit/fixtures/curly2.js
+++ b/tests/stable/unit/fixtures/curly2.js
@@ -9,3 +9,7 @@ for (;;) {
 while (true) {
     doSomething();
 }
+
+do {
+    doSomething();
+} while (true);

--- a/tests/stable/unit/options.js
+++ b/tests/stable/unit/options.js
@@ -247,6 +247,7 @@ exports.curly = function (test) {
 		.addError(2, "Expected '{' and instead saw 'return'.")
 		.addError(5, "Expected '{' and instead saw 'doSomething'.")
 		.addError(8, "Expected '{' and instead saw 'doSomething'.")
+		.addError(11, "Expected '{' and instead saw 'doSomething'.")
 		.test(src, { es3: true, curly: true });
 
 	TestRun(test).test(src1, { es3: true, curly: true });


### PR DESCRIPTION
Added support for do-statement bodies that are not block statements in the same way that we can already do with e.g. if or while statements.

The new functionality will obey the `curly` option and allows the statement body to appear on the same line or the following line (in which case existing indentation rules will apply).

Here is a [Stack Overflow question](http://stackoverflow.com/questions/16411162/is-it-possible-and-reasonable-to-convince-jshint-to-accept-a-single-line-do-lo) which prompted this patch.
