### PR TITLE
Make generate-identifier-data.js use 2 spaces like the rest of the files.

### DIFF
--- a/scripts/generate-identifier-data.js
+++ b/scripts/generate-identifier-data.js
@@ -46,7 +46,7 @@ var fs = require('fs');
 var writeFile = function(fileName, data) {
   fs.writeFileSync(
     fileName,
-    'module.exports = ' + JSON.stringify(data, null, '\t') + ';\n'
+    'module.exports = ' + JSON.stringify(data, null, '  ') + ';\n'
   );
 };
 


### PR DESCRIPTION
Now the generated files' indentation matches the current one the files in the repository have.
