### PR TITLE
Closes #1081 by adding the `anonfuncs` option

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -109,6 +109,7 @@ var JSHINT = (function () {
                           // loops
       mootools    : true, // if MooTools globals should be predefined
       multistr    : true, // allow multiline strings
+      anonfuncs   : true, // allow anonymous functions
       freeze      : true, // if modifying native object prototypes should be disallowed
       newcap      : true, // if constructor names must be capitalized
       noarg       : true, // if arguments.caller and arguments.callee should be
@@ -2896,6 +2897,13 @@ var JSHINT = (function () {
 
     if (name) {
       addlabel(name, { type: "function" });
+    }
+
+    // If false, anonfuncs will raise a warning on anonymous functions.
+    // This is mainly used for debugging as it makes stack traces more readable.
+    // Named functions still have their names stripped by most minifiers.
+    if (state.option.anonfuncs === false && name === undefined) {
+      warning("W126", state.tokens.curr);
     }
 
     funct["(params)"] = functionparams(fatarrowparams);

--- a/src/messages.js
+++ b/src/messages.js
@@ -197,7 +197,8 @@ var warnings = {
   W122: "Invalid typeof value '{a}'",
   W123: "'{a}' is already defined in outer scope.",
   W124: "A generator function shall contain a yield statement.",
-  W125: "This line contains non-breaking spaces: http://jshint.com/doc/options/#nonbsp"
+  W125: "This line contains non-breaking spaces: http://jshint.com/doc/options/#nonbsp",
+  W126: "Expected a named function"
 };
 
 var info = {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -824,3 +824,14 @@ exports.testModuleKeyword = function (test) {
 
   test.done();
 };
+
+exports.testAnonFunctions = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/anon-functions.js", "utf8");
+
+  TestRun(test)
+    .addError(6, "Expected a named function", {character: 3})
+    .addError(9, "Expected a named function", {character: 2})
+    .addError(13, "Expected a named function", {character: 9})
+    .test(src, {anonfuncs: false});
+  test.done()
+};

--- a/tests/unit/fixtures/anon-functions.js
+++ b/tests/unit/fixtures/anon-functions.js
@@ -1,0 +1,19 @@
+var w = 2;
+function x(f) {
+	return f(w);
+} // named function
+
+x(function (n) { return n * 2; }); // anonymous function
+x(function doubleIt(n) { return n * 2; }); // named function
+
+(function () {
+	return 0;
+})(); // anonymous function
+
+var y = function () {
+	return 0;
+}; // anonymous function
+
+var z = function z() {
+	return 0;
+}; // named function


### PR DESCRIPTION
This option allows anonymous (unnamed) functions.
If false, anonymous functions will raise a warning (W126).
