### PR TITLE
Redo #1548 for the master branch

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1486,8 +1486,19 @@ function block(ordinary, stmt, isfunc, isfatarrow, iscase) {
 
     delete funct["(nolet)"];
   }
-  // Don't clear and let it propagate out if it is "break", "return", or "throw" in switch case
-  if (!(iscase && ["break", "return", "throw"].indexOf(funct["(verb)"]) != -1)) {
+
+  // Don't clear and let it propagate out if it is "break", "return" or similar in switch case
+  switch (funct["(verb)"]) {
+  case "break":
+  case "continue":
+  case "return":
+  case "throw":
+    if (iscase) {
+      break;
+    }
+
+    /* falls through */
+  default:
     funct["(verb)"] = null;
   }
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3938,6 +3938,32 @@ exports["test for 'break' in switch case + curly braces"] = function (test) {
   test.done();
 };
 
+exports["test for 'break' in switch case in loop + curly braces"] = function (test) {
+  var code = [
+    "while (true) {",
+    "  switch (foo) {",
+    "    case 1: { break; }",
+    "    case 2: { return; }",
+    "    case 3: { throw 'Error'; }",
+    "    case 4: { continue; }",
+    "    case 11: {",
+    "      while (true) {",
+    "        break;",
+    "      }",
+    "    }",
+    "    default: break;",
+    "  }",
+    "}"
+  ];
+
+  // No error for case 1, 2, 3, 4.
+  var run = TestRun(test)
+    .addError(11, "Expected a 'break' statement before 'default'.")
+    .test(code);
+
+  test.done();
+};
+
 exports["/*jshint ignore */ should be a good option and only accept start, end or line as values"] = function (test) {
   var code = [
     "/*jshint ignore:start*/",


### PR DESCRIPTION
Switch statement within loop doesn't recognize 'continue' if case is wrapped in { }
Also for #1579
