### PR TITLE
Add optional parameters to cli.gather

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -332,11 +332,12 @@ var exports = {
 	 */
 	gather: function (opts) {
 		var files = [];
+
 		var reg = new RegExp("\\.(js" +
-			(opts.extensions === "" ? "" : "|" +
+			(!opts.extensions ? "" : "|" +
 				opts.extensions.replace(/,/g, "|").replace(/[\. ]/g, "")) + ")$");
 
-		var ignores = opts.ignores.map(function (target) {
+		var ignores = !opts.ignores ? loadIgnores() : opts.ignores.map(function (target) {
 			return path.resolve(target);
 		});
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -457,6 +457,25 @@ exports.group = {
 		test.done();
 	},
 
+	testGatherOptionalParameters: function (test) {
+		sinon.stub(shjs, "test")
+			.withArgs("-e", sinon.match(/.*/)).returns(true);
+
+		sinon.stub(shjs, "cat")
+			.withArgs(sinon.match(/\.jshintignore$/)).returns(path.join("ignore", "**"));
+
+		var files = cli.gather({
+			args: ["file.js"]
+		});
+
+		test.equal(files.length, 1);
+		test.equal(files[0], "file.js");
+
+		shjs.test.restore();
+		shjs.cat.restore();
+		test.done();
+	},
+
 	testGather: function (test) {
 		var dir = __dirname + "/../examples/";
 		var files = [];


### PR DESCRIPTION
If gather was invoked without an object that had an extensions and ignores
property then there would be an exception thrown.  It is reasonable that a
client would invoke jshint with an object without these properties.  Especially
since grunt-contrib-jshint relied on the fact that ignores was optional (see
commit 5de09c4) and then that functionality was changed without discussion or
warning, breaking grunt-contrib-jshint.

gruntjs/grunt-contrib-jshint#86
