### PR TITLE
Add basic support for ES6 TemplateLiterals

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -27,7 +27,8 @@ var Token = {
   Keyword: 6,
   NullLiteral: 7,
   BooleanLiteral: 8,
-  RegExp: 9
+  RegExp: 9,
+  TemplateLiteral: 10
 };
 
 /*
@@ -87,6 +88,10 @@ function Lexer(source, options) {
   for (var i = 0; i < options.indent; i += 1) {
     this.tab += " ";
   }
+
+  // Share option with Parser, so that the file may be processed differently
+  // depending on the state.
+  this.esnext = options.esnext;
 }
 
 Lexer.prototype = {
@@ -794,6 +799,62 @@ Lexer.prototype = {
   },
 
   /*
+   * Extract a template literal out of the next sequence of characters
+   * and/or lines or return 'null' if its not possible. Since template
+   * literals can span across multiple lines, this method has to move
+   * the char pointer.
+   */
+  scanTemplateLiteral: function() {
+    // String must start with a backtick.
+    if (!this.esnext || this.peek() !== "`") {
+      return null;
+    }
+
+    var startLine = this.line;
+    var startChar = this.char;
+    var jump = 1;
+    var value = "";
+
+    // For now, do not perform any linting of the content of the template
+    // string. Just skip until the next backtick is found.
+    this.skip();
+
+    while (this.peek() !== "`") {
+      while (this.peek() === "") {
+        // End of line --- For template literals in ES6, no backslash is
+        // required to precede newlines.
+        if (!this.nextLine()) {
+          this.trigger("error", {
+            code: "E052",
+            line: startLine,
+            character: startChar
+          });
+
+          return {
+            type: Token.TemplateLiteral,
+            value: value,
+            isUnclosed: true
+          };
+        }
+        value += "\n";
+      }
+
+      // TODO: do more interesting linting here, similar to string literal
+      // linting.
+      var char = this.peek();
+      this.skip(jump);
+      value += char;
+    }
+
+    this.skip();
+    return {
+      type: Token.TemplateLiteral,
+      value: value,
+      isUnclosed: false
+    };
+  },
+
+  /*
    * Extract a string out of the next sequence of characters and/or
    * lines or return 'null' if its not possible. Since strings can
    * span across multiple lines this method has to move the char
@@ -1168,7 +1229,8 @@ Lexer.prototype = {
     // character pointer.
 
     var match = this.scanComments() ||
-      this.scanStringLiteral();
+      this.scanStringLiteral() ||
+      this.scanTemplateLiteral();
 
     if (match) {
       return match;
@@ -1300,8 +1362,17 @@ Lexer.prototype = {
           hasOctal: token.hasOctal,
           missedBackslashes: token.missedBackslashes
         });
-
         return { type: "(string)", value: token.value, pos: this.pos() };
+      case Token.TemplateLiteral:
+        this.prereg = false;
+        this.trigger("Template", {
+          line: this.line,
+          char: this.char,
+          from: this.from,
+          value: token.value,
+          // TODO: Other info.
+        });
+        return { type: "(template)", value: token.value, pos: this.pos() };
       case Token.Identifier:
         this.prereg = false;
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -89,7 +89,8 @@ var errors = make("error", {
   E048: "Let declaration not directly within block.",
   E049: "A {a} cannot be named '{b}'.",
   E050: "Mozilla requires the yield expression to be parenthesized here.",
-  E051: "Regular parameters cannot come after default parameters."
+  E051: "Regular parameters cannot come after default parameters.",
+  E052: "Unclosed template literal."
 });
 
 var warnings = make("warning", {

--- a/src/parser.js
+++ b/src/parser.js
@@ -1517,6 +1517,10 @@ type("(string)", function () {
   return this;
 });
 
+type("(template)", function() {
+  return this;
+});
+
 syntax["(identifier)"] = {
   type: "(identifier)",
   lbp: 0,
@@ -3903,7 +3907,7 @@ function parse(input, options, program) {
   warnings = 0;
 
   // Configure and start lexer
-  lex = new Lexer(input, { indent: state.option.indent });
+  lex = new Lexer(input, { indent: state.option.indent, esnext: state.option.esnext });
 
   lex.on("warning", function (ev) {
     warn(ev.code, { coord: { line: ev.line, ch: ev.character }, args: ev.data });

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -710,6 +710,15 @@ exports.testES6ModulesDefaultExportsAffectUnused = function (test) {
   test.done();
 };
 
+exports.testES6TemplateLiterals = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/es6-template-literal.js", "utf8");
+  TestRun(test)
+    .addError(6, "Unclosed template literal.")
+    .addError(6, "Missing semicolon.")
+    .test(src, { esnext: true });
+  test.done();
+};
+
 exports.testPotentialVariableLeak = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/leak.js", "utf8");
 

--- a/tests/unit/fixtures/es6-template-literal.js
+++ b/tests/unit/fixtures/es6-template-literal.js
@@ -1,0 +1,6 @@
+var one = 1, two = 2;
+
+var string = `  ${one} + ${two}
+= ${one + two}`;
+
+var unterminated = `${one}


### PR DESCRIPTION
These changes are intended to prevent jshint from choking on template literals when esnext mode is enabled. It has been written to support a sub-lexing process to allow for further linting in the future. At this time it does not support escaped string characters with backslashes, due to my limited knowledge of the template literal syntax.

I am hopeful that this will pave the way for doing more useful linting with this construct, and to allow jshint to be used in applications which make use of this language feature.

Fixes #1219 (sort of).
