### PR TITLE
Support TemplateLiterals and quotemark option.

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -922,7 +922,8 @@ Lexer.prototype = {
     return {
       type: tokenType,
       value: value,
-      isUnclosed: false
+      isUnclosed: false,
+      quote: "`"
     };
   },
 

--- a/src/style.js
+++ b/src/style.js
@@ -56,9 +56,15 @@ exports.register = function (linter) {
 
   linter.on("String", function style_scanQuotes(data) {
     var quotmark = linter.getOption("quotmark");
+    var esnext = linter.getOption("esnext");
     var code;
 
     if (!quotmark) {
+      return;
+    }
+
+    // If quotmark is enabled, return if this is a template literal.
+    if (esnext && data.quote === "`") {
       return;
     }
 

--- a/tests/unit/fixtures/quotes4.js
+++ b/tests/unit/fixtures/quotes4.js
@@ -1,0 +1,2 @@
+var test1 = 'string';
+var test2 = `string`;

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1230,6 +1230,34 @@ exports.quotesInline = function (test) {
   test.done();
 };
 
+// Test the `quotmark` option along with TemplateLiterals.
+exports.quotesAndTemplateLiterals = function (test) {
+  var src = fs.readFileSync(__dirname + '/fixtures/quotes4.js', 'utf8');
+
+  // Without esnext
+  TestRun(test)
+    .addError(2, "Unexpected '`'.")
+    .addError(2, "Unexpected early end of program.")
+    .addError(2, "Expected an identifier and instead saw '(end)'.")
+    .addError(2, "Missing semicolon.")
+    .test(src);
+
+  // With esnext
+  TestRun(test)
+    .test(src, {esnext: true});
+
+  // With esnext and single quotemark
+  TestRun(test)
+    .test(src, {esnext: true, quotmark: 'single'});
+
+  // With esnext and double quotemark
+  TestRun(test)
+    .addError(1, "Strings must use doublequote.")
+    .test(src, {esnext: true, quotmark: 'double'});
+
+  test.done();
+};
+
 exports.scope = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/scope.js', 'utf8');
 


### PR DESCRIPTION
I had originally filed this to solve issue #1797. This solves the problem for me, but I think checking the value of data.quote inside of style.js  would probably be more correct. If anyone could point me in the right direction of doing so I would appreciate it. We need to populate the data.quote with a ` (backtick) character instead of being undefined.
