### PR TITLE
Bump JSHint dev dependency to latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 
 	"devDependencies": {
-		"jshint":     "1.1.0",
+		"jshint":     "2.1.x",
 		"shelljs":    "0.1.x",
 		"browserify": "2.12.x",
 		"coveraje":   "0.2.x",


### PR DESCRIPTION
Not sure if there is a better way of automating the bump as part of the minor patch release.
