### PR TITLE
Added an option to the .jshintrc files allowing them to extend others

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -4,6 +4,7 @@ var cli         = require("cli");
 var path        = require("path");
 var shjs        = require("shelljs");
 var minimatch   = require("minimatch");
+var _           = require("underscore");
 var JSHINT      = require("./jshint.js").JSHINT;
 var defReporter = require("./reporters/default").reporter;
 
@@ -323,6 +324,12 @@ var exports = {
 		try {
 			var config = JSON.parse(removeComments(shjs.cat(fp)));
 			config.dirname = path.dirname(fp);
+
+			if (config['extends']) {
+				_.extend(config, exports.loadConfig(path.resolve(config.dirname, config['extends'])));
+				delete config['extends'];
+			}
+
 			return config;
 		} catch (err) {
 			cli.error("Can't parse config file: " + fp);
@@ -405,7 +412,7 @@ var exports = {
 		return results.length === 0;
 	},
 
-	/** 
+	/**
 	 * Helper exposed for testing.
 	 * Used to determine is stdout has any buffered output before exiting the program
 	 */


### PR DESCRIPTION
Adds a simple option to the .jshintrc files, which allows them to extend another file. This can be done once per file, but the chain is followed recursively. Merging of the config files is "shallow", in the interest of simplicity.

This is useful for the same reason it is useful when writing classes: it really helps keep things DRY when you need an entire directory or subset of a project to follow only slightly different rules than the rest of the project.

The example I think most people would relate to, is the ability to define different globals in your test directory from the rest of your project. In my case, I have a directory where every file should follow the project's rules, except the limit on line length:

```
{
  "extends": "../.jshintrc",
  "maxlen": 0"
}
```
