### PR TITLE
Count ternary and or operators for complexity

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -2055,7 +2055,13 @@ var JSHINT = (function () {
 		return that;
 	}, 30);
 
-	infix("||", "or", 40);
+	var orPrecendence = 40;
+	infix("||", function (left, that) {
+		increaseComplexityCount();
+		that.left = left;
+		that.right = expression(orPrecendence);
+		return that;
+	}, orPrecendence);
 	infix("&&", "and", 50);
 	bitwise("|", "bitor", 70);
 	bitwise("^", "bitxor", 80);

--- a/tests/stable/unit/fixtures/max-cyclomatic-complexity-per-function.js
+++ b/tests/stable/unit/fixtures/max-cyclomatic-complexity-per-function.js
@@ -76,3 +76,7 @@ function functionWithCyclomaticComplexity_8() {
 function functionWithCyclomaticComplexityDueToTernaryStatements_2(a) {
   var b = a ? true : false;
 }
+
+function functionWithCyclomaticComplexityDueToOrOperators_2(a) {
+  var b = a || {};
+}

--- a/tests/stable/unit/options.js
+++ b/tests/stable/unit/options.js
@@ -1492,6 +1492,7 @@ exports.maxcomplexity = function (test) {
 		.addError(25, "This function's cyclomatic complexity is too high. (2)")
 		.addError(47, "This function's cyclomatic complexity is too high. (8)")
 		.addError(76, "This function's cyclomatic complexity is too high. (2)")
+		.addError(80, "This function's cyclomatic complexity is too high. (2)")
 		.test(src, { es3: true, maxcomplexity: 1 });
 
 	TestRun(test)


### PR DESCRIPTION
Both ternary and || operators introduce independent code paths, and it's therefore sensible to include them when calculating JS cyclomatic complexity.
