### PR TITLE
Wrong initialization of the script extraction algorithm

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -245,7 +245,7 @@ function extract(code, when) {
 	if (when !== "always" && (when !== "auto" || !/^\s*</.test(code)))
 		return code;
 
-	var inscript = true;
+	var inscript = false;
 	var index = 0;
 	var js = [];
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -225,7 +225,7 @@ exports.group = {
 	},
 
 	textExtract: function (test) {
-		var html = "<html><script>var a = 1;</script></html>";
+		var html = "<html>text<script>var a = 1;</script></html>";
 		var text = "hello world";
 		var js   = "var a = 1;";
 
@@ -235,11 +235,11 @@ exports.group = {
 
 		test.equal(cli.extract(js, "never"), js);
 		test.equal(cli.extract(js, "auto"), js);
-		test.equal(cli.extract(js, "always"), js);
+		test.equal(cli.extract(js, "always"), '');
 
 		test.equal(cli.extract(text, "never"), text);
 		test.equal(cli.extract(text, "auto"), text);
-		test.equal(cli.extract(text, "always"), text);
+		test.equal(cli.extract(text, "always"), '');
 
 		html = [
 			"<html>",
@@ -255,7 +255,7 @@ exports.group = {
 				"</script>",
 			"</html>" ].join("\n");
 
-		js = ["\n\n", "var a = 1;", "\n\n\n\n\n", "var b = 1;\n" ].join("\n");
+		js = ["\n", "var a = 1;", "\n\n\n\n\n", "var b = 1;\n" ].join("\n");
 
 		test.equal(cli.extract(html, "auto"), js);
 		test.done();


### PR DESCRIPTION
Right now, the script extraction fails if we have text before the first script tag (ex: `<html><title>foo</title><script>...`) because the algorithm thinks it is part of the script.

We should wait for the first script tag before extracting scripts. This changes some of the unit tests as well, but `--extract always` is basically the equivalent of saying that the input file is an html file (because it is treated like one).
