### PR TITLE
Add typed array option, implied by "node" option

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -128,6 +128,7 @@ var JSHINT = (function () {
 			                    // predefined
 			rhino       : true, // if the Rhino environment globals should be predefined
 			shelljs     : true, // if ShellJS globals should be predefined
+			typed       : true, // if typed array globals should be predefined
 			undef       : true, // if variables should be declared before used
 			scripturl   : true, // if script-targeted URLs should be tolerated
 			shadow      : true, // if variable shadowing should be tolerated
@@ -333,6 +334,9 @@ var JSHINT = (function () {
 			combine(predefined, vars.shelljs);
 			combine(predefined, vars.node);
 		}
+		if (state.option.typed) {
+			combine(predefined, vars.typed);
+		}
 
 		if (state.option.phantom) {
 			combine(predefined, vars.phantom);
@@ -344,6 +348,7 @@ var JSHINT = (function () {
 
 		if (state.option.node) {
 			combine(predefined, vars.node);
+			combine(predefined, vars.typed);
 		}
 
 		if (state.option.devel) {
@@ -356,6 +361,7 @@ var JSHINT = (function () {
 
 		if (state.option.browser) {
 			combine(predefined, vars.browser);
+			combine(predefined, vars.typed);
 		}
 
 		if (state.option.nonstandard) {

--- a/src/vars.js
+++ b/src/vars.js
@@ -45,8 +45,6 @@ exports.ecmaIdentifiers = {
 // Global variables commonly provided by a web browser environment.
 
 exports.browser = {
-	ArrayBuffer          : false,
-	ArrayBufferView      : false,
 	Audio                : false,
 	Blob                 : false,
 	addEventListener     : false,
@@ -59,7 +57,6 @@ exports.browser = {
 	close                : false,
 	closed               : false,
 	CustomEvent          : false,
-	DataView             : false,
 	DOMParser            : false,
 	defaultStatus        : false,
 	document             : false,
@@ -67,8 +64,6 @@ exports.browser = {
 	ElementTimeControl   : false,
 	event                : false,
 	FileReader           : false,
-	Float32Array         : false,
-	Float64Array         : false,
 	FormData             : false,
 	focus                : false,
 	frames               : false,
@@ -128,9 +123,6 @@ exports.browser = {
 	HTMLUListElement     : false,
 	HTMLVideoElement     : false,
 	history              : false,
-	Int16Array           : false,
-	Int32Array           : false,
-	Int8Array            : false,
 	Image                : false,
 	length               : false,
 	localStorage         : false,
@@ -328,10 +320,6 @@ exports.browser = {
 	SVGZoomAndPan        : false,
 	TimeEvent            : false,
 	top                  : false,
-	Uint16Array          : false,
-	Uint32Array          : false,
-	Uint8Array           : false,
-	Uint8ClampedArray    : false,
 	WebSocket            : false,
 	window               : false,
 	Worker               : false,
@@ -386,7 +374,6 @@ exports.node = {
 	__filename    : false,
 	__dirname     : false,
 	Buffer        : false,
-	DataView      : false,
 	console       : false,
 	exports       : true,  // In Node it is ok to exports = module.exports = foo();
 	GLOBAL        : false,
@@ -458,6 +445,21 @@ exports.shelljs = {
 	tempdir      : false
 };
 
+exports.typed = {
+	ArrayBuffer         : false,
+	ArrayBufferView     : false,
+	DataView            : false,
+	Float32Array        : false,
+	Float64Array        : false,
+	Int16Array          : false,
+	Int32Array          : false,
+	Int8Array           : false,
+	Uint16Array         : false,
+	Uint32Array         : false,
+	Uint8Array          : false,
+	Uint8ClampedArray   : false
+};
+
 exports.wsh = {
 	ActiveXObject            : true,
 	Enumerator               : true,
@@ -478,7 +480,7 @@ exports.dojo = {
 	dojo     : false,
 	dijit    : false,
 	dojox    : false,
-	define	 : false,
+	define   : false,
 	"require": false
 };
 

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -442,6 +442,29 @@ exports.shelljs = function (test) {
 	test.done();
 };
 
+exports.typed = function (test) {
+	var globals = [
+		"ArrayBuffer",
+		"ArrayBufferView",
+		"DataView",
+		"Float32Array",
+		"Float64Array",
+		"Int16Array",
+		"Int32Array",
+		"Int8Array",
+		"Uint16Array",
+		"Uint32Array",
+		"Uint8Array",
+		"Uint8ClampedArray"
+	];
+
+	globalsImplied(test, globals);
+	globalsKnown(test, globals, { browser: true });
+	globalsKnown(test, globals, { node: true });
+	globalsKnown(test, globals, { typed: true });
+
+	test.done();
+};
 
 
 exports.wsh = function (test) {


### PR DESCRIPTION
Added new env option "typed", that defines the variables for typed
arrays. This option is implied when the "browser" or "node" options
is set, so the obsolete mentions of "DataView", "Uint8Array", etc.
have been removed from the "node" and "browser" envs.

Added unit test to prevent regressions.

(unrelated style fix: "`define:<TAB>`" -> "`define:<SPACES>`" at exports.dojo)
