### PR TITLE
support a --filename flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -462,7 +462,7 @@ var exports = {
       cli.withStdin(function (code) {
         var config = opts.config;
         if (opts.filename && !config) {
-          var filename = path.join(process.cwd(), opts.filename);
+          var filename = path.resolve(opts.filename);
           config = loadNpmConfig(filename) ||
             exports.loadConfig(findConfig(filename));
         }


### PR DESCRIPTION
This flags allows sending code to jshint over STDIN and pretending it is a certain file.

Then we can do the config lookup algorithm relative to the `dirname` of that file as we would do with `jshint somefile`

This makes text editor integration easier

See https://github.com/SublimeLinter/SublimeLinter-jshint/issues/22
