### PR TITLE
FIX: TypeError when Array has prototype extensions

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3364,16 +3364,18 @@ var JSHINT = (function () {
 				lone = true;
 			}
 			for (var t in tokens) {
-				t = tokens[t];
-				if (funct[t.id] === "const") {
-					warning("E011", null, t.id);
-				}
-				if (funct["(global)"] && predefined[t.id] === false) {
-					warning("W079", t.token, t.id);
-				}
-				if (t.id) {
-					addlabel(t.id, { token: t.token, type: "const", unused: true });
-					names.push(t.token);
+				if (tokens.hasOwnProperty(t)) {
+					t = tokens[t];
+					if (funct[t.id] === "const") {
+						warning("E011", null, t.id);
+					}
+					if (funct["(global)"] && predefined[t.id] === false) {
+						warning("W079", t.token, t.id);
+					}
+					if (t.id) {
+						addlabel(t.id, { token: t.token, type: "const", unused: true });
+						names.push(t.token);
+					}
 				}
 			}
 			if (prefix) {
@@ -3436,16 +3438,18 @@ var JSHINT = (function () {
 				lone = true;
 			}
 			for (var t in tokens) {
-				t = tokens[t];
-				if (state.option.inESNext() && funct[t.id] === "const") {
-					warning("E011", null, t.id);
-				}
-				if (funct["(global)"] && predefined[t.id] === false) {
-					warning("W079", t.token, t.id);
-				}
-				if (t.id) {
-					addlabel(t.id, { type: "unused", token: t.token });
-					names.push(t.token);
+				if (tokens.hasOwnProperty(t)) {
+					t = tokens[t];
+					if (state.option.inESNext() && funct[t.id] === "const") {
+						warning("E011", null, t.id);
+					}
+					if (funct["(global)"] && predefined[t.id] === false) {
+						warning("W079", t.token, t.id);
+					}
+					if (t.id) {
+						addlabel(t.id, { type: "unused", token: t.token });
+						names.push(t.token);
+					}
 				}
 			}
 			if (prefix) {
@@ -3517,16 +3521,18 @@ var JSHINT = (function () {
 				lone = true;
 			}
 			for (var t in tokens) {
-				t = tokens[t];
-				if (state.option.inESNext() && funct[t.id] === "const") {
-					warning("E011", null, t.id);
-				}
-				if (funct["(global)"] && predefined[t.id] === false) {
-					warning("W079", t.token, t.id);
-				}
-				if (t.id && !funct["(nolet)"]) {
-					addlabel(t.id, { type: "unused", token: t.token, islet: true });
-					names.push(t.token);
+				if (tokens.hasOwnProperty(t)) {
+					t = tokens[t];
+					if (state.option.inESNext() && funct[t.id] === "const") {
+						warning("E011", null, t.id);
+					}
+					if (funct["(global)"] && predefined[t.id] === false) {
+						warning("W079", t.token, t.id);
+					}
+					if (t.id && !funct["(nolet)"]) {
+						addlabel(t.id, { type: "unused", token: t.token, islet: true });
+						names.push(t.token);
+					}
 				}
 			}
 			if (prefix) {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -769,3 +769,12 @@ exports.testColumnNumAfterNonStrictComparison = function (test) {
 		.test(src, {eqeqeq: true});
 	test.done();
 };
+
+
+exports.testArrayPrototypeExtensions = function (test) {
+	Array.prototype.undefinedPrototypeProperty = undefined;
+
+	JSHINT("var x = 123;\nlet y = 456;\nconst z = 123;");
+	delete Array.prototype.undefinedPrototypeProperty;
+	test.done();
+};


### PR DESCRIPTION
I encountered this problem while trying to run JSHint in a browser when
Ember.js had already been loaded for integration tests.

If `Array.prototype` contains keys, JSHint will raise an error:

```
TypeError: Cannot read property 'id' of undefined
```

This is happening when iterating through keys of a `tokens` object
without checking `hasOwnProperty`.

This fix adds the check for `hasOwnProperty` to the three places where
I discovered the bug occurred. It has tests to confirm the new behavior
works.
