### PR TITLE
Let shebang (#!) with "node" imply "node:true"

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -214,6 +214,9 @@ function Lexer(source) {
 	// Shebangs are used by Node scripts.
 
 	if (lines[0] && lines[0].substr(0, 2) === "#!") {
+		if (lines[0].indexOf("node") !== -1) {
+			state.option.node = true;
+		}
 		lines[0] = "";
 	}
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -212,6 +212,16 @@ exports.shebang = function (test) {
 	test.done();
 };
 
+exports.shebangImpliesNode = function (test) {
+	var code = [
+		"#!usr/bin/env node",
+		"require('module');",
+	];
+
+	TestRun(test).test(code);
+	test.done();
+};
+
 exports.numbers = function (test) {
 	/*jshint maxlen: 300*/
 


### PR DESCRIPTION
It felt a bit redundant to have two lines of boilerplate for build scripts:

```
#!/usr/bin/env node
/* jshint node:true */
```

With this PR, "#! .... node ..." implies `jshint node:true`
