### PR TITLE
Multi-line template literal test case.

### DIFF
--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -775,6 +775,14 @@ exports.testES6TemplateLiteralsUndef = function (test) {
   test.done();
 };
 
+exports.testES6TemplateLiteralsMultiLine = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/es6-template-literal-multiline.js", "utf8");
+  TestRun(test)
+    .test(src, { esnext: true });
+
+  test.done();
+};
+
 exports.testES6ExportStarFrom = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-export-star-from.js", "utf8");
   TestRun(test)

--- a/tests/unit/fixtures/es6-template-literal-multiline.js
+++ b/tests/unit/fixtures/es6-template-literal-multiline.js
@@ -1,0 +1,5 @@
+function returnMultiLine() {
+  return `<strong>
+    This does not use any interpolation.
+  <strong>`;
+};


### PR DESCRIPTION
I noticed that a function which returns a template literal throws a linting error. I don't think this should be the case. Oddly enough it works properly if you put an interpolated variable ${} in the first line of the literal. The following errors are thrown when I run the attached test case:

```
  [bold]{Line 4, Char 9} Missing semicolon.
  [bold]{Line 6, Char 1} Expected an assignment or function call and instead saw an expression.
  [bold]{Line 7, Char 2} Unnecessary semicolon.
```


@caitp @rwaldron - Do you guys have any pointers of where to look into to fix this?