### PR TITLE
Fix Issue #1194

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -379,7 +379,7 @@ var exports = {
 
 		if (opts.useStdin) {
 			cli.withStdin(function (code) {
-				lint(code, results, opts.config || {}, data);
+				lint(code, results, opts.config || exports.loadConfig(findConfig(".jshintrc")), data);
 				(opts.reporter || defReporter)(results, data, { verbose: opts.verbose });
 				cb(results.length === 0);
 			});


### PR DESCRIPTION
In Documentation/Configuration, first paragraph, is stated that:
"JSHint will look for this file in the current working directory and, if not
found, will move one level up the directory tree all the way up to the
filesystem root." (note: "this file" = ".jshintrc")
Ref: http://www.jshint.com/docs/config/

But this is not true if input is coming from stdin.
This patch address this unexpected behaviour by calling function findConfig
even when the input is coming from stdin.
