### PR TITLE
Handle "hasOwnProperty" global variable

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -318,7 +318,7 @@ var JSHINT = (function () {
 
   function combine(dest, src) {
     Object.keys(src).forEach(function (name) {
-      if (JSHINT.blacklist.hasOwnProperty(name)) return;
+      if (Object.prototype.hasOwnProperty.call(JSHINT.blacklist, name)) return;
       dest[name] = src[name];
     });
   }


### PR DESCRIPTION
If the user adds "hasOwnProperty" as a global variable, an error is thrown because JSHINT.blacklist.hasOwnProperty is no longer a function, but becomes a string. Ironically, these libraries define a global hasOwnProperty, so that this exact error doesn't occur inside their library. By calling the original Object prototype, the correct function is called and jshint won't crash.

This fixes an issue in another repository: https://github.com/spenceralger/gulp-jshint/issues/39, and various libraries who use hasOwnProperty (such as AngularJS) won't crash jshint.

Ran npm test successfully: "OK: 974 assertions (4073ms)"

Thank you
