### PR TITLE
Support ES6 `export * from ...` syntax

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4135,6 +4135,13 @@ var JSHINT = (function () {
       warning("W119", state.tokens.curr, "export");
     }
 
+    if (state.tokens.next.value === "*") {
+      advance("*");
+      advance("from");
+      advance("(string)");
+      return this;
+    }
+
     if (state.tokens.next.type === "default") {
       advance("default");
       if (state.tokens.next.id === "function" || state.tokens.next.id === "class") {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -743,6 +743,17 @@ exports.testES6TemplateLiterals = function (test) {
   test.done();
 };
 
+exports.testES6ExportStarFrom = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/es6-export-star-from.js", "utf8");
+  TestRun(test)
+    .addError(2, "Expected 'from' and instead saw 'foo'.")
+    .addError(2, "Expected '(string)' and instead saw ';'.")
+    .addError(2, "Missing semicolon.")
+    .addError(3, "Expected '(string)' and instead saw '78'.")
+    .test(src, { esnext: true });
+  test.done();
+};
+
 exports.testPotentialVariableLeak = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/leak.js", "utf8");
 

--- a/tests/unit/fixtures/es6-export-star-from.js
+++ b/tests/unit/fixtures/es6-export-star-from.js
@@ -1,0 +1,3 @@
+export * from './foo.js';
+export * foo;
+export * from 78;


### PR DESCRIPTION
Add support for the `export * FromClause ;` export declaration, described at https://people.mozilla.org/~jorendorff/es6-draft.html#sec-exports

Closes #1717
