### PR TITLE
 Issue #1491: Parenthesis in odd-numbered token is ignored before arrow function

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2585,7 +2585,6 @@ var JSHINT = (function () {
 
       i += 1;
       pn1 = peek(i);
-      i += 1;
     } while (!(parens === 0 && pn.value === ")") &&
              pn1.value !== "=>" && pn1.value !== ";" && pn1.type !== "(end)");
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4243,3 +4243,16 @@ exports["test destructuring function parameters as legacy JS"] = function (test)
 
   test.done();
 };
+
+exports["test for parentheses in odd-numbered token"] = function (test) {
+  var code = [
+    "let f, b;",
+    "let a = x => ({ f: f(x) });",
+    "b = x => x;"
+  ];
+
+  TestRun(test)
+    .test(code, {esnext: true});
+
+  test.done();
+};


### PR DESCRIPTION
Fix for Issue #1491.
