### PR TITLE
Use minimatch library to match patterns in overrides config property

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -442,7 +442,13 @@ function lint(code, results, config, data, file) {
   if (config.overrides) {
     if (file) {
       _.each(config.overrides, function (options, pattern) {
-        if ((new RegExp(pattern)).test(file)) _.extend(config, options);
+        if (minimatch(file, pattern, { nocase: true, matchBase: true })) {
+          if (options.globals) {
+            globals = _.extend(globals || {}, options.globals);
+            delete options.globals;
+          }
+          _.extend(config, options);
+        }
       });
     }
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -139,7 +139,7 @@ exports.group = {
     var config = {
       "asi": true,
       "overrides": {
-        "bar.js$": {
+        "bar.js": {
           "asi": false
         }
       }


### PR DESCRIPTION
It will be more convenient then regexp patterns because they are hard to write and test.

Example config:

``` js
{
    "node": true,

    "curly": true,
    "camelcase": true,
    "eqeqeq": true,
    "es3": true,
    "immed": true,
    "latedef": "nofunc",
    "newcap": true,
    "noarg": true,
    "noempty": true,
    "nonew": true,
    "quotmark": "single",
    "undef": true,
    "unused": "vars",
    "strict": false,
    "maxparams": 4,
    "maxdepth": 4,
    "maxlen": 120,

    "expr": true,
    "lastsemic": true,
    "laxbreak": true,
    "sub": true,

    "overrides": {
        "*.blocks/**/*.js": {
            "browser": true,
            "jquery": true,

            "globals": {
                "BEM": false,
                "BEMHTML": false,
                "Lego": false
            }
        },
        "*.blocks/**/*.test.js": {
            "globals": {
                "describe": false,
                "xdescribe": false,
                "ddescribe": false,
                "before": false,
                "after": false,
                "beforeEach": false,
                "afterEach": false,
                "it": false,
                "xit": false,
                "iit": false,
                "jasmine": false,
                "expect": false,
                "spyOn": false,
                "sinon": false
            }
        },
        "*.blocks/**/*.bemjson.js": {
            "maxlen": false
        }
    }
}
```

Config property `globals` will be also extended, not just overwritten.
