### PR TITLE
add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name":     "jshint",
+  "homepage": "http://jshint.com/",
+  "description": "Static analysis tool for JavaScript",
+
+  "authors": [{
+    "name":  "Anton Kovalyov",
+    "email": "anton@kovalyov.net",
+    "homepage":   "http://anton.kovalyov.net/"
+  }],
+
+  "main": "dist/jshint.js",
+
+  "license": "MIT",
+
+  "ignore": [
+    ".*",
+    "*.json",
+    "bin",
+    "data",
+    "node_modules",
+    "examples",
+    "res",
+    "scripts",
+    "src",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hi - I wonder if you'd consider adding a bower.json file? Doing so means that bower/AMD users can `bower install jshint` and do this...

```js
var JSHINT = require( 'jshint' );
```

...instead of this...

```js
var JSHINT = require( 'bower_components/jshint/dist/jshint' );
```

...(or setting up a custom paths config) because Bower looks for the `main` property inside a `bower.json` file.

Thanks!
