### PR TITLE
Prevent __proto__ var in linted script from causing an error.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1939,7 +1939,7 @@ var JSHINT = (function () {
 
 	function note_implied(tkn) {
 		var name = tkn.value, line = tkn.line, a = implied[name];
-		if (typeof a === "function") {
+		if (typeof a === "function" || typeof a === 'object') {
 			a = false;
 		}
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -749,3 +749,8 @@ exports.testClonePassedObjects = function (test) {
 	test.ok(options.predef.length == 1);
 	test.done();
 };
+
+exports.testMagicProtoVariable = function (test) {
+	JSHINT("__proto__ = 1;");
+	test.done();
+};


### PR DESCRIPTION
Saw this error when linting [getter-in-prototype.js](https://github.com/joyent/node/blob/master/deps/v8/test/mjsunit/getter-in-prototype.js):

```
TypeError: Object #<Object> has no method 'push'
    at note_implied (/home/andreas/.local/lib/node_modules/jshint/src/jshint.js:1960:6)
    at Object.state.syntax.(identifier).nud (/home/andreas/.local/lib/node_modules/jshint/src/jshint.js:2046:5)
    at expression (/home/andreas/.local/lib/node_modules/jshint/src/jshint.js:961:30)
    at statement (/home/andreas/.local/lib/node_modules/jshint/src/jshint.js:1684:7)
    at statements (/home/andreas/.local/lib/node_modules/jshint/src/jshint.js:1733:12)
    at itself (/home/andreas/.local/lib/node_modules/jshint/src/jshint.js:4717:5)
    at lint (/home/andreas/.local/lib/node_modules/jshint/src/cli.js:290:7)
    at exports.run.verbose (/home/andreas/.local/lib/node_modules/jshint/src/cli.js:401:4)
    at Array.forEach (native)
    at Object.exports.run (/home/andreas/.local/lib/node_modules/jshint/src/cli.js:390:9)
```

Added a quick fix that prevents it from erroring, but probably isn't the correct fix for actually making a `__proto__` var subject to linting.
