### PR TITLE
Config: Discoverability from other drives (#1574)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var _                 = require("underscore");
+var fs                = require("fs");
 var cli               = require("cli");
 var path              = require("path");
 var shjs              = require("shelljs");
@@ -72,7 +73,11 @@ function deprecated(text, alt) {
  */
 function findConfig(file) {
   var dir  = path.dirname(path.resolve(file));
-  var envs = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+  var envs = getHomeDir();
+
+  if (!envs)
+    return home;
+
   var home = path.normalize(path.join(envs, ".jshintrc"));
 
   var proj = findFile(".jshintrc", dir);
@@ -83,6 +88,22 @@ function findConfig(file) {
     return home;
 
   return null;
+}
+
+function getHomeDir() {
+  var environment = global.process.env;
+  var paths = [environment.HOME,
+               environment.USERPROFILE,
+               environment.HOMEPATH,
+               environment.HOMEDRIVE + environment.HOMEPATH];
+
+  for (var homeIndex in paths)
+    if (paths.hasOwnProperty(homeIndex)) {
+      var homePath = paths[homeIndex];
+
+      if (homePath && fs.existsSync(homePath))
+        return homePath;
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes #1574:

In Windows, when the project resides in drive other than the one with user profile directory, JsHint doesn't resolve the correct home path.
