### PR TITLE
Updating Checkstyle reporter to provide error codes

### DIFF
--- a/src/reporters/checkstyle.js
+++ b/src/reporters/checkstyle.js
@@ -2,7 +2,7 @@
 // http://github.com/relaxnow
 module.exports =
 {
-	reporter: function (results, data)
+	reporter: function (results, data, opts)
 	{
 		"use strict";
 
@@ -15,7 +15,9 @@ module.exports =
 				"<": "&lt;",
 				">": "&gt;"
 			},
-			file, fileName, i, issue, globals, unuseds;
+			file, fileName, i, issue, globals, unuseds, errorMessage;
+
+		opts = opts || {};
 
 		function encode(s) {
 			for (var r in pairs) {
@@ -33,13 +35,19 @@ module.exports =
 				files[result.file] = [];
 			}
 
+			// Create the error message
+			errorMessage = result.error.reason;
+			if (opts.verbose) {
+				errorMessage += ' (' + result.error.code + ')';
+			}
+
 			// Add the error
 			files[result.file].push({
 				severity: 'error',
 				line: result.error.line,
 				column: result.error.character,
-				message: result.error.reason,
-				source: result.error.raw
+				message: errorMessage,
+				source: result.error.code
 			});
 		});
 


### PR DESCRIPTION
There are two goals in this pull request:
1. When the --verbose option is supplied, add the error code to the checkstyle message attribute, so this output matches the default reporter.
2. Make the source attribute of the checkstyle output more useful.  In it's current incarnation, it's simply a less useful version of the message attribute, and Jenkins (among other tools) break when they try to use it for categorization.  In this change we simply use `result.error.code` for the source, which makes for easy categorization

I would much rather use the name of the actual JSHint option that is causing the error, but this information is not provided to the reporter, so it would take a large amount of refactoring to get that to work.  Perhaps we can write a mapping from error code to option, and leverage that to create the source in the future.
