### PR TITLE
Update bin/build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -20,7 +20,7 @@ bundle.bundle({}, function (err, src) {
   var web   = distDir + "/jshint.js";
   var rhino = distDir + "/jshint-rhino.js";
 
-  [ "// " + version,
+  [ "/*! " + version + " */",
     "var JSHINT;",
     "if (typeof window === 'undefined') window = {};",
     "(function () {",


### PR DESCRIPTION
This fixes an erroneous "dist" dir creation outside of jshint's source dir on my OS (Windows) when doing `npm run build`. On *nix like systems everything should work as usual.
