### PR TITLE
disallow trailing whitespace on empty lines

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -1279,10 +1279,8 @@ Lexer.prototype = {
         this.skip();
       }
 
-      if (this.peek() === "") { // EOL
-        if (!/^\s*$/.test(this.getLines()[this.line - 1]) && state.option.trailing) {
-          this.trigger("warning", { code: "W102", line: this.line, character: start });
-        }
+      if (state.option.trailing && this.peek() === "") { // EOL
+        this.trigger("warning", { code: "W102", line: this.line, character: start });
       }
     }
 

--- a/tests/unit/fixtures/white.js
+++ b/tests/unit/fixtures/white.js
@@ -3,10 +3,10 @@ function hello () {
 }
 
 var bye = function() {
-    if(hey){
-        // Next two lines have a trailing whitespace
+    if(hey){ // Next two lines have trailing whitespace
+        
         return; 
-    } 
+    }
 };
 
 try {

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1208,8 +1208,8 @@ exports.trailing = function (test) {
   TestRun(test).test(src, {es3: true});
 
   TestRun(test)
+    .addError(7, "Trailing whitespace.", { character: 1 })
     .addError(8, "Trailing whitespace.", { character: 16 })
-    .addError(9, "Trailing whitespace.", { character: 6 })
     .test(src, { es3: true, trailing: true });
 
   test.done();

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3358,20 +3358,6 @@ exports["regression test for crash from GH-964"] = function (test) {
   test.done();
 };
 
-exports["regression test for GH-890"] = function (test) {
-  var code = [
-    "var a = 1; ",
-    "  ",
-    "var b;"
-  ];
-
-  TestRun(test)
-    .addError(1, "Trailing whitespace.")
-    .test(code, { trailing: true });
-
-  test.done();
-};
-
 exports["automatic comma insertion GH-950"] = function (test) {
   var code = [
     "var a = b",


### PR DESCRIPTION
We've flip-flopped on this issue. Recently in #182 @antonkovalyov expressed interest in a patch disallowing (again) trailing whitespace on otherwise empty lines. I'm not sure whether this breaking change is acceptable. Ugly as it might be, we could appease both sides by supporting _three_ values for `trailing`: `false`, `true`, and `"strict"`. At this stage I'm submitting the simplest possible change. I will update the PR in response to feedback.
