### PR TITLE
issue #1282: consider relaxing the "maxlen" option in comments for some cases

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -107,6 +107,7 @@ function Lexer(source) {
 	this.char = 1;
 	this.from = 1;
 	this.input = "";
+	this.inComment = false;
 
 	for (var i = 0; i < state.option.indent; i += 1) {
 		state.tab += " ";
@@ -447,6 +448,7 @@ Lexer.prototype = {
 
 		/* Multi-line comment */
 		if (ch2 === "*") {
+			this.inComment = true;
 			this.skip(2);
 
 			while (this.peek() !== "*" || this.peek(1) !== "/") {
@@ -462,6 +464,7 @@ Lexer.prototype = {
 							character: startChar
 						});
 
+						this.inComment = false;
 						return commentToken("/*", body, {
 							isMultiline: true,
 							isMalformed: true
@@ -474,6 +477,7 @@ Lexer.prototype = {
 			}
 
 			this.skip(2);
+			this.inComment = false;
 			return commentToken("/*", body, { isMultiline: true });
 		}
 	},
@@ -1350,7 +1354,7 @@ Lexer.prototype = {
 		// long.
 
 		if (state.option.maxlen && state.option.maxlen < this.input.length) {
-			var inComment = state.tokens.curr.comment ||
+			var inComment = this.inComment ||
 				startsWith.call(inputTrimmed, "//") ||
 				startsWith.call(inputTrimmed, "/*");
 

--- a/tests/unit/fixtures/maxlen.js
+++ b/tests/unit/fixtures/maxlen.js
@@ -7,6 +7,11 @@ var someCode; // http://jshint.com/docs/
   // http://jshint.com/docs/
   /* http://jshint.com/docs/
    */
+a = 23;
   /*
    * http://jshint.com/docs/
    */
+a = 23;
+/*
+   http://jshint.com/docs/
+ */


### PR DESCRIPTION
Correctly fix the issue #1282 for multiline comments.

The added test was working because `state.tokens.curr.comment` was hitting the _previous_ comment, that's why I added a code line between comments in the test, and this showed the issue.
