### PR TITLE
Add 'Event' (capital E) to browser variables - to support http://mzl.la/1mR23Bc

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -71,6 +71,7 @@ exports.browser = {
   document             : false,
   Element              : false,
   ElementTimeControl   : false,
+  Event                : false,
   event                : false,
   FileReader           : false,
   FormData             : false,


### PR DESCRIPTION
Replaces #1645

---

Otherwise I get warnings for using undefined variables when using `Event.BUBBLING_PHASE`, `Event.AT_TARGET`, `Event.CAPTURING_PHASE` and `Event.NONE`

---

@valueof said I needed to update the tests - but this is just a configuration change (just adding an allowed global) and I couldn't find any similar tests for `event` (lowercase), or, `ElementTimeControl`, or many of the other vars listed in that file.

Happy to add a test but couldn't find any suitable template to work from :-/.
