### PR TITLE
ES6 export function requires trailing semicolon.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4137,7 +4137,7 @@ var JSHINT = (function () {
 
     if (state.tokens.next.type === "default") {
       advance("default");
-      if (state.tokens.next.id === "function" || state.tokens.next.id === "class") {
+      if (state.tokens.next.id === "class") {
         this.block = true;
       }
       this.exportee = expression(10);
@@ -4176,7 +4176,6 @@ var JSHINT = (function () {
       exported[state.tokens.next.value] = true;
       state.syntax["const"].fud.call(state.syntax["const"].fud);
     } else if (state.tokens.next.id === "function") {
-      this.block = true;
       advance("function");
       exported[state.tokens.next.value] = true;
       state.syntax["function"].fud();

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -699,7 +699,7 @@ exports.testES6ModulesNamedExportsAffectUnused = function (test) {
     "var z = 42;",
     "export { a, x };",
     "export var b = { baz: 'baz' };",
-    "export function boo() { return z; }",
+    "export function boo() { return z; };",
     "export class MyClass { }"
   ];
 
@@ -722,7 +722,7 @@ exports.testES6ModulesDefaultExportsAffectUnused = function (test) {
     "var x = 23;",
     "var z = 42;",
     "export default { a: a, x: x };",
-    "export default function boo() { return x + z; }",
+    "export default function boo() { return x + z; };",
     "export default class MyClass { }"
   ];
 

--- a/tests/unit/fixtures/es6-import-export.js
+++ b/tests/unit/fixtures/es6-import-export.js
@@ -22,7 +22,7 @@ export default foobar;
 // makes testing a hell of a lot easier
 export default function() {
   return "foobar";
-}
+};
 
 export { foo };
 export { foo, bar };
@@ -31,7 +31,7 @@ export { foo, bar };
 
 export function a() {
   return "a";
-}
+};
 
 export var b = function() {
   return "b";


### PR DESCRIPTION
@stefanpenner brought this to my attention. Per @wycats and @domenic the trailing semi-colon is required for the following scenarios:

``` javascript
export default function () { return 'foo'; };
export function foo () { return 'bar'; };
```

For reference:

https://people.mozilla.org/~jorendorff/es6-draft.html#sec-exports
