### PR TITLE
Fixes #1729. Added browserify flag to subset browser-safe node globals

### DIFF
--- a/examples/.jshintrc
+++ b/examples/.jshintrc
@@ -60,6 +60,7 @@
 
     // Environments
     "browser"       : true,     // Web Browser (window, document, etc)
+    "browserify"    : false,    // Browserify (node.js code in the browser)
     "couch"         : false,    // CouchDB
     "devel"         : true,     // Development/debugging (alert, confirm, etc)
     "dojo"          : false,    // Dojo Toolkit

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -150,6 +150,7 @@ var JSHINT = (function () {
       nonstandard : true, // if non-standard (but widely adopted) globals should
       // be predefined
       browser     : true, // if the standard browser globals should be predefined
+      browserify  : true, // if the standard browserify globals should be predefined
       devel       : true, // if logging globals should be predefined (console, alert, etc.)
 
       // Obsolete options
@@ -403,6 +404,12 @@ var JSHINT = (function () {
     if (state.option.browser) {
       combine(predefined, vars.browser);
       combine(predefined, vars.typed);
+    }
+
+    if (state.option.browserify) {
+      combine(predefined, vars.browser);
+      combine(predefined, vars.typed);
+      combine(predefined, vars.browserify);
     }
 
     if (state.option.nonstandard) {
@@ -4799,8 +4806,10 @@ var JSHINT = (function () {
         directives();
 
         if (state.directive["use strict"]) {
-          if (!state.option.globalstrict && !(state.option.node || state.option.phantom)) {
-            warning("W097", state.tokens.prev);
+          if (!state.option.globalstrict) {
+            if (!(state.option.node || state.option.phantom || state.option.browserify)) {
+              warning("W097", state.tokens.prev);
+            }
           }
         }
 

--- a/src/vars.js
+++ b/src/vars.js
@@ -409,6 +409,17 @@ exports.node = {
   clearImmediate: true  // v0.9.1+
 };
 
+exports.browserify = {
+  __filename    : false,
+  __dirname     : false,
+  global        : false,
+  module        : false,
+  require       : false,
+  Buffer        : true,
+  exports       : true,
+  process       : true
+};
+
 exports.phantom = {
   phantom      : true,
   require      : true,

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -60,9 +60,15 @@ exports.node = function (test) {
   TestRun(test)
     .test(globalStrict, { es3: true, node: true, strict: true });
 
+  TestRun(test)
+    .test(globalStrict, { es3: true, browserify: true, strict: true });
+
   // Don't assume strict:true for Node environments. See bug GH-721.
   TestRun(test)
     .test("function test() { return; }", { es3: true, node: true });
+
+  TestRun(test)
+    .test("function test() { return; }", { es3: true, browserify: true });
 
   // Make sure that we can do fancy Node export
 
@@ -75,6 +81,10 @@ exports.node = function (test) {
   TestRun(test)
     .addError(1, "Read only.")
     .test(overwrites, { es3: true, node: true });
+
+  TestRun(test)
+    .addError(1, "Read only.")
+    .test(overwrites, { es3: true, browserify: true });
 
   test.done();
 };


### PR DESCRIPTION
See #1729.
