### PR TITLE
Allow expressions with a comma in switch case condition

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3871,7 +3871,7 @@ var JSHINT = (function () {
         }
         indentation();
         advance("case");
-        this.cases.push(expression(20));
+        this.cases.push(expression(0));
         increaseComplexityCount();
         g = true;
         advance(":");

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4101,6 +4101,17 @@ exports["test for 'break' in switch case in loop + curly braces"] = function (te
   test.done();
 };
 
+exports["allow expression with a comma in switch case condition"] = function (test) {
+  var code = [
+    "switch (false) {",
+    "  case x = 1, y = x: { break; }",
+    "}"
+  ]
+
+  var run = TestRun(test).test(code);
+  test.done();
+};
+
 exports["/*jshint ignore */ should be a good option and only accept start, end or line as values"] = function (test) {
   var code = [
     "/*jshint ignore:start*/",


### PR DESCRIPTION
The ES5 grammar specifies that the `case` keyword should be followed by an
expression (http://www.ecma-international.org/ecma-262/5.1/#sec-A.4) and that
an expression can consist of a comma-separated list of sub-expressions
(http://www.ecma-international.org/ecma-262/5.1/#sec-A.3), so the JSHint parser
should accomodate these commas.

I wasn't sure if I should first create a separate issue and then submit a PR, so I decided to just make a PR that includes a test case that fails without my fix, and passes with it. So that should demonstrate what would have been in the issue.
