### PR TITLE
Limit parseInt radix check to ES3 only

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2366,7 +2366,7 @@ var JSHINT = (function () {
 		nospace(state.tokens.prev, state.tokens.curr);
 
 		if (typeof left === "object") {
-			if (left.value === "parseInt" && n === 1) {
+			if (state.option.inES3() && left.value === "parseInt" && n === 1) {
 				warning("W065", state.tokens.curr);
 			}
 			if (!state.option.evil) {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -505,6 +505,8 @@ exports.missingRadix = function (test) {
 		})
 		.test(code, {es3: true});
 
+	TestRun(test).test(code);
+
 	test.done();
 };
 


### PR DESCRIPTION
Fixes #1253
