### PR TITLE
Added basic handling of (abandoned) ECMA 4 type annotations.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -127,6 +127,7 @@ var JSHINT = (function () {
         lastsemic   : true, // if semicolons may be ommitted for the trailing
         loopfunc    : true, // if functions should be allowed to be defined within
         expr        : true, // if ExpressionStatement should be allowed as Programs
+        es4type     : true, // if ES4 type annotations should be allowed
         esnext      : true // if es.next specific syntax should be allowed
       },
 
@@ -1572,6 +1573,17 @@ var JSHINT = (function () {
     }
   }
 
+  function typeannotation() {
+    var i = optionalidentifier();
+    if (i) {
+      while (state.tokens.next.id === ".") {
+        advance(".");
+        i = optionalidentifier();
+      }
+      return i;
+    }
+    error("E030", state.tokens.next, state.tokens.next.value);
+  }
 
   function reachable(s) {
     var i = 0, t;
@@ -2856,6 +2868,13 @@ var JSHINT = (function () {
           error("E051", state.tokens.current);
         }
       }
+      if (state.tokens.next.id === ":") {
+        if (!state.option.es4type) {
+          error("E053");
+        }
+        advance(":");
+        typeannotation();
+      }
       if (state.tokens.next.id === "=") {
         if (!state.option.inESNext()) {
           warning("W119", state.tokens.next, "default parameters");
@@ -2971,6 +2990,13 @@ var JSHINT = (function () {
     }
 
     funct["(params)"] = functionparams(fatarrowparams);
+    if (state.tokens.next.id === ":") {
+      if (!state.option.es4type) {
+        error("E053");
+      }
+      advance(":");
+      typeannotation();
+    }
     funct["(metrics)"].verifyMaxParametersPerFunction(funct["(params)"]);
 
     // So we parse fat-arrow functions after we encounter =>. So basically
@@ -3468,6 +3494,14 @@ var JSHINT = (function () {
       }
 
       this.first = this.first.concat(names);
+      
+      if (state.tokens.next.id === ":") {
+        if (!state.option.es4type) {
+          error("E053");
+        }
+        advance(":");
+        typeannotation();
+      }
 
       if (state.tokens.next.id === "=") {
         advance("=");
@@ -3960,6 +3994,13 @@ var JSHINT = (function () {
       if (state.tokens.next.id === "var") {
         advance("var");
         state.syntax["var"].fud.call(state.syntax["var"].fud, true);
+        if (state.tokens.next.id === ":") {
+          if (!state.option.es4type) {
+            error("E053");
+          }
+          advance(":");
+          typeannotation();
+        }
       } else if (state.tokens.next.id === "let") {
         advance("let");
         // create a new block scope
@@ -4000,6 +4041,13 @@ var JSHINT = (function () {
         if (state.tokens.next.id === "var") {
           advance("var");
           state.syntax["var"].fud.call(state.syntax["var"].fud);
+          if (state.tokens.next.id === ":") {
+            if (!state.option.es4type) {
+              error("E053");
+            }
+            advance(":");
+            typeannotation();
+          }
         } else if (state.tokens.next.id === "let") {
           advance("let");
           // create a new block scope

--- a/src/messages.js
+++ b/src/messages.js
@@ -67,7 +67,8 @@ var errors = {
   E049: "A {a} cannot be named '{b}'.",
   E050: "Mozilla requires the yield expression to be parenthesized here.",
   E051: "Regular parameters cannot come after default parameters.",
-  E052: "Unclosed template literal."
+  E052: "Unclosed template literal.",
+  E053: "Type annotations are not available in standard ECMA script (use es4type option)."
 };
 
 var warnings = {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -867,3 +867,33 @@ exports.testIncorrectJsonDetection = function (test) {
   TestRun(test).test(src);
   test.done();
 };
+
+exports.testES4TypeSpecifierErrorsByDefault = function (test) {
+  var code1 = "var i : Number = 3;";
+  var code2 = "function something() : Number { return 1; }";
+  var code3 = "var something = function() : Number { return 1; };";
+  var code4 = "function something(i : Number) { return 1; }";
+  var code5 = "for (var i : Number = 0; i < 3; i++) { }";
+  var code6 = "for each (var i : Number in [1, 3, 5, 7]) { }";
+  TestRun(test).addError(1, "Type annotations are not available in standard ECMA script (use es4type option).").test(code1, {});
+  TestRun(test).addError(1, "Type annotations are not available in standard ECMA script (use es4type option).").test(code2, {});
+  TestRun(test).addError(1, "Type annotations are not available in standard ECMA script (use es4type option).").test(code3, {});
+  TestRun(test).addError(1, "Type annotations are not available in standard ECMA script (use es4type option).").test(code4, {});
+  TestRun(test).addError(1, "Type annotations are not available in standard ECMA script (use es4type option).").test(code5, {});
+  test.done();
+}
+
+exports.testES4TypeSpecifiersAllowed = function (test) {
+  var code1 = "var i : Number = 3;";
+  var code2 = "function something() : Number { return 1; }";
+  var code3 = "var something = function() : Number { return 1; };";
+  var code4 = "function something(i : Number) { return 1; }";
+  var code5 = "for (var i : Number = 0; i < 3; i++) { }";
+  var code6 = "for each (var i : Number in [1, 3, 5, 7]) { }";
+  TestRun(test).test(code1, { es4type: true });
+  TestRun(test).test(code2, { es4type: true });
+  TestRun(test).test(code3, { es4type: true });
+  TestRun(test).test(code4, { es4type: true });
+  TestRun(test).test(code5, { es4type: true });
+  test.done();
+}


### PR DESCRIPTION
These are not allowed in standard Javascript or in later ECMA
versions, but some custom ECMA implementations do allow them.

This commit doesn't add any additional checking of types, it
just allows scripts that do have type annotations in them to be
checked for other standard errors/warnings.

I need this support  for a project I am working on, and can work
off of my own fork, however I thought maybe others could use it
too.

I was not able to find a formal definition of type annotations,
so I based them on the code I have.

Some examples:

``` javascript
function add(x : Number, y : Number) : Number {
  var sum : Number = x + y;
  return sum;
}
for (var i : Number = 0; i < 10; i++) {
  // do something.
}
```
