### PR TITLE
Allow const/let/var above declaration if not used.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4749,6 +4749,8 @@ var JSHINT = (function () {
 
             if (context[name] === "unused")
               context[name] = "var";
+            else if (context[name] === "const" && getprop(context, name, "unused"))
+              setprop(context, name, { unused: false });
             else if (context[name] === "unction")
               context[name] = "closure";
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2187,6 +2187,27 @@ exports["make sure let variables are not treated as globals"] = function (test) 
   test.done();
 };
 
+exports["make sure variables referenced in code above declaration are not marked as unused"] = function (test) {
+  // This is a regression test for GH-1462
+  var code = [
+    "const o = {",
+      "f: function () {",
+        "console.log(a);",
+        "console.log(b);",
+        "console.log(c);",
+      "}",
+    "};",
+
+    "const a = 'aaa';",
+    "let b = 'bbb';",
+    "var c = 'ccc';",
+    "o.f();",
+  ];
+
+  TestRun(test).test(code, { esnext: true, browser: true, unused: true });
+  test.done();
+};
+
 exports["make sure var variables can shadow let variables"] = function (test) {
   // This is a regression test for GH-1394
   var code = [


### PR DESCRIPTION
Ref gh-1462

@valueof I made it work for `const` but I have no idea how to make it work for `let`. From what I see, `var` & `const` are handled by one data structure (though with weirdnesses like `var` being written as `unused` when not used and `const` being just `const` in such a case just with a special `unused` property written in a different structure that is ignored in the `var` case...) but `let` is handled in a completely different way.

I spent some time looking at the code but I cannot figure out what's exactly going on here... Could you help me make it work for `let` as well?
