### PR TITLE
ES6 module exports should not count as unused

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4254,7 +4254,7 @@ var JSHINT = (function () {
     if (state.tokens.next.value === "{") {
       advance("{");
       for (;;) {
-        identifier();
+        exported[identifier()] = true;
 
         if (state.tokens.next.value === ",") {
           advance(",");
@@ -4271,20 +4271,25 @@ var JSHINT = (function () {
 
     if (state.tokens.next.id === "var") {
       advance("var");
+      exported[state.tokens.next.value] = true;
       state.syntax["var"].fud.call(state.syntax["var"].fud);
     } else if (state.tokens.next.id === "let") {
       advance("let");
+      exported[state.tokens.next.value] = true;
       state.syntax["let"].fud.call(state.syntax["let"].fud);
     } else if (state.tokens.next.id === "const") {
       advance("const");
+      exported[state.tokens.next.value] = true;
       state.syntax["const"].fud.call(state.syntax["const"].fud);
     } else if (state.tokens.next.id === "function") {
       this.block = true;
       advance("function");
+      exported[state.tokens.next.value] = true;
       state.syntax["function"].fud();
     } else if (state.tokens.next.id === "class") {
       this.block = true;
       advance("class");
+      exported[state.tokens.next.value] = true;
       state.syntax["class"].fud();
     } else {
       error("E024", state.tokens.next, state.tokens.next.value);

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -712,6 +712,53 @@ exports.testES6Modules = function (test) {
   test.done();
 };
 
+exports.testES6ModulesNamedExportsAffectUnused = function (test) {
+  // Named Exports should count as used
+  var src1 = [
+    "var a = {",
+    "  foo: 'foo',",
+    "  bar: 'bar'",
+    "};",
+    "var x = 23;",
+    "var z = 42;",
+    "export { a, x };",
+    "export var b = { baz: 'baz' };",
+    "export function boo() { return z; }",
+    "export class MyClass { }"
+  ];
+
+  TestRun(test)
+    .test(src1, {
+      esnext: true,
+      unused: true
+    });
+
+  test.done();
+};
+
+exports.testES6ModulesDefaultExportsAffectUnused = function (test) {
+  // Default Exports should count as used
+  var src1 = [
+    "var a = {",
+    "  foo: 'foo',",
+    "  bar: 'bar'",
+    "};",
+    "var x = 23;",
+    "var z = 42;",
+    "export default { a: a, x: x };",
+    "export default function boo() { return x + z; }",
+    "export default class MyClass { }"
+  ];
+
+  TestRun(test)
+    .test(src1, {
+      esnext: true,
+      unused: true
+    });
+
+  test.done();
+};
+
 exports.testPotentialVariableLeak = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/leak.js", "utf8");
 


### PR DESCRIPTION
Assign identifier to exported when exporting a named variable, func, let, const or class.

I messed around with this.exportee but couldn't figure out how that is used since I don't see any other references to it.
