### PR TITLE
Add CI testing for newer Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
+  - "0.8"
+  - "0.10"
+  - "0.11"


### PR DESCRIPTION
This will run the test suite against the 0.8+ stable and latest unstable (0.11) branches. 
The quotes are required for the 0.10 version due to the way the YAML parser strips trailing zeros.
