### PR TITLE
Handle single-line comments for block ignore

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -1329,7 +1329,9 @@ Lexer.prototype = {
 		// If we are ignoring linter errors, replace the input with empty string
 		// if it doesn't already at least start or end a multi-line comment
 		if (state.ignoreLinterErrors === true) {
-			if (! (startsWith.call(inputTrimmed, "/*") || endsWith.call(inputTrimmed, "*/"))) {
+			if (! (startsWith.call(inputTrimmed, "/*") ||
+							startsWith.call(inputTrimmed, "//") ||
+							endsWith.call(inputTrimmed, "*/"))) {
 				this.input = "";
 			}
 		}

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4087,6 +4087,21 @@ exports["should be able to ignore a single line with a trailing comment: // jshi
 	test.done();
 };
 
+exports["jshint ignore:start/end should be detected using single line comments"] = function (test) {
+	var code = [
+		"// jshint ignore:start",
+		"var a;",
+		"// jshint ignore:end",
+		"var b;",
+	];
+
+	var run = TestRun(test).addError(4, "'b' is defined but never used.");
+
+	run.test(code, {unused: true});
+
+	test.done();
+};
+
 exports["regression test for GH-1431"] = function (test) {
 	// The code is invalid but it should not crash JSHint.
 	TestRun(test)


### PR DESCRIPTION
When the block ignore directive is active, it is possible that the
corresponding end ignore directive is written using a single-line
comment.

This means that lines beginning with a single line comment cannot be set
to the empty string value during the ignore directive processing.

References:

  Closes issue #1453
