### PR TITLE
Update cli.js so that findFile does not search up beyond the home directory.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -158,6 +158,14 @@ function findFile(name, dir) {
     return null;
   }
 
+  // Do not search up beyond home directory.
+  // More efficient, especially when home directories
+  // are automount points.
+  if (process.env.HOME === dir) {
+    findFileResults[filename] = null;
+    return null;
+  }
+
   return findFile(name, parent);
 }
 


### PR DESCRIPTION
Hello and thank you for JSHint,
At $work we have home directories on an automount path, and so for example with /home/users/slebedev/project_dir, if the user does not have a .jshintignore file in the cwd, directories above or home directory then /home/.jshintignore is stat'ed which for us triggers an automount action (ldap+NFS), while this should not cause any problems, it is something I noticed while investigating an automount issue.  I was just wondering if findFile in cli.js needs to search up beyond the home directory all the way to root?
Thanks.
