### PR TITLE
Overrides doesn't match relative paths

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -463,7 +463,7 @@ function lint(code, results, config, data, file) {
   if (config.overrides) {
     if (file) {
       _.each(config.overrides, function (options, pattern) {
-        if (minimatch(file, pattern, { nocase: true, matchBase: true })) {
+        if (minimatch(path.normalize(file), pattern, { nocase: true, matchBase: true })) {
           if (options.globals) {
             globals = _.extend(globals || {}, options.globals);
             delete options.globals;


### PR DESCRIPTION
JSHint doesn't override configuration when it is called with a relative path like `./src/bar.js` while the pattern is for `src/bar.js` for example (the opposite is also true).

``` json
{
  "overrides": {
    "src/bar/js": { "asi": true }
  }
}
```

```
$ jshint src/bar.js     # => overrides configuration
$ jshint ./src/bar.js   # => won't override configuration
```

This patch tries to fix the problem by normalizing the file path, which transforms `./src/bar.js` into `src/bar.js` so that the overrides pattern will match both cases transparently. It's still compatible with relative patterns like `../src/bar.js`  since `path` won't normalize a leading `..` (but there is no test to assert it)
