### PR TITLE
Requiring js files from data dir fails if jshint is used as dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 
 	"files": [
 		"bin",
-		"src"
+		"src",
+    "data"
 	]
 }


### PR DESCRIPTION
Commit 7f694e45d makes use of js files inside the data dir.
However, if you npm install jshint as a dependency on one of
your projects, you will notice the data dir is not present.
This is because the data dir is deleted as part of the installation
procedure. I am not sure whether such files should be moved to the
src dir (which is kept) or if data should not be removed
in the first place. I have no opinion on that but I decided to
make a pull-request that fixes the latter.
