### PR TITLE
Run lint along with tests on CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "0.8"
   - "0.10"
   - "0.11"
+script:
+  - node make.js all


### PR DESCRIPTION
I noticed there where errors when running the `lint` target in the build. This will now run the full build test+lint for PRs and commits*. 

\* Fixes sold separately
