### PR TITLE
Fix spurious arguments in function calls is jshint.js

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2715,7 +2715,7 @@ var JSHINT = (function () {
   }
 
   prefix("[", function () {
-    var blocktype = lookupBlockType(true);
+    var blocktype = lookupBlockType();
     if (blocktype.isCompArray) {
       if (!state.option.inESNext()) {
         warning("W119", state.tokens.curr, "array comprehension");


### PR DESCRIPTION
Several function calls in jshint.js pass extra arguments to the functions they invoke, which end up being ignored. This PR suggests simply removing the spurious arguments to clarify the situation.

Addresses https://github.com/jshint/jshint/issues/1800
