### PR TITLE
Allow trailing underscore in identifiers' names

### DIFF
--- a/src/stable/style.js
+++ b/src/stable/style.js
@@ -64,20 +64,36 @@ exports.register = function (linter) {
 	});
 
 	// Check that all identifiers are using camelCase notation.
-	// Exceptions: names like MY_VAR and _myVar.
+	// Exceptions: names like MY_VAR, _myVar, and myVar_.
 
 	linter.on("Identifier", function style_scanCamelCase(data) {
+		var camelCaseRE = /^[A-Za-z0-9]+$/;
+		var upperCaseRE = /^[A-Z0-9_]+$/;
+		var isNice = function (identifier) {
+			return camelCaseRE.test(identifier) || upperCaseRE.test(identifier);
+		};
+
 		if (!linter.getOption("camelcase")) {
 			return;
 		}
 
-		if (data.name.replace(/^_+/, "").indexOf("_") > -1 && !data.name.match(/^[A-Z0-9_]*$/)) {
-			linter.warn("W106", {
-				line: data.line,
-				char: data.from,
-				data: [ data.name ]
-			});
+		if (isNice(data.name)) {
+			return;
 		}
+
+		if (/^_+/.test(data.name) && isNice(data.name.replace(/^_+/, ""))) {
+			return;
+		}
+
+		if (/_+$/.test(data.name) && isNice(data.name.replace(/_+$/, ""))) {
+			return;
+		}
+
+		linter.warn("W106", {
+			line: data.line,
+			char: data.from,
+			data: [ data.name ]
+		});
 	});
 
 	// Enforce consistency in style of quoting.

--- a/tests/stable/unit/fixtures/camelcase.js
+++ b/tests/stable/unit/fixtures/camelcase.js
@@ -15,3 +15,10 @@ var TEST_1, test1, test_1;
 function _FooBar(_testMe) {
     this.__testMe = _testMe;
 }
+
+function FooBar_(test_) {
+    this.TEST_ME_ = 12;
+    this.test__ = test_;
+}
+
+var _test_, _, testMe_, test_me_;

--- a/tests/stable/unit/options.js
+++ b/tests/stable/unit/options.js
@@ -217,6 +217,8 @@ exports.testCamelcase = function (test) {
 		.addError(6, "Identifier 'test_me' is not in camel case.")
 		.addError(6, "Identifier 'test_me' is not in camel case.")
 		.addError(13, "Identifier 'test_1' is not in camel case.")
+		.addError(24, "Identifier '_test_' is not in camel case.")
+		.addError(24, "Identifier 'test_me_' is not in camel case.")
 		.test(source, { es3: true, camelcase: true });
 
 


### PR DESCRIPTION
See Google JavaScript Style Guide for private members.
http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
