### PR TITLE
Redo issue 1543 for master

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -3491,7 +3491,10 @@ stmt("return", function () {
 }(prefix("yield", function () {
   var prev = state.tokens.prev;
   if (api.getEnvironment("es6", true) && !funct["(generator)"]) {
-    warn("E046", { token: state.tokens.curr, args: ["yield"] });
+    // If it's a yield within a catch clause inside a generator then that's ok
+    if (!("(catch)" === funct["(name)"] && funct["(context)"]["(generator)"])) {
+      warn("E046", { token: state.tokens.curr, args: ["yield"] });
+    }
   } else if (!api.getEnvironment("es6")) {
     warn("W104", { token: state.tokens.curr, args: ["yield"] });
   }

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2489,6 +2489,27 @@ exports["test: mozilla generator as esnext"] = function (test) {
   test.done();
 };
 
+exports["test: esnext generator with yield statement inside try-catch"] = function (test) {
+  // see issue: https://github.com/jshint/jshint/issues/1505
+  var code = [
+    "function* fib() {",
+    "  try {",
+    "    yield 1;",
+    "  } catch (err) {",
+    "    yield err;",
+    "  }",
+    "}",
+    "var g = fib();",
+    "for (let i = 0; i < 10; i++)",
+    "  print(g.next());"
+  ];
+ 
+  TestRun(test)
+    .test(code, {esnext: true, unused: true, undef: true, predef: ["print", "Iterator"]});
+ 
+  test.done();
+};
+
 exports["test: mozilla generator as es5"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [


### PR DESCRIPTION
Don't throw an error when yield statement used within a catch block inside a generator function
