### PR TITLE
Support Object Short Notation

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1488,12 +1488,14 @@ var JSHINT = (function () {
   // argument (see identifier())
   // prop means that this identifier is that of an object property
 
-  function optionalidentifier(fnparam, prop) {
+  function optionalidentifier(fnparam, prop, preserve) {
     if (!state.tokens.next.identifier) {
       return;
     }
 
-    advance();
+    if (!preserve) {
+      advance();
+    }
 
     var curr = state.tokens.curr;
     var val  = state.tokens.curr.value;
@@ -2710,16 +2712,20 @@ var JSHINT = (function () {
   }, 160);
 
 
-  function property_name() {
-    var id = optionalidentifier(false, true);
+  function property_name(preserve) {
+    var id = optionalidentifier(false, true, preserve);
 
     if (!id) {
       if (state.tokens.next.id === "(string)") {
         id = state.tokens.next.value;
-        advance();
+        if (!preserve) {
+          advance();
+        }
       } else if (state.tokens.next.id === "(number)") {
         id = state.tokens.next.value.toString();
-        advance();
+        if (!preserve) {
+          advance();
+        }
       }
     }
 
@@ -3148,21 +3154,33 @@ var JSHINT = (function () {
             advance("*");
             g = true;
           }
-          i = property_name();
-          saveProperty(tag + i, state.tokens.next);
-
-          if (typeof i !== "string") {
-            break;
-          }
-
-          if (state.tokens.next.value === "(") {
+          if (!isclassdef &&
+              state.tokens.next.identifier &&
+              (peek().id === "," || peek().id === "}")) {
             if (!state.option.inESNext()) {
-              warning("W104", state.tokens.curr, "concise methods");
+              warning("W104", state.tokens.curr, "object short notation");
             }
-            doFunction(i, undefined, g);
-          } else if (!isclassdef) {
-            advance(":");
+            i = property_name(true);
+            saveProperty(tag + i, state.tokens.next);
+
             expression(10);
+          } else {
+            i = property_name();
+            saveProperty(tag + i, state.tokens.next);
+
+            if (typeof i !== "string") {
+              break;
+            }
+
+            if (state.tokens.next.value === "(") {
+              if (!state.option.inESNext()) {
+                warning("W104", state.tokens.curr, "concise methods");
+              }
+              doFunction(i, undefined, g);
+            } else if (!isclassdef) {
+              advance(":");
+              expression(10);
+            }
           }
         }
         // It is a Syntax Error if PropName of MethodDefinition is "prototype".

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3604,6 +3604,23 @@ exports["concise methods support for 'set' without 'get'"] = function (test) {
   test.done();
 };
 
+exports["object short notation"] = function (test) {
+  var code = [
+    "var foo = 42;",
+    "var bar = {foo};",
+    "var baz = {foo, bar};"
+  ];
+
+  TestRun(test).test(code, {esnext: true});
+
+  TestRun(test)
+    .addError(2, "'object short notation' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(3, "'object short notation' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .test(code);
+
+  test.done();
+};
+
 exports["spread rest operator support"] = function (test) {
   var code = [
     // spread operator


### PR DESCRIPTION
This adds support for object short notation:

``` javascript
function f(x, y) { return {x: x, y: y}; }
// Object Short Notation
function f(x, y) { return {x, y}; }
```

Support for this feature is limited to `esnext` mode.
