### PR TITLE
Config: Prioritize userprofile for HOME search

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -92,8 +92,8 @@ function findConfig(file) {
 
 function getHomeDir() {
   var environment = global.process.env;
-  var paths = [environment.HOME,
-               environment.USERPROFILE,
+  var paths = [environment.USERPROFILE,
+               environment.HOME,
                environment.HOMEPATH,
                environment.HOMEDRIVE + environment.HOMEPATH];
 


### PR DESCRIPTION
In Windows, it turns out if the current user is
not the default user, `environment.HOME`
returns drive root instead of the user-profile
directory.

This PR change the priority. This change will
not break the current usage / implementations.
