### PR TITLE
Handle "hasOwnProperty" as a global variable

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -318,7 +318,7 @@ var JSHINT = (function () {
 
   function combine(dest, src) {
     Object.keys(src).forEach(function (name) {
-      if (JSHINT.blacklist.hasOwnProperty(name)) return;
+      if (_.has(JSHINT.blacklist, name)) return;
       dest[name] = src[name];
     });
   }


### PR DESCRIPTION
(This is a re-opened PR #1668 against `master` instead of the removed `2.x` branch)

If the user adds "hasOwnProperty" as a global variable, an error is thrown because `JSHINT.blacklist.hasOwnProperty` is no longer a function, but becomes a string. Ironically, some libraries define a global "hasOwnProperty", so that this exact error doesn't occur inside their own library.

This fixes an issue in another repository: spenceralger/gulp-jshint#39. Also various libraries who use hasOwnProperty (such as AngularJS) won't crash jshint.

As @valueof suggested here https://github.com/jshint/jshint/pull/1668#issuecomment-43298008, I used underscore instead of vanilla JavaScript
