### PR TITLE
Extend "globals" configuration deeply

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -509,7 +509,9 @@ var exports = {
       config.dirname = path.dirname(fp);
 
       if (config['extends']) {
-        _.defaults(config, exports.loadConfig(path.resolve(config.dirname, config['extends'])));
+        var baseConfig = exports.loadConfig(path.resolve(config.dirname, config['extends']));
+        config.globals = _.extend({}, baseConfig.globals, config.globals);
+        _.defaults(config, baseConfig);
         delete config['extends'];
       }
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -24,10 +24,11 @@ exports.group = {
     sinon.stub(shjs, "cat")
       .withArgs(sinon.match(/file\.js$/)).returns("var a = function () {}; a();")
       .withArgs(sinon.match(/file1\.json$/)).returns("wat")
-      .withArgs(sinon.match(/file2\.json$/)).returns("{\"node\":true}")
+      .withArgs(sinon.match(/file2\.json$/)).returns("{\"node\":true,\"globals\":{\"foo\":true,\"bar\":true}}")
       .withArgs(sinon.match(/file4\.json$/)).returns("{\"extends\":\"file3.json\"}")
       .withArgs(sinon.match(/file5\.json$/)).returns("{\"extends\":\"file2.json\"}")
-      .withArgs(sinon.match(/file6\.json$/)).returns("{\"extends\":\"file2.json\",\"node\":false}");
+      .withArgs(sinon.match(/file6\.json$/)).returns("{\"extends\":\"file2.json\",\"node\":false}")
+      .withArgs(sinon.match(/file7\.json$/)).returns("{\"extends\":\"file2.json\",\"globals\":{\"bar\":false,\"baz\":true}}");
 
     sinon.stub(shjs, "test")
       .withArgs("-e", sinon.match(/file\.js$/)).returns(true)
@@ -97,6 +98,12 @@ exports.group = {
     cli.interpret([
       "node", "jshint", "file.js", "--config", "file2.json"
     ]);
+
+    // Performs a deep merge of "globals" configuration
+    cli.interpret([
+      "node", "jshint", "file2.js", "--config", "file7.json"
+    ]);
+    test.deepEqual(cli.run.lastCall.args[0].config.globals, { foo: true, bar: false, baz: true });
 
     _cli.error.restore();
     cli.run.restore();


### PR DESCRIPTION
Allow for extension of the "globals" configuration option. Users may
override any or all "globals" values by explicitly specifying them in
the extending configuration.

The necessity of this change is based on my interpretation of the "extends" option functionality, so it's a little subjective. I believe that this is in line with the spirit of the feature, which is to limit duplication in configuration logic.

My use case is a project that maintains unit tests for client-side code and server-side code. Both environments use [Mocha](https://github.com/visionmedia/mocha), and the client uses AMD. I would like to share and extend the "globals" configuration like this:

`/.jshintrc`

``` json
{
  "undef": true
}
```

`./test/.jshintrc`

``` json
{
  "extends": "../.jshintrc",
  "globals": {
    "suite": true,
    "test": true,
    "setup": true,
    "teardown": true,
    "assert": true
   }
}
```

`./test/client/.jshintrc`

``` json
{
  "extends": "../.jshintrc",
  "browser": true,
  "globals": {
    "define": true
  }
}
```

`./test/server/.jshintrc`

``` json
{
  "extends": "../.jshintrc",
  "node": true
}
```
