### PR TITLE
Removed the specific globals and unused reporting from checkstyle report...

### DIFF
--- a/src/reporters/checkstyle.js
+++ b/src/reporters/checkstyle.js
@@ -51,40 +51,6 @@ module.exports =
 			});
 		});
 
-		data.forEach(function (result) {
-			file = data.file;
-			globals = result.implieds;
-			unuseds = result.unused;
-
-			// Register the file
-			result.file = result.file.replace(/^\.\//, '');
-			if (!files[result.file]) {
-				files[result.file] = [];
-			}
-
-			if (globals) {
-				globals.forEach(function (global) {
-					files[result.file].push({
-						severity: 'warning',
-						line: global.line,
-						column: 0,
-						message: "Implied global '" + global.name + "'",
-						source: 'jshint.implied-globals'
-					});
-				});
-			}
-			if (unuseds) {
-				unuseds.forEach(function (unused) {
-					files[result.file].push({
-						severity: 'warning',
-						line: unused.line,
-						column: 0,
-						message: "Unused variable: '" + unused.name + "'",
-						source: 'jshint.implied-unuseds'
-					});
-				});
-			}
-		});
 
 		out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
 		out.push("<checkstyle version=\"4.3\">");


### PR DESCRIPTION
...er.

Global and unused errors appear in the normal reporting and are reported twice. This also prohibits suppressing the error with a jshint comment such as 

// jshint unused: false

One error appears even if the above hint is added.
