### PR TITLE
Make jshintignore treat leading slashes as relative to the current directory

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -203,7 +203,7 @@ function loadIgnores(exclude, excludePath) {
 			if (line[0] === "!")
 				return "!" + path.resolve(path.dirname(file), line.substr(1).trim());
 
-			return path.resolve(path.dirname(file), line.trim());
+			return path.join(path.dirname(file), line.trim());
 		});
 }
 


### PR DESCRIPTION
Currently, a leading slash in a `.jshintignore` file means that the specific file is an absolute path. This is inconsistent with the behaviour of `.gitignore` files, which treat paths with leading slashes as being relative to the current directory.
