### PR TITLE
Add es6 object initiator shorthand. Fixes #1555

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -2625,6 +2625,12 @@ function checkCondAssignment(expr) {
             warn("W104", { token: state.tokens.curr, args: ["concise methods"] });
           }
           doFunction(i, undefined, g);
+        } else if (state.tokens.curr.identifier && api.getEnvironment("es6") &&
+          (state.tokens.next.value === "," || state.tokens.next.value === "}")) {
+
+          if (state.tokens.next.value === "}") {
+            break;
+          }
         } else if (!isclassdef) {
           advance(":");
           expression(10);

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4195,3 +4195,21 @@ exports["test destructuring function parameters as legacy JS"] = function (test)
 
   test.done();
 };
+
+exports["test es6 object initator syntax"] = function (test) {
+  var code = [
+    "var a = 1;",
+    "var b = { a };",
+    "var c = { b, a };",
+    "var c = { 1 };" // Only identifiers can be used.
+  ];
+
+  TestRun(test)
+    .addError(4, "Expected ':' and instead saw '}'.")
+    .addError(4, "Expected an identifier and instead saw ';'.")
+    .addError(4, "Unmatched '{'.")
+    .addError(4, "Missing semicolon.")
+    .test(code, { esnext: true });
+
+  test.done();
+};


### PR DESCRIPTION
This will fix #1555.

Supports `{ a }` and `{ a, b }`.
