### PR TITLE
Do not generate camelCase warnings for "__proto__" and "super_"

### DIFF
--- a/src/stable/style.js
+++ b/src/stable/style.js
@@ -64,18 +64,40 @@ exports.register = function (linter) {
 	});
 
 	// Check that all identifiers are using camelCase notation.
-	// Exceptions: names like MY_VAR and _myVar.
+	// Exceptions: names like MY_VAR, _myVar and exact names __proto__ and super_.
 
 	linter.on("Identifier", function style_scanCamelCase(data) {
+		var identifier;
+		var exceptions;
+		var nodeExceptions;
+
 		if (!linter.getOption("camelcase")) {
 			return;
 		}
 
-		if (data.name.replace(/^_+/, "").indexOf("_") > -1 && !data.name.match(/^[A-Z0-9_]*$/)) {
+		identifier = data.name;
+
+		exceptions = [
+			"__proto__"
+		];
+		if (exceptions.indexOf(identifier) > -1) {
+			return;
+		}
+
+		if (linter.getOption("node")) {
+			nodeExceptions = [
+				"super_"  // Node.js util.inherits make super constructor accessible via constructor.super_.
+			];
+			if (nodeExceptions.indexOf(identifier) > -1) {
+				return;
+			}
+		}
+
+		if (identifier.replace(/^_+/, "").indexOf("_") > -1 && !identifier.match(/^[A-Z0-9_]*$/)) {
 			linter.warn("W106", {
 				line: data.line,
 				char: data.from,
-				data: [ data.name ]
+				data: [ identifier ]
 			});
 		}
 	});

--- a/tests/stable/unit/fixtures/camelcase.js
+++ b/tests/stable/unit/fixtures/camelcase.js
@@ -1,3 +1,5 @@
+/* jshint proto: true, node: true */
+
 function FooBar(testMe) {
   this.testMe = testMe;
 }
@@ -15,3 +17,7 @@ var TEST_1, test1, test_1;
 function _FooBar(_testMe) {
     this.__testMe = _testMe;
 }
+
+var o = Function.prototype.__proto__;
+var s = ({}).constructor.super_;
+var test_;

--- a/tests/stable/unit/options.js
+++ b/tests/stable/unit/options.js
@@ -212,11 +212,12 @@ exports.testCamelcase = function (test) {
 
 	// Require identifiers in camel case if camelcase is true
 	TestRun(test)
-		.addError(5, "Identifier 'Foo_bar' is not in camel case.")
-		.addError(5, "Identifier 'test_me' is not in camel case.")
-		.addError(6, "Identifier 'test_me' is not in camel case.")
-		.addError(6, "Identifier 'test_me' is not in camel case.")
-		.addError(13, "Identifier 'test_1' is not in camel case.")
+		.addError(7, "Identifier 'Foo_bar' is not in camel case.")
+		.addError(7, "Identifier 'test_me' is not in camel case.")
+		.addError(8, "Identifier 'test_me' is not in camel case.")
+		.addError(8, "Identifier 'test_me' is not in camel case.")
+		.addError(15, "Identifier 'test_1' is not in camel case.")
+		.addError(23, "Identifier 'test_' is not in camel case.")
 		.test(source, { es3: true, camelcase: true });
 
 


### PR DESCRIPTION
`__proto__` and `super_` are not user-defined, so it does not make sense to generate warnings.

Rels #1090.
