### PR TITLE
latedef check should ignore inner functions when set to "nofunc"

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1512,11 +1512,9 @@ var JSHINT = (function () {
 			}
 			if (t.id !== "(endline)") {
 				if (t.id === "function") {
-					if (!state.option.latedef) {
-						break;
+					if (state.option.latedef === true) {
+						warning("W026", t);
 					}
-
-					warning("W026", t);
 					break;
 				}
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -71,7 +71,6 @@ exports.latedef = function (test) {
 	// When latedef is true, JSHint must not tolerate the use before definition
 	TestRun(test)
 		.addError(10, "'vr' was used before it was defined.")
-		.addError(18, "Inner functions should be listed at the top of the outer function.")
 		.test(src, { es3: true, latedef: "nofunc" });
 
 	// When latedef_func is true, JSHint must not tolerate the use before definition for functions


### PR DESCRIPTION
This patch suppresses this warning when the `latedef` option is set to `"nofunc"`:

> Inner functions should be listed at the top of the outer function.

Here’s some sample code that currently triggers this warning when `latedef` is `"nofunc"` or `true`:

```
function foo() {
  bar();
  function bar() {
    console.log('bar');
  }
}
```
