### PR TITLE
Issue #1282: relax the "maxlen" option in some situations

### DIFF
--- a/src/reg.js
+++ b/src/reg.js
@@ -32,3 +32,7 @@ exports.javascriptURL = /^(?:javascript|jscript|ecmascript|vbscript|mocha|livesc
 
 // Catches /* falls through */ comments (ft)
 exports.fallsThrough = /^\s*\/\*\s*falls?\sthrough\s*\*\/\s*$/;
+
+// very conservative rule (eg: only one space between the start of the comment and the first character)
+// to relax the maxlen option
+exports.maxlenException = /^(?:(?:\/\/|\/\*|\*) ?)?[^ ]+$/;

--- a/tests/unit/fixtures/maxlen.js
+++ b/tests/unit/fixtures/maxlen.js
@@ -1,3 +1,12 @@
 var a = "test maxlen";
 var b = "test maxlen ";
 var c = "test maxlen  ";
+  //  http://jshint.com/docs/
+var someCode; // http://jshint.com/docs/
+  // http://jshint.com/docs/ is a good website
+  // http://jshint.com/docs/
+  /* http://jshint.com/docs/
+   */
+  /*
+   * http://jshint.com/docs/
+   */

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1382,6 +1382,10 @@ exports.maxlen = function (test) {
 
 	TestRun(test)
 		.addError(3, "Line is too long.")
+		.addError(4, "Line is too long.")
+		.addError(5, "Line is too long.")
+		.addError(6, "Line is too long.")
+		// line 7 and more are exceptions and won't trigger the error
 		.test(src, { es3: true, maxlen: 23 });
 
 	test.done();


### PR DESCRIPTION
This commit relax the "maxlen" option for the following situations:
- the line is a comment AND
- it contains no space except the leading spaces, and the one space between the
  comment opening or a litteral '*' and the text
