### PR TITLE
Support spaces in `/*global` just like in `/*jshint`.

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -581,8 +581,8 @@ var JSHINT = (function () {
 		if (nt.type === "globals") {
 			body.forEach(function (g) {
 				g = g.split(":");
-				var key = g[0];
-				var val = g[1];
+				var key = (g[0] || "").trim();
+				var val = (g[1] || "").trim();
 
 				if (key.charAt(0) === "-") {
 					key = key.slice(1);


### PR DESCRIPTION
Currently `/*global` does not accept `param: true` values, only `param:true` are accepted.
This patch amends to that (copying the very code used for `/*jshint` a few lines later in the same function).
