### PR TITLE
"shelljs:true" should imply "node:true"

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -330,6 +330,7 @@ var JSHINT = (function () {
 
 		if (state.option.shelljs) {
 			combine(predefined, vars.shelljs);
+			combine(predefined, vars.node);
 		}
 
 		if (state.option.phantom) {

--- a/tests/stable/unit/fixtures/shelljs.js
+++ b/tests/stable/unit/fixtures/shelljs.js
@@ -24,3 +24,8 @@ chmod();
 config.hi = 'hi';
 error();
 tempdir();
+
+// node stuff
+require('hi');
+module.exports = 'hi';
+process.exit();

--- a/tests/stable/unit/options.js
+++ b/tests/stable/unit/options.js
@@ -338,6 +338,9 @@ exports.shelljs = function (test) {
 		.addError(24, "'config' is not defined.")
 		.addError(25, "'error' is not defined.")
 		.addError(26, "'tempdir' is not defined.")
+		.addError(29, "'require' is not defined.")
+		.addError(30, "'module' is not defined.")
+		.addError(31, "'process' is not defined.")
 		.test(src, { undef: true });
 
 	TestRun(test, 2)


### PR DESCRIPTION
figured this makes sense, as you need to `require('shelljs/global')` or `require('shelljs/make')`
