### PR TITLE
Make checks for generator functions without yield optional

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -148,6 +148,7 @@ var JSHINT = (function () {
 			wsh         : true, // if the Windows Scripting Host environment globals
 			                    // should be predefined
 			yui         : true, // YUI variables should be predefined
+			noyield     : true, // allow generators without a yield
 
 			// Obsolete options
 			onecase     : true, // if one case switch statements should be allowed
@@ -2969,8 +2970,8 @@ var JSHINT = (function () {
 
 		block(false, true, true, fatarrowparams ? true : false);
 
-		if (generator && funct["(generator)"] !== "yielded") {
-			error("E047", state.tokens.curr);
+		if (!state.option.noyield && generator && funct["(generator)"] !== "yielded") {
+			warning("W124", state.tokens.curr);
 		}
 
 		funct["(metrics)"].verifyMaxStatementsPerFunction();

--- a/src/messages.js
+++ b/src/messages.js
@@ -62,7 +62,7 @@ var errors = {
 	E044: null,
 	E045: "Invalid for each loop.",
 	E046: "A yield statement shall be within a generator function (with syntax: `function*`)",
-	E047: "A generator function shall contain a yield statement.",
+	E047: null, // Vacant
 	E048: "Let declaration not directly within block.",
 	E049: "A {a} cannot be named '{b}'.",
 	E050: "Mozilla requires the yield expression to be parenthesized here.",
@@ -194,7 +194,8 @@ var warnings = {
 	W120: "You might be leaking a variable ({a}) here.",
 	W121: "Extending prototype of native object: '{a}'.",
 	W122: "Invalid typeof value '{a}'",
-	W123: "'{a}' is already defined in outer scope."
+	W123: "'{a}' is already defined in outer scope.",
+	W124: "A generator function shall contain a yield statement."
 };
 
 var info = {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2485,6 +2485,18 @@ exports["test: esnext generator without yield"] = function (test) {
 	test.done();
 };
 
+exports["test: esnext generator without yield and check turned off"] = function (test) {
+	var code = [
+		"function* emptyGenerator() {}",
+
+		"emptyGenerator();"
+	];
+	TestRun(test)
+		.test(code, {esnext: true, noyield: true, unused: true, undef: true, predef: ["print"]});
+
+	test.done();
+};
+
 exports["test: mozilla generator"] = function (test) {
 	// example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
 	var code = [


### PR DESCRIPTION
Generators without a yield are valid, making this check too strict.

For example:

```
function *() {} // This is useless but valid.
```

This commit makes the check optional (`noyield` switches the check off), adds a unit test for the new switch, and makes the error for unyielding generators a warning.

References:

Closes #1123 
