### PR TITLE
const erroneously reported as unused

### DIFF
--- a/tests/unit/fixtures/unused.js
+++ b/tests/unit/fixtures/unused.js
@@ -41,3 +41,12 @@ function bazbaz() {
 }
 
 bazbaz();
+
+function useSomeConstDefinedLater() {
+	return A_CONST + " à vous";
+}
+
+useSomeConstDefinedLater();
+
+const A_CONST = "Bonjour";
+


### PR DESCRIPTION
Added a case in unit tests when a const is erroneously reported as
unused while it is:

```
{Line 51, Char 14} 'A_CONST' is defined but never used.
```

As you can see I only contribute a new test case, not the fix for it. Even if the JSHint code and project structure is very clean and normalized, entering in the parsing code is not immediate. And let me take the chance to thank you warmly for JSHint :-)
