### PR TITLE
Add tab option to set tabwidth without turning on indent error checking.

### DIFF
--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -159,6 +159,7 @@ var JSHINT = (function () {
 		valOptions = {
 			maxlen       : false,
 			indent       : false,
+			tab          : false,
 			maxerr       : false,
 			predef       : false,
 			quotmark     : false, //'single'|'double'|true
@@ -4399,6 +4400,7 @@ var JSHINT = (function () {
 		state.option = newOptionObj;
 		state.ignored = newIgnoredObj;
 
+		state.option.tab = state.option.tab || 4;
 		state.option.indent = state.option.indent || 4;
 		state.option.maxerr = state.option.maxerr || 50;
 

--- a/src/stable/lex.js
+++ b/src/stable/lex.js
@@ -227,7 +227,7 @@ function Lexer(source) {
 	this.from = 1;
 	this.input = "";
 
-	for (var i = 0; i < state.option.indent; i += 1) {
+	for (var i = 0; i < state.option.tab; i += 1) {
 		state.tab += " ";
 	}
 }


### PR DESCRIPTION
This commit fixes issue #1196
