### PR TITLE
Cyclomatic complexity. Issue #840.

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -2092,7 +2092,6 @@ var JSHINT = (function () {
 
 	var orPrecendence = 40;
 	infix("||", function (left, that) {
-		increaseComplexityCount();
 		that.left = left;
 		that.right = expression(orPrecendence);
 		return that;
@@ -3561,10 +3560,12 @@ var JSHINT = (function () {
 				indentation(-state.option.indent);
 				advance("case");
 				this.cases.push(expression(20));
-				increaseComplexityCount();
 				g = true;
 				advance(":");
 				funct["(verb)"] = "case";
+        if (state.tokens.next.id != "case") { // should not increase complexity for empty block
+          increaseComplexityCount();
+        }
 				break;
 			case "default":
 				switch (funct["(verb)"]) {

--- a/tests/stable/unit/fixtures/cyclomatic-complexity-per-condition.js
+++ b/tests/stable/unit/fixtures/cyclomatic-complexity-per-condition.js
@@ -1,0 +1,67 @@
+function complexity_2(someVal) {
+  switch (someVal) {
+    case 1:
+    case 2:
+    case 3:
+      doSomething();
+      break;
+    default:
+      doSomethingElse();
+      break;
+  }
+}
+
+function same_Complexity_2(someVal) {
+  if (someVal === 1 || someVal === 2 || someVal === 3) {
+    doSomething();
+  } else {
+    doSomethingElse();
+  }
+}
+
+function complexity_3(someVal) {
+  switch (someVal) {
+    case 1:
+    case 2:
+      break;
+    case 3:
+      doSomething();
+      break;
+    default:
+      doSomethingElse();
+      break;
+  }
+}
+
+function same_Complexity_3(someVal) {
+  if (someVal === 1 || someVal === 2) {
+    doSomething();
+  } else if(someVal === 3) {
+    doSomethingElse();
+  } else {
+    doSomethingElse();
+  }
+}
+
+function complexity_3(someVal) {
+  if (someVal === 1 && someVal === 2) {
+    doSomething();
+  } else if(someVal != 3) {
+    doSomethingElse();
+  } else {
+    doSomethingElse();
+  }
+}
+
+function complexity_4(someVal) {
+  switch (someVal) {
+    case 1:
+      something();
+      break;
+    case 2:
+      doSomething();
+      break;
+    case 3:
+      doSomethingElse();
+  }
+}

--- a/tests/stable/unit/options.js
+++ b/tests/stable/unit/options.js
@@ -1560,6 +1560,25 @@ exports.maxcomplexity = function (test) {
 };
 
 /*
+ * Tests the `maxcomplexity` option
+ */
+exports.maxcomplexity = function (test) {
+	var fixture = '/fixtures/cyclomatic-complexity-per-condition.js';
+	var src = fs.readFileSync(__dirname + fixture, 'utf8');
+
+	TestRun(test)
+		.addError(1, "This function's cyclomatic complexity is too high. (2)")
+		.addError(14, "This function's cyclomatic complexity is too high. (2)")
+		.addError(22, "This function's cyclomatic complexity is too high. (3)")
+		.addError(36, "This function's cyclomatic complexity is too high. (3)")
+		.addError(46, "This function's cyclomatic complexity is too high. (3)")
+		.addError(56, "This function's cyclomatic complexity is too high. (4)")
+		.test(src, { es3: true, maxcomplexity: 1 });
+
+	test.done();
+};
+
+/*
  * Tests ignored warnings.
  */
 exports.ignored = function (test) {


### PR DESCRIPTION
``` javascript
increaseComplexityCount();
```

was removed for '||'. I wonder if there is a case, when complexity increases as a result of '||' in conditional statement?

In switch: seems like complexity should not be increases for blank 'case' statement.

Tests included.
