### PR TITLE
Use `.gitignore` file if there is `.jshintignore` file

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -186,7 +186,7 @@ function findFile(name, dir) {
  * @return {array} a list of files to ignore.
  */
 function loadIgnores(exclude, excludePath) {
-  var file = findFile(excludePath || ".jshintignore");
+  var file = findFile(excludePath || ".jshintignore") || findFile(".gitignore");
 
   if (!file && !exclude) {
     return [];


### PR DESCRIPTION
I'm not sure if you will agree with this change but it makes sense to me...

Currently, `jshint` will read a gitignore file if explicitly specified (`jshint --exclude .gitignore`), but otherwise will not. I propose that, in the absence of a `.jshintignore` file, a `.gitignore` file should be used by default.
