### PR TITLE
Export JSHINT if CommonJS modules are available

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -24,6 +24,7 @@ bundle.bundle({}, function (err, src) {
 		"var require;",
 		src,
 		"JSHINT = require('jshint').JSHINT;",
+		"if (typeof exports === 'object' && exports) exports.JSHINT = JSHINT;",
 		"}());"
 	].join("\n").to(web);
 


### PR DESCRIPTION
Export `JSHINT` if CommonJS modules are bringing in the distribution via `require` e.g.:

```
jshint = require("/path/to/jshint.js").JSHINT;
```

[We're](http://typesafe.com/) developing a series of JS [sbt plugins](http://www.scala-sbt.org/) that will be used from the [Play web development framework](http://www.playframework.com/). Our plugin for JSHint will download the artifact via Webjars and then require it from its own JS script.
