### PR TITLE
Added foxx flag for ArangoDB Foxx globals

### DIFF
--- a/examples/.jshintrc
+++ b/examples/.jshintrc
@@ -61,6 +61,7 @@
     // Environments
     "browser"       : true,     // Web Browser (window, document, etc)
     "couch"         : false,    // CouchDB
+    "foxx"          : false,    // ArangoDB Foxx
     "devel"         : true,     // Development/debugging (alert, confirm, etc)
     "dojo"          : false,    // Dojo Toolkit
     "jquery"        : false,    // jQuery

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -133,6 +133,7 @@ var JSHINT = (function () {
       // Third party globals
       mootools    : true, // if MooTools globals should be predefined
       couch       : true, // if CouchDB globals should be predefined
+      foxx        : true, // if ArangoDB Foxx globals should be predefined
       jasmine     : true, // Jasmine functions should be predefined
       jquery      : true, // if jQuery globals should be predefined
       node        : true, // if the Node.js environment globals should be
@@ -361,6 +362,10 @@ var JSHINT = (function () {
 
     if (state.option.couch) {
       combine(predefined, vars.couch);
+    }
+
+    if (state.option.foxx) {
+      combine(predefined, vars.foxx);
     }
 
     if (state.option.qunit) {
@@ -4799,8 +4804,10 @@ var JSHINT = (function () {
         directives();
 
         if (state.directive["use strict"]) {
-          if (!state.option.globalstrict && !(state.option.node || state.option.phantom)) {
-            warning("W097", state.tokens.prev);
+          if (!state.option.globalstrict) {
+            if (!(state.option.node || state.option.phantom || state.option.foxx)) {
+              warning("W097", state.tokens.prev);
+            }
           }
         }
 

--- a/src/vars.js
+++ b/src/vars.js
@@ -386,6 +386,15 @@ exports.couch = {
   provides  : false
 };
 
+exports.foxx = {
+  __filename        : false,
+  __dirname         : false,
+  module            : false,
+  exports           : false,
+  require           : false,
+  applicationContext: false
+};
+
 exports.node = {
   __filename    : false,
   __dirname     : false,


### PR DESCRIPTION
[ArangoDB](https://www.arangodb.org/) is a document and graph database that allows defining APIs in (mostly) node-compatible JavaScript apps called [Foxx apps](https://www.arangodb.org/arangodb-foxx).

This PR adds a `foxx` flag analogous to the existing `couch` flag for Couch apps. As there were no tests for `couch`, `phantom` and `shelljs` I haven't added any new tests.
