### PR TITLE
Add proper support for comments in .jshintignore

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -200,7 +200,8 @@ function loadIgnores(exclude, excludePath) {
 
   return lines
     .filter(function (line) {
-      return !!line.trim();
+      // ignore blank lines and comments
+      return !!line.trim() && !/^#/.test(line);
     })
     .map(function (line) {
       if (line[0] === "!")


### PR DESCRIPTION
Patch for https://github.com/jshint/jshint/issues/1757. 

Ignores lines of a `.jshintignore` file that start with `#`, in addition to blank lines.
