### PR TITLE
Count variable as unused if it is only assigned

### DIFF
--- a/tests/unit/fixtures/unused.js
+++ b/tests/unit/fixtures/unused.js
@@ -1,7 +1,7 @@
 var a = 1;
 var b = 2;
 
-b += 1;
+a = 2;
 
 function main(e, f) {
     var c = 3;


### PR DESCRIPTION
``` javascript
var foo = require('foo');
var bar;
bar = require('foo');
```

This will catch `foo`, but not `bar`.

```
test.js: line 1, col 8, 'foo' is defined but never used.

1 error
```

Seems like it should be possible to expand this check so that being assigned to never counts as a variable being "used". Is there any reason I'm not thinking of that this wouldn't work?
