### PR TITLE
Fix problem finding .jshintrc in windows and node 0.10

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -104,7 +104,7 @@ function findConfig(file) {
 	var name = ".jshintrc";
 	var dir = path.dirname(path.resolve(file));
 	var proj = findFile(name, dir);
-	var home = path.normalize(path.join(process.env.HOME || process.env.HOMEPATH, name));
+	var home = path.normalize(path.join(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE, name));
 
 	if (proj) {
 		return proj;


### PR DESCRIPTION
With node 0.10.x and Windows 8 the env variable must be `process.env.USERPROFILE` instead of the previous one.
