### PR TITLE
Removed 'browserify' from the .jshintrc example

### DIFF
--- a/examples/.jshintrc
+++ b/examples/.jshintrc
@@ -60,7 +60,6 @@
 
     // Environments
     "browser"       : true,     // Web Browser (window, document, etc)
-    "browserify"    : false,    // Browserify (node.js code in the browser)
     "couch"         : false,    // CouchDB
     "devel"         : true,     // Development/debugging (alert, confirm, etc)
     "dojo"          : false,    // Dojo Toolkit


### PR DESCRIPTION
This option doesn't appear to be supported so I've removed it from the
.jshintrc example.
