### PR TITLE
Adding the new option, globals, to the valOptions array so that error me...

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -160,7 +160,8 @@ var JSHINT = (function () {
 			maxlen       : false,
 			indent       : false,
 			maxerr       : false,
-			predef       : false,
+			predef       : false, //predef is deprecated and being replaced by globals
+			globals      : false, 
 			quotmark     : false, //'single'|'double'|true
 			scope        : false,
 			maxstatements: false, // {int} max statements per function


### PR DESCRIPTION
...ssage E001, "Bad option: 'globals'", does not get created.

This relates to [Issue #1178](https://github.com/jshint/jshint/pull/1178).

I am not quite sure how to add a test case for this, but _npm test_ still runs successfully with 814 assertions after this minor change. 
