### PR TITLE
Add a relaxing option to disable the unsafeChars check (W100)

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -137,6 +137,8 @@ var JSHINT = (function () {
 			sub         : true, // if all forms of subscript notation are tolerated
 			supernew    : true, // if `new function () { ... };` and `new Object;`
 			                    // should be tolerated
+			unsafechars : true, // if unsafe characters should not be checked
+			                    //
 			trailing    : true, // if trailing whitespace rules apply
 			validthis   : true, // if 'this' inside a non-constructor function is valid.
 			                    // This is a function scoped option only.

--- a/src/stable/lex.js
+++ b/src/stable/lex.js
@@ -1455,7 +1455,7 @@ Lexer.prototype = {
 		this.input = this.input.replace(/\t/g, state.tab);
 		char = this.scanUnsafeChars();
 
-		if (char >= 0) {
+		if (! state.option.unsafechars && char >= 0) {
 			this.trigger("warning", { code: "W100", line: this.line, character: char });
 		}
 

--- a/tests/stable/unit/parser.js
+++ b/tests/stable/unit/parser.js
@@ -17,6 +17,9 @@ exports.unsafe = function (test) {
 		.addError(1, "This character may get silently deleted by one or more browsers.")
 		.test(code, {es3: true});
 
+	TestRun(test)
+		.test(code, {es3: true, unsafechars: true});
+
 	test.done();
 };
 


### PR DESCRIPTION
This patch modifies the check for unsafe characters (unsafeChars) by
providing an option to relax it (option.unsafechars).

Several of the characters in the "unsafeChar" list are legitimate
Unicode characters (such as characters for the Sinahala language), and
can work properly if expected.

By default, this patch has no effect. It only causes a change in
behavior if the 'unsafechars' option is set to true.

References: GH-901
