### PR TITLE
Added JSHint configuration to run JSHint standalone.

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -1,0 +1,20 @@
+/**
+ * JSHint configuration File
+ * See http://jshint.com/docs/ for more details 
+ * Examples at : https://github.com/jshint/jshint/blob/master/examples/.jshintrc
+ **/
+
+{
+	"boss": true,
+	"node": true,       // NodeJS JavaScript files
+	"strict": true,     // Require "use strict" statement
+	"white": false,     // Check whitespaces between operators
+	"smarttabs": true,
+	"maxlen":    100,
+	"newcap":    false,
+	"undef":     true,
+	"unused":    true,
+	"onecase":   true,
+	"indent":    2
+}
+


### PR DESCRIPTION
It is strange that running
    jshint src/jshint.js
yields a lot of errors, this patch fixes it adding JSHint configuration.
