### PR TITLE
Added default parameter support (esnext/moz)

### DIFF
--- a/src/shared/messages.js
+++ b/src/shared/messages.js
@@ -65,7 +65,8 @@ var errors = {
 	E047: "A generator function shall contain a yield statement.",
 	E048: "Let declaration not directly within block.",
 	E049: "A {a} cannot be named '{b}'.",
-	E050: "Mozilla requires the yield expression to be parenthesized here."
+	E050: "Mozilla requires the yield expression to be parenthesized here.",
+	E051: "Regular parameters cannot come after default parameters."
 };
 
 var warnings = {

--- a/src/stable/jshint.js
+++ b/src/stable/jshint.js
@@ -2597,6 +2597,7 @@ var JSHINT = (function () {
 		var ident;
 		var tokens = [];
 		var t;
+		var pastDefault = false;
 
 		if (parsed) {
 			if (parsed instanceof Array) {
@@ -2661,6 +2662,21 @@ var JSHINT = (function () {
 				ident = identifier(true);
 				params.push(ident);
 				addlabel(ident, "unused", state.tokens.curr);
+			}
+
+			// it is a syntax error to have a regular argument after a default argument
+			if (pastDefault) {
+				if (state.tokens.next.id !== "=") {
+					error("E051", state.tokens.current);
+				}
+			}
+			if (state.tokens.next.id === "=") {
+				if (!state.option.inESNext()) {
+					warning("W119", state.tokens.next, "default parameters");
+				}
+				advance("=");
+				pastDefault = true;
+				expression(10);
 			}
 			if (state.tokens.next.id === ",") {
 				comma();

--- a/tests/stable/unit/core.js
+++ b/tests/stable/unit/core.js
@@ -720,3 +720,22 @@ exports.testPotentialVariableLeak = function (test) {
 
 	test.done();
 };
+
+exports.testDefaultArguments = function (test) {
+	var src = fs.readFileSync(__dirname + "/fixtures/default-arguments.js", "utf8");
+	TestRun(test)
+		.addError(11, "Regular parameters cannot come after default parameters.")
+		.test(src, { esnext: true });
+
+	TestRun(test)
+		.addError(11, "Regular parameters cannot come after default parameters.")
+		.test(src, { moz: true });
+
+	TestRun(test)
+		.addError(7, "'default parameters' is only available in ES6 (use esnext option).")
+		.addError(11, "'default parameters' is only available in ES6 (use esnext option).")
+		.addError(11, "Regular parameters cannot come after default parameters.")
+		.test(src, {  });
+
+	test.done();
+};

--- a/tests/stable/unit/fixtures/default-arguments.js
+++ b/tests/stable/unit/fixtures/default-arguments.js
@@ -1,0 +1,18 @@
+function Doit() {
+}
+
+Doit.prototype = {
+  _someProperty: null,
+
+  test: function(num, num2=1, num3=2) {
+    return num === num2;
+  },
+
+	testBadDefault: function(num, num2=1, num3) {
+		return num === num2;
+	},
+
+  get someProperty() {
+    return this._someProperty;
+  },
+};


### PR DESCRIPTION
Closes #1195.

Very basic, but handles parsing parameter lists that contain default parameters, as well as checking for regular parameters coming after default parameters (which is a syntax error).
