### PR TITLE
Support export default = { .. } in esnext

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4257,8 +4257,14 @@ var JSHINT = (function () {
       warning("W119", state.tokens.curr, "export");
     }
 
+    // Handle special default export situation
     if (state.tokens.next.type === "default") {
       advance("default");
+      // Allow alternate assignment expression syntax; export default = 42;
+      if (state.tokens.next.value === "=") {
+        advance("=");
+      }
+      // Allow export default function() { ... } and class
       if (state.tokens.next.id === "function" || state.tokens.next.id === "class") {
         this.block = true;
       }

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -674,6 +674,8 @@ exports.testUndefinedAssignment = function (test) {
 
 exports.testES6Modules = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-import-export.js", "utf8");
+  var classError = "'class' is available in ES6 (use esnext option) " +
+                   "or Mozilla JS extensions (use moz).";
 
   TestRun(test)
     .test(src, {esnext: true});
@@ -691,11 +693,17 @@ exports.testES6Modules = function (test) {
     .addError(34, "'export' is only available in ES6 (use esnext option).")
     .addError(38, "'export' is only available in ES6 (use esnext option).")
     .addError(40, "'export' is only available in ES6 (use esnext option).")
-    .addError(40, "'class' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(40, classError)
     .addError(41, "'export' is only available in ES6 (use esnext option).")
-    .addError(41, "'class' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(41, classError)
     .addError(42, "'export' is only available in ES6 (use esnext option).")
-    .addError(42, "'class' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(42, classError)
+    .addError(46, "'export' is only available in ES6 (use esnext option).")
+    .addError(47, "'export' is only available in ES6 (use esnext option).")
+    .addError(50, "'export' is only available in ES6 (use esnext option).")
+    .addError(50, classError)
+    .addError(51, "'export' is only available in ES6 (use esnext option).")
+    .addError(51, classError)
     .test(src, {});
 
   var src2 = [

--- a/tests/unit/fixtures/es6-import-export.js
+++ b/tests/unit/fixtures/es6-import-export.js
@@ -40,3 +40,12 @@ export var c = "c";
 export class Foo {}
 export class List extends Array {}
 export default class Bar {}
+
+// Alternate default = syntax
+
+export default = { foo: 'foo', bar: 'bar' };
+export default = function() {
+	return "barbaz";
+}
+export default = class Bar {}
+export default = class Bar extends Array {}


### PR DESCRIPTION
- Add check for "=" token after default keyword and advance it.
- Add test cases to es6 test fixture and update unit test.

Based on discussions from es6-module-transpiler and esprima
(https://github.com/square/es6-module-transpiler/issues/63?,
 https://code.google.com/p/esprima/issues/detail?id=410) it seems like
both syntaxes should be supported.

/cc @thomasboyt
