### PR TITLE
Glob documentation for example .jshintignore

### DIFF
--- a/examples/.jshintignore
+++ b/examples/.jshintignore
@@ -1,2 +1,4 @@
 ignored.js
 another.js
+ignoreimmediatechildren/*.js
+ignoreincludingsubdirectories/**


### PR DESCRIPTION
I had some difficulty figuring out the glob syntax for JSHint, since the original documentation referenced in https://groups.google.com/forum/#!topic/jshint/62N12QUhBCs no longer exists on the current JSHint. Adding it to this example in the hopes that it will be helpful.
