### PR TITLE
Make 'camelcase' ignore trailing underscores.

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -71,7 +71,7 @@ exports.register = function (linter) {
 			return;
 		}
 
-		if (data.name.replace(/^_+/, "").indexOf("_") > -1 && !data.name.match(/^[A-Z0-9_]*$/)) {
+		if (data.name.replace(/^_+|_+$/g, "").indexOf("_") > -1 && !data.name.match(/^[A-Z0-9_]*$/)) {
 			linter.warn("W106", {
 				line: data.line,
 				char: data.from,

--- a/tests/unit/fixtures/camelcase.js
+++ b/tests/unit/fixtures/camelcase.js
@@ -15,3 +15,7 @@ var TEST_1, test1, test_1;
 function _FooBar(_testMe) {
     this.__testMe = _testMe;
 }
+
+function _FooBar_(testMe_) {
+	this.__testMe__ = testMe_;
+}


### PR DESCRIPTION
This patch modifies 'camelcase' checks so that they ignore both leading and trailing underscores. For example:

```
var _xxx = 5; // was ok
var _xxx_ = 5; // used to give a warning, now ok
var xxx_ = 5; // used to give a warning, now ok
```

The trailing underscores do not really break camelCase convention as they by definition will not be separating words.

In addition, this convention is used in AngularJS - see the documentation for dependency injection during tests at http://docs.angularjs.org/tutorial/step_05

References:
- Closes GH-1209
