### PR TITLE
[[Fix]] Allow W117 and undef to be toggled per line.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -494,7 +494,9 @@ var JSHINT = (function () {
   }
 
   function isundef(scope, code, token, a) {
-    return JSHINT.undefs.push([scope, code, token, a]);
+    if (!state.ignored[code] && state.option.undef !== false) {
+      JSHINT.undefs.push([scope, code, token, a]);
+    }
   }
 
   function removeIgnoredMessages() {

--- a/tests/unit/fixtures/ignore-w117.js
+++ b/tests/unit/fixtures/ignore-w117.js
@@ -1,0 +1,16 @@
+function testUndeclaredGlobalSuppressWarningUsingW117() {
+  //jshint -W117
+  c();
+  //jshint +W117
+  c();
+}
+function testUndeclaredGlobalSuppressWarningUsingUndef() {
+  //jshint undef:false
+  c();
+  //jshint undef:true
+  c();
+}
+
+function testUndeclaredGlobal() {
+  c();
+}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1597,6 +1597,21 @@ exports.unignored = function (test) {
 };
 
 /*
+ * Tests that the W117 and undef can be toggled per line.
+ */
+exports['per-line undef / -W117'] = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/ignore-w117.js", "utf-8");
+
+  TestRun(test)
+    .addError(5, "'c' is not defined.")
+    .addError(11, "'c' is not defined.")
+    .addError(15, "'c' is not defined.")
+    .test(src, { undef:true });
+
+  test.done();
+};
+
+/*
 * Tests the `freeze` option -- Warn if native object prototype is assigned to.
 */
 exports.freeze = function (test) {


### PR DESCRIPTION
This patch allows JSHint to apply `-W117` and `undef:false` to a local part within the file.

Use-case: I have code where some variables are only defined if some conditional is true. I don't want to put `/* globals name_of_variable */` in the file, because it could result in unknowingly using the variable when it does not exist. Therefore I need an option to toggle the error for a specific section.

(edit: `unused` -> `undef`)