### PR TITLE
Add 'Event' (capital E) to browser variables - to support http://mzl.la/1mR23Bc

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -71,6 +71,7 @@ exports.browser = {
   document             : false,
   Element              : false,
   ElementTimeControl   : false,
+  Event                : false,
   event                : false,
   FileReader           : false,
   FormData             : false,


### PR DESCRIPTION
Otherwise I get warnings for using undefined variables when using `Event.BUBBLING_PHASE`, `Event.AT_TARGET`, `Event.CAPTURING_PHASE` and `Event.NONE`
