### PR TITLE
Add repository and bug information for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,15 @@
 		"url":   "http://anton.kovalyov.net/"
 	},
 
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/jshint/jshint.git"
+	},
+
+	"bugs": {
+		"url": "https://github.com/jshint/jshint/issues"
+	},
+
 	"bin": {
 		"jshint": "./bin/jshint"
 	},


### PR DESCRIPTION
Missing the repository section now throws a warning on install (noticed in npm 1.2.21, but may have been earlier).
