### PR TITLE
Add basic support for ES6 TemplateLiterals

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1992,6 +1992,10 @@ var JSHINT = (function () {
     return this;
   });
 
+  type("(template)", function () {
+    return this;
+  });
+
   state.syntax["(identifier)"] = {
     type: "(identifier)",
     lbp: 0,

--- a/src/messages.js
+++ b/src/messages.js
@@ -66,7 +66,8 @@ var errors = {
   E048: "Let declaration not directly within block.",
   E049: "A {a} cannot be named '{b}'.",
   E050: "Mozilla requires the yield expression to be parenthesized here.",
-  E051: "Regular parameters cannot come after default parameters."
+  E051: "Regular parameters cannot come after default parameters.",
+  E052: "Unclosed template literal."
 };
 
 var warnings = {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -761,6 +761,15 @@ exports.testES6ModulesDefaultExportsAffectUnused = function (test) {
   test.done();
 };
 
+exports.testES6TemplateLiterals = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/es6-template-literal.js", "utf8");
+  TestRun(test)
+    .addError(6, "Unclosed template literal.")
+    .addError(6, "Missing semicolon.")
+    .test(src, { esnext: true });
+  test.done();
+};
+
 exports.testPotentialVariableLeak = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/leak.js", "utf8");
 

--- a/tests/unit/fixtures/es6-template-literal.js
+++ b/tests/unit/fixtures/es6-template-literal.js
@@ -1,0 +1,6 @@
+var one = 1, two = 2;
+
+var string = `  ${one} + ${two}
+= ${one + two}`;
+
+var unterminated = `${one}


### PR DESCRIPTION
**rebased for 2.x branch**

These changes are intended to prevent jshint from choking on template literals
when esnext mode is enabled. It has been written to support a sub-lexing
process to allow for further linting in the future. At this time it does not
support escaped string characters with backslashes, due to my limited
knowledge of the template literal syntax.

I am hopeful that this will pave the way for doing more useful linting with
this construct, and to allow jshint to be used in applications which make use
of this language feature.

Closes #1563
Closes #1219
