### PR TITLE
Quiet some warnings based on the current style

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "boss": true,
+  "newcap": false,
+  "node": true,
+  "smarttabs": true
+}


### PR DESCRIPTION
When editing jshint code I get a lot of warnings.  Adding a local `.jshintrc` suppresses these (tested by running `jshint src` with jshint 2.1.4.  

I'm not sure if you want all (or even any) of these warnings suppressed, but I figured it wouldn't hurt to ask.  I'd guess the options `node` and `smarttabs` are pretty harmless as long as you're careful about the formatting that comes in on new patches.  Cheers!
