### PR TITLE
Rhino Wrapper: Globals & Exitcode

### DIFF
--- a/src/platforms/rhino.js
+++ b/src/platforms/rhino.js
@@ -9,6 +9,7 @@
 	var optstr; // arg1=val1,arg2=val2,...
 	var predef; // global1=true,global2,global3,...
 	var opts   = {};
+	var globals = {};
 	var retval = 0;
 
 	args.forEach(function (arg) {
@@ -80,13 +81,13 @@
 		});
 	}
 
-	opts.predef = opts.globals || {};
+	globals = opts.globals || {};
 	delete(opts.globals);
 
 	if (predef) {
 		predef.split(",").forEach(function (arg) {
 			var global = arg.split("=");
-			opts.predef[global[0]] = global[1] === "true" ? true : false;
+			globals[global[0]] = global[1] === "true" ? true : false;
 		});
 	}
 
@@ -98,7 +99,7 @@
 			quit(1);
 		}
 
-		if (!JSHINT(input, opts)) {
+		if (!JSHINT(input, opts, globals)) {
 			for (var i = 0, err; err = JSHINT.errors[i]; i += 1) {
 				print(err.reason + " (" + name + ":" + err.line + ":" + err.character + ")");
 				print("> " + (err.evidence || "").replace(/^\s*(\S*(\s+\S+)*)\s*$/, "$1"));


### PR DESCRIPTION
This PR fixes 2 issues I have come across.
1.) Exit Code behaviour differed between the Node-CLI Version of JSHint and the Rhino Wrapper. "JSHint ran fine, but you have lints" now exits with 2 on rhino as well.
2.) When linting multiple files at once, JSHint "forgot" the configured globals from the second file on, This Patch introduces the globals as the third argument to JSHINT( input, opts, globals), rather than relying on "opts.predef". This Behaviour was also taken from the Cli-Wrapper.
