### PR TITLE
Don't throw an error when yield statement used within a catch block inside a generator function

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4160,7 +4160,10 @@ var JSHINT = (function () {
   }(prefix("yield", function () {
     var prev = state.tokens.prev;
     if (state.option.inESNext(true) && !funct["(generator)"]) {
-      error("E046", state.tokens.curr, "yield");
+      // If it's a yield within a catch clause inside a generator then that's ok
+      if (!("(catch)" === funct["(name)"] && funct["(context)"]["(generator)"])) {
+        error("E046", state.tokens.curr, "yield");
+      }
     } else if (!state.option.inESNext()) {
       warning("W104", state.tokens.curr, "yield");
     }

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2544,6 +2544,26 @@ exports["test: mozilla generator as esnext"] = function (test) {
   test.done();
 };
 
+exports["test: yield statement within try-catch"] = function (test) {
+  // see issue: https://github.com/jshint/jshint/issues/1505
+  var code = [
+    "function* fib() {",
+    "  try {",
+    "    yield 1;",
+    "  } catch (err) {",
+    "    yield err;",
+    "  }",
+    "}",
+    "var g = fib();",
+    "for (let i = 0; i < 10; i++)",
+    "  print(g.next());"
+  ];
+  TestRun(test)
+    .test(code, {esnext: true, unused: true, undef: true, predef: ["print", "Iterator"]});
+
+  test.done();
+};
+
 exports["test: mozilla generator as es5"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [


### PR DESCRIPTION
This fixes this issue and adds a parser unit test to ensure it stays fixed.

See jshint/jshint#1505
