### PR TITLE
Fixed #1252: Warn assigning prototype of "native" object

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -108,6 +108,7 @@ var JSHINT = (function () {
 			                    // loops
 			mootools    : true, // if MooTools globals should be predefined
 			multistr    : true, // allow multiline strings
+      nativeobject: true, // if modifying native object prototypes should be allowed
 			newcap      : true, // if constructor names must be capitalized
 			noarg       : true, // if arguments.caller and arguments.callee should be
 			                    // disallowed
@@ -1326,11 +1327,50 @@ var JSHINT = (function () {
 				node.type === "undefined");
 	}
 
+  function findNativePrototype(left) {
+    var prototype = false;
+    var natives = ["Array", "ArrayBuffer", "Boolean", "Collator", "DataView", "Date",
+        "DateTimeFormat", "Error", "EvalError", "Float32Array", "Float64Array",
+        "Function", "Infinity", "Intl", "Int16Array", "Int32Array", "Int8Array",
+        "Iterator", "Number", "NumberFormat", "Object", "RangeError",
+        "ReferenceError", "RegExp", "StopIteration", "String", "SyntaxError",
+        "TypeError", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray",
+        "URIError"];
+    function walkPrototype(obj) {
+      if (typeof obj === "object") {
+        if (obj.right === "prototype") {
+          return obj;
+        } else if (typeof obj.left === "object") {
+          return walkPrototype(obj.left);
+        }
+      }
+    }
+    function walkNative(obj) {
+      while (!obj.identifier && typeof obj.left === "object") {
+        obj = obj.left;
+      }
+      if (obj.identifier && natives.indexOf(obj.value) >= 0) {
+        return obj.value;
+      }
+    }
+    prototype = walkPrototype(left);
+    if (prototype) {
+      return walkNative(prototype);
+    }
+  }
+
 	function assignop(s, f, p) {
 		var x = infix(s, typeof f === "function" ? f : function (left, that) {
 			that.left = left;
 
 			if (left) {
+        if (state.option.nativeobject) {
+          var nativeObject = findNativePrototype(left);
+          if (nativeObject) {
+            warning("W121", left, nativeObject);
+          }
+        }
+
 				if (predefined[left.value] === false &&
 						scope[left.value]["(global)"] === true) {
 					warning("W020", left);

--- a/src/messages.js
+++ b/src/messages.js
@@ -192,7 +192,8 @@ var warnings = {
 	W117: "'{a}' is not defined.",
 	W118: "'{a}' is only available in Mozilla JavaScript extensions (use moz option).",
 	W119: "'{a}' is only available in ES6 (use esnext option).",
-	W120: "You might be leaking a variable ({a}) here."
+	W120: "You might be leaking a variable ({a}) here.",
+  W121: "Extending prototype of native object: '{a}'."
 };
 
 var info = {

--- a/tests/unit/fixtures/nativeobject.js
+++ b/tests/unit/fixtures/nativeobject.js
@@ -1,0 +1,11 @@
+// Test that a warning will occur when modifying a native object's prototype.
+
+Array.prototype.count = function(value) {
+  var count = 0, i;
+  for (i=0; i<this.length; ++i) {
+    if (this[i] === value) {
+      ++count;
+    }
+  }
+  return count;
+};

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1626,3 +1626,16 @@ exports.unignored = function (test) {
 
 	test.done();
 };
+
+/*
+ * Tests the `nativeobject` option -- Warn if native object prototype is assigned to.
+ */
+exports.nativeobject = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/nativeobject.js", "utf-8");
+
+  TestRun(test)
+    .addError(3, "Extending prototype of native object: 'Array'.")
+    .test(src, { es3: true, nativeobject: true });
+
+  test.done();
+};


### PR DESCRIPTION
Wanting to warn on assignment to prototype of native objects.

There are limits to this implementation, it would be very easy to assign native prototypes without being warned. Further, the list of native objects is a static array, and there is no option as of yet to ignore or add additional objects to warn on. Finally, mechanisms like _.extend() are not handled. So, if anyone could suggest some better ways to do this, I'm happy to try and build a more robust version.

I'm also open to naming the option better, `nativeobject` might not be the best name, hmm?
