### PR TITLE
Do not assume JSON block when mapping array

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4247,10 +4247,15 @@ var JSHINT = (function () {
         ret.notJson = true;
         break;
       }
-      if (_.contains(["}", "]"], pn.value) && pn1.value === "=" && bracketStack === 0) {
-        ret.isDestAssign = true;
-        ret.notJson = true;
-        break;
+      if (_.contains(["}", "]"], pn.value) && bracketStack === 0) {
+        if (pn1.value === "=") {
+          ret.isDestAssign = true;
+          ret.notJson = true;
+          break;
+        } else if (pn1.value === ".") {
+          ret.notJson = true;
+          break;
+        }
       }
       if (pn.value === ";") {
         ret.isBlock = true;

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -823,3 +823,12 @@ exports.testModuleKeyword = function (test) {
 
   test.done();
 };
+
+// Issue #1446, PR #1688
+exports.testIncorrectJsonDetection = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/mappingstart.js", "utf8");
+  // Without the bug fix, a JSON lint error will be raised because the parser
+  // thinks it is rendering JSON instead of JavaScript.
+  TestRun(test).test(src);
+  test.done();
+};

--- a/tests/unit/fixtures/mappingstart.js
+++ b/tests/unit/fixtures/mappingstart.js
@@ -1,0 +1,3 @@
+['foo', 'bar', 'baz'].forEach(function(name) {
+    console.log(name);
+});


### PR DESCRIPTION
If the following code snippet is the first line of a program, JSHint
incorrectly assumes it is JSON when doing array destructuring checks:

```
['foo', 'bar', 'baz'].forEach(function(name) {
  console.log(name)
});
```

Fixes #1446
