### PR TITLE
Make `arguments` not a reserved keyword.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2159,16 +2159,17 @@ var JSHINT = (function () {
   delim(":").reach = true;
   delim("#");
 
+  type("arguments", function (x) {
+    if (state.directive["use strict"] && funct["(global)"]) {
+      warning("E008", x);
+    }
+  }).identifier = true;
+
   reserve("else");
   reserve("case").reach = true;
   reserve("catch");
   reserve("default").reach = true;
   reserve("finally");
-  reservevar("arguments", function (x) {
-    if (state.directive["use strict"] && funct["(global)"]) {
-      warning("E008", x);
-    }
-  });
   reservevar("eval");
   reservevar("false");
   reservevar("Infinity");

--- a/tests/unit/fixtures/reserved.js
+++ b/tests/unit/fixtures/reserved.js
@@ -14,3 +14,4 @@ var obj = { class: 'foo' };
 obj.else = 1;
 obj.throws = 2;
 obj.protected = 4;
+obj.arguments = 8;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3746,7 +3746,6 @@ exports["class and method naming"] = function (test) {
   ];
   var run = TestRun(test)
     .addError(1, "Expected an identifier and instead saw 'eval' (a reserved word).")
-    .addError(2, "Expected an identifier and instead saw 'arguments' (a reserved word).")
     .addError(4, "A class getter method cannot be named 'constructor'.")
     .addError(5, "A class setter method cannot be named 'constructor'.")
     .addError(7, "A class method cannot be named 'prototype'.");


### PR DESCRIPTION
This patch changes the handling of `arguments` so that it is not considered a
reserved keyword. It is not listed as a reserved keyword on either MDN or the
ES5.1 specification: http://www.ecma-international.org/ecma-262/5.1/#sec-7.6.1

I verified that the following code works in IE 8, Chrome 32, and Firefox 26.

``` javascript
function arguments() {
  return arguments[0] + arguments[1];
}
var object = {};
object.arguments = arguments(1, 2);
object.arguments === 3;
```
