### PR TITLE
Changed process.stdout.write to console.log

### DIFF
--- a/src/reporters/checkstyle.js
+++ b/src/reporters/checkstyle.js
@@ -76,6 +76,6 @@ module.exports =
 
     out.push("</checkstyle>");
 
-    process.stdout.write(out.join("\n") + "\n");
+    console.log(out.join("\n"));
   }
 };

--- a/src/reporters/default.js
+++ b/src/reporters/default.js
@@ -28,7 +28,7 @@ module.exports = {
     });
 
     if (str) {
-      process.stdout.write(str + "\n" + len + ' error' + ((len === 1) ? '' : 's') + "\n");
+      console.log(str + "\n" + len + ' error' + ((len === 1) ? '' : 's'));
     }
   }
 };

--- a/src/reporters/jslint_xml.js
+++ b/src/reporters/jslint_xml.js
@@ -52,6 +52,6 @@ module.exports =
 
     out.push("</jslint>");
 
-    process.stdout.write(out.join("\n") + "\n");
+    console.log(out.join("\n") + "\n");
   }
 };

--- a/src/reporters/non_error.js
+++ b/src/reporters/non_error.js
@@ -46,7 +46,7 @@ module.exports = {
     });
 
     if (str) {
-      process.stdout.write(str + "\n");
+      console.log(str + "\n");
     }
   }
 };


### PR DESCRIPTION
Unlike process.stdout.write console.log could be overwritten
by a surrounding process/caller/script to style the output.
For this it should not be neccessary to copy-and-patch all
reporters.
