### PR TITLE
Issue #1095: Support for array comprehensions using for-of

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2496,7 +2496,17 @@ var JSHINT = (function () {
 		res.exps = true;
 		funct["(comparray)"].stack();
 
-		res.right = expression(10);
+		// Handle reversed for expressions, used in spidermonkey
+		var reversed = false;
+		if (state.tokens.next.value !== "for") {
+			reversed = true;
+			if (!state.option.inMoz(true)) {
+				warning("W116", state.tokens.next, "for", state.tokens.next.value);
+			}
+			funct["(comparray)"].setState("use");
+			res.right = expression(10);
+		}
+
 		advance("for");
 		if (state.tokens.next.value === "each") {
 			advance("each");
@@ -2523,6 +2533,12 @@ var JSHINT = (function () {
 			res.filter = expression(10);
 			advance(")");
 		}
+
+		if (!reversed) {
+			funct["(comparray)"].setState("use");
+			res.right = expression(10);
+		}
+
 		advance("]");
 		funct["(comparray)"].unstack();
 		return res;
@@ -2531,8 +2547,8 @@ var JSHINT = (function () {
 	prefix("[", function () {
 		var blocktype = lookupBlockType(true);
 		if (blocktype.isCompArray) {
-			if (!state.option.inMoz(true)) {
-				warning("W118", state.tokens.curr, "array comprehension");
+			if (!state.option.inESNext()) {
+				warning("W119", state.tokens.curr, "array comprehension");
 			}
 			return comprehensiveArrayExpression();
 		} else if (blocktype.isDestAssign && !state.option.inESNext()) {
@@ -4060,17 +4076,13 @@ var JSHINT = (function () {
 
 	var lookupBlockType = function () {
 		var pn, pn1;
-		var i = 0;
+		var i = -1;
 		var bracketStack = 0;
 		var ret = {};
 		if (_.contains(["[", "{"], state.tokens.curr.value))
 			bracketStack += 1;
-		if (_.contains(["[", "{"], state.tokens.next.value))
-			bracketStack += 1;
-		if (_.contains(["]", "}"], state.tokens.next.value))
-			bracketStack -= 1;
 		do {
-			pn = peek(i);
+			pn = (i === -1) ? state.tokens.next : peek(i);
 			pn1 = peek(i + 1);
 			i = i + 1;
 			if (_.contains(["[", "{"], pn.value)) {
@@ -4165,7 +4177,7 @@ var JSHINT = (function () {
 						if (v.undef)
 							isundef(v.funct, "W117", v.token, v.value);
 					});
-					_carrays.splice(_carrays[_carrays.length - 1], 1);
+					_carrays.splice(-1, 1);
 					_current = _carrays[_carrays.length - 1];
 				},
 				setState: function (s) {
@@ -4173,13 +4185,18 @@ var JSHINT = (function () {
 						_current.mode = s;
 				},
 				check: function (v) {
+					if (!_current) {
+						return;
+					}
 					// When we are in "use" state of the list comp, we enqueue that var
 					if (_current && _current.mode === "use") {
-						_current.variables.push({funct: funct,
-													token: state.tokens.curr,
-													value: v,
-													undef: true,
-													unused: false});
+						if (use(v)) {
+							_current.variables.push({funct: funct,
+														token: state.tokens.curr,
+														value: v,
+														undef: true,
+														unused: false});
+						}
 						return true;
 					// When we are in "define" state of the list comp,
 					} else if (_current && _current.mode === "define") {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2365,6 +2365,25 @@ exports["test: mozilla generator as legacy JS"] = function (test) {
 exports["test: array comprehension"] = function (test) {
 	// example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
 	var code = [
+		"function *range(begin, end) {",
+		"	for (let i = begin; i < end; ++i) {",
+		"		yield i;",
+		"	}",
+		"}",
+		"var ten_squares = [for (i of range(0, 10)) i * i];",
+		"var evens = [for (i of range(0, 21)) if (i % 2 === 0) i];",
+		"print('squares:', ten_squares);",
+		"print('evens:', evens);"
+	];
+	TestRun(test)
+		.test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+
+	test.done();
+};
+
+exports["test: moz-style array comprehension"] = function (test) {
+	// example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
+	var code = [
 		"function range(begin, end) {",
 		"	for (let i = begin; i < end; ++i) {",
 		"		yield i;",
@@ -2382,6 +2401,25 @@ exports["test: array comprehension"] = function (test) {
 };
 
 exports["test: array comprehension with for..of"] = function (test) {
+	// example adapted from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
+	var code = [
+		"function *range(begin, end) {",
+		"	for (let i = begin; i < end; ++i) {",
+		"		yield i;",
+		"	}",
+		"}",
+		"var ten_squares = [for (i of range(0, 10)) i * i];",
+		"var evens = [for (i of range(0, 21)) if (i % 2 === 0) i];",
+		"print('squares:', ten_squares);",
+		"print('evens:', evens);"
+	];
+	TestRun(test)
+		.test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+
+	test.done();
+};
+
+exports["test: moz-style array comprehension with for..of"] = function (test) {
 	// example adapted from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
 	var code = [
 		"function range(begin, end) {",
@@ -2402,6 +2440,18 @@ exports["test: array comprehension with for..of"] = function (test) {
 
 exports["test: array comprehension with unused variables"] = function (test) {
 	var code = [
+		"var ret = [for (i of unknown) i];",
+		"print('ret:', ret);",
+	];
+	TestRun(test)
+		.addError(1, "'unknown' is not defined.")
+		.test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+
+	test.done();
+};
+
+exports["test: moz-style array comprehension with unused variables"] = function (test) {
+	var code = [
 		"var ret = [i for (i of unknown)];",
 		"print('ret:', ret);",
 	];
@@ -2412,7 +2462,7 @@ exports["test: array comprehension with unused variables"] = function (test) {
 	test.done();
 };
 
-exports["test: array comprehension as esnext"] = function (test) {
+exports["test: moz-style array comprehension as esnext"] = function (test) {
 	// example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
 	var code = [
 		"function range(begin, end) {",
@@ -2428,30 +2478,41 @@ exports["test: array comprehension as esnext"] = function (test) {
 	TestRun(test)
 		.addError(3, "A yield statement shall be within a generator function (with syntax: " +
 			"`function*`)")
-		.addError(6, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(6, "Expected 'for' and instead saw 'i'.")
 		.addError(6, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(7, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(7, "Expected 'for' and instead saw 'i'.")
 		.addError(7, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
 		.test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
 
 	test.done();
 };
 
-exports["test: reversed array comprehension as esnext"] = function (test) {
+exports["test: array comprehension as es5"] = function (test) {
+	// example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
 	var code = [
-		"var numbers = [i for (i of [1, 2, 3])];",
-		"print('numbers:', numbers);"
+		"function *range(begin, end) {",
+		"	for (let i = begin; i < end; ++i) {",
+		"		yield i;",
+		"	}",
+		"}",
+		"var ten_squares = [for (i of range(0, 10)) i * i];",
+		"var evens = [for (i of range(0, 21)) if (i % 2 === 0) i];",
+		"print('squares:', ten_squares);",
+		"print('evens:', evens);"
 	];
 	TestRun(test)
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions (use moz option).")
-		.test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+		.addError(1, "'function*' is only available in ES6 (use esnext option).")
+		.addError(2, "'let' is only available in JavaScript 1.7.")
+		.addError(3, "'yield' is only available in JavaScript 1.7.")
+		.addError(6, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(7, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.test(code, {unused: true, undef: true, predef: ["print"]}); // es5
 
 	test.done();
 };
-
-exports["test: array comprehension as es5"] = function (test) {
+exports["test: moz-style array comprehension as es5"] = function (test) {
 	// example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
 	var code = [
 		"function range(begin, end) {",
@@ -2467,11 +2528,13 @@ exports["test: array comprehension as es5"] = function (test) {
 	TestRun(test)
 		.addError(2, "'let' is only available in JavaScript 1.7.")
 		.addError(3, "'yield' is only available in JavaScript 1.7.")
-		.addError(6, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(6, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(6, "Expected 'for' and instead saw 'i'.")
 		.addError(6, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(7, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(7, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(7, "Expected 'for' and instead saw 'i'.")
 		.addError(7, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
 		.test(code, {unused: true, undef: true, predef: ["print"]}); // es5
 
@@ -2485,6 +2548,30 @@ exports["test: array comprehension as legacy JS"] = function (test) {
 		"		yield i;",
 		"	}",
 		"}",
+		"var ten_squares = [for (i of range(0, 10)) i * i];",
+		"var evens = [for (i of range(0, 21)) if (i % 2 === 0) i];",
+		"print('squares:', ten_squares);",
+		"print('evens:', evens);"
+	];
+	TestRun(test)
+		.addError(2, "'let' is only available in JavaScript 1.7.")
+		.addError(3, "'yield' is only available in JavaScript 1.7.")
+		.addError(6, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(7, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+
+	test.done();
+};
+exports["test: moz-style array comprehension as legacy JS"] = function (test) {
+	// example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
+	var code = [
+		"function range(begin, end) {",
+		"	for (let i = begin; i < end; ++i) {",
+		"		yield i;",
+		"	}",
+		"}",
 		"var ten_squares = [i * i for each (i in range(0, 10))];",
 		"var evens = [i for each (i in range(0, 21)) if (i % 2 === 0)];",
 		"print('squares:', ten_squares);",
@@ -2493,18 +2580,30 @@ exports["test: array comprehension as legacy JS"] = function (test) {
 	TestRun(test)
 		.addError(2, "'let' is only available in JavaScript 1.7.")
 		.addError(3, "'yield' is only available in JavaScript 1.7.")
-		.addError(6, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(6, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(6, "Expected 'for' and instead saw 'i'.")
 		.addError(6, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(7, "'array comprehension' is only available in Mozilla JavaScript extensions (use " +
-			"moz option).")
+		.addError(7, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(7, "Expected 'for' and instead saw 'i'.")
 		.addError(7, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
 		.test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
 
 	test.done();
 };
+exports['test: array comprehension with dest array at global scope'] = function (test) {
+	var code = [
+		"[for ([i, j] of [[0,0], [1,1], [2,2]]) [i, j] ];",
+		"var destarray_comparray_1 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, [j, j] ]];",
+		"var destarray_comparray_2 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, {i: [i, j]} ]];",
+	];
+	TestRun(test)
+		.test(code, {esnext: true, undef: true, predef: ["print"]});
 
-exports['test array comprehension with dest array at global scope'] = function (test) {
+	test.done();
+};
+exports['test: moz-style array comprehension with dest array at global scope'] = function (test) {
 	var code = [
 		"[ [i, j] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 		"var destarray_comparray_1 = [ [i, [j, j] ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
@@ -2515,61 +2614,98 @@ exports['test array comprehension with dest array at global scope'] = function (
 
 	test.done();
 };
-exports['test array comprehension with dest array at global scope as esnext'] = function (test) {
+exports['test: moz-style array comprehension with dest array at global scope as esnext'] = function (test) {
 	var code = [
 		"[ [i, j] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 		"var destarray_comparray_1 = [ [i, [j, j] ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 		"var destarray_comparray_2 = [ [i, {i: [i, j]} ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 	];
 	TestRun(test)
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(1, "Expected 'for' and instead saw '['.")
 		.addError(1, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(2, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(2, "Expected 'for' and instead saw '['.")
 		.addError(2, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(3, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(3, "Expected 'for' and instead saw '['.")
 		.addError(3, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
 		.test(code, {esnext: true, undef: true, predef: ["print"]});
 
 	test.done();
 };
-exports['test array comprehension with dest array at global scope as es5'] = function (test) {
+exports['test: array comprehension with dest array at global scope as es5'] = function (test) {
+	var code = [
+		"[for ([i, j] of [[0,0], [1,1], [2,2]]) [i, j] ];",
+		"var destarray_comparray_1 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, [j, j] ] ];",
+		"var destarray_comparray_2 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, {i: [i, j]} ] ];",
+	];
+	TestRun(test)
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(2, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(3, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.test(code, {undef: true, predef: ["print"]}); // es5
+
+	test.done();
+};
+exports['test: moz-style array comprehension with dest array at global scope as es5'] = function (test) {
 	var code = [
 		"[ [i, j] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 		"var destarray_comparray_1 = [ [i, [j, j] ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 		"var destarray_comparray_2 = [ [i, {i: [i, j]} ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 	];
 	TestRun(test)
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(1, "Expected 'for' and instead saw '['.")
 		.addError(1, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(2, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(2, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(2, "Expected 'for' and instead saw '['.")
 		.addError(2, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(3, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(3, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(3, "Expected 'for' and instead saw '['.")
 		.addError(3, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
 		.test(code, {undef: true, predef: ["print"]}); // es5
 
 	test.done();
 };
-exports['test array comprehension with dest array at global scope as JS legacy'] = function (test) {
+exports['test: array comprehension with dest array at global scope as JS legacy'] = function (test) {
+	var code = [
+		"[for ([i, j] of [[0,0], [1,1], [2,2]]) [i, j] ];",
+		"var destarray_comparray_1 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, [j, j] ] ];",
+		"var destarray_comparray_2 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, {i: [i, j]} ] ];",
+	];
+	TestRun(test)
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(2, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(3, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.test(code, {es3: true, undef: true, predef: ["print"]});
+
+	test.done();
+};
+exports['test: moz-style array comprehension with dest array at global scope as JS legacy'] = function (test) {
 	var code = [
 		"[ [i, j] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 		"var destarray_comparray_1 = [ [i, [j, j] ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 		"var destarray_comparray_2 = [ [i, {i: [i, j]} ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
 	];
 	TestRun(test)
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(1, "Expected 'for' and instead saw '['.")
 		.addError(1, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(2, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(2, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(2, "Expected 'for' and instead saw '['.")
 		.addError(2, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-		.addError(3, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(3, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(3, "Expected 'for' and instead saw '['.")
 		.addError(3, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
 		.test(code, {es3: true, undef: true, predef: ["print"]});
 
@@ -2577,6 +2713,17 @@ exports['test array comprehension with dest array at global scope as JS legacy']
 };
 
 exports["test: array comprehension imbrication with dest array"] = function (test) {
+	var code = [
+		"[for ([i, j] of [for ([a, b] of [[2,2], [3,4]]) [a, b] ]) [i, j] ];"
+	];
+
+	TestRun(test)
+		.test(code, {esnext: true, undef: true, predef: ["print"]});
+
+	test.done();
+};
+
+exports["test: moz-style array comprehension imbrication with dest array"] = function (test) {
 	var code = [
 		"[ [i, j] for ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
 	];
@@ -2587,7 +2734,7 @@ exports["test: array comprehension imbrication with dest array"] = function (tes
 	test.done();
 };
 
-exports["test: array comprehension imbrication with dest array using for..of"] = function (test) {
+exports["test: moz-style array comprehension imbrication with dest array using for..of"] = function (test) {
 	var code = [
 		"[ [i, j] for ([i, j] of [[a, b] for ([a, b] of [[2,2], [3,4]])]) ];"
 	];
@@ -2597,45 +2744,76 @@ exports["test: array comprehension imbrication with dest array using for..of"] =
 
 	test.done();
 };
-exports["test: array comprehension imbrication with dest array as esnext"] = function (test) {
+
+exports["test: moz-style array comprehension imbrication with dest array as esnext"] = function (test) {
 	var code = [
 		"[ [i, j] for each ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
 	];
 	TestRun(test)
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(1, "Expected 'for' and instead saw '['.")
 		.addError(1, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
 		.test(code, {esnext: true, undef: true, predef: ["print"]});
 
 	test.done();
 };
+
 exports["test: array comprehension imbrication with dest array as es5"] = function (test) {
 	var code = [
-		"[ [i, j] for each ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
-
+		"[for ([i, j] of [for ([a, b] of [[2,2], [3,4]]) [a, b] ]) [i, j] ];"
 	];
 	TestRun(test)
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
-		.addError(1, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
 		.test(code, {undef: true, predef: ["print"]}); // es5
 
 	test.done();
 };
+
+exports["test: moz-style array comprehension imbrication with dest array as es5"] = function (test) {
+	var code = [
+		"[for ([i, j] of [for ([a, b] of [[2,2], [3,4]]) [a, b] ]) [i, j] ];"
+	];
+	TestRun(test)
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.test(code, {undef: true, predef: ["print"]}); // es5
+
+	test.done();
+};
+
 exports["test: array comprehension imbrication with dest array as legacy JS"] = function (test) {
 	var code = [
 		"[ [i, j] for each ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
 
 	];
 	TestRun(test)
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
-		.addError(1, "'array comprehension' is only available in Mozilla JavaScript extensions " +
-			"(use moz option).")
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(1, "Expected 'for' and instead saw '['.")
+		.addError(1, "Expected 'for' and instead saw '['.")
+		.addError(1, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
+		.test(code, {es3: true, undef: true, predef: ["print"]});
+
+	test.done();
+};
+exports["test: moz-style array comprehension imbrication with dest array as legacy JS"] = function (test) {
+	var code = [
+		"[ [i, j] for each ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
+
+	];
+	TestRun(test)
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(1, "'array comprehension' is only available in ES6 " +
+			"(use esnext option).")
+		.addError(1, "Expected 'for' and instead saw '['.")
+		.addError(1, "Expected 'for' and instead saw '['.")
 		.addError(1, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
 		.test(code, {es3: true, undef: true, predef: ["print"]});
 


### PR DESCRIPTION
This adds support for for .. of comprehensions.

for .. in comprehensions already kinda sorta worked - [i for (i in foo)] read 'i in foo' as a single expression, but 'of' isn't a valid infix like 'in' is.

This patch handles the two sides of the in/of separately.  It adds a new state to the CompArray, "generate", which is used while parsing the generator side of the in/of separator.

Standard first patch disclaimers apply.
