### PR TITLE
Make 'forin' check recognize negative checks with continue

### DIFF
--- a/tests/unit/fixtures/forin.js
+++ b/tests/unit/fixtures/forin.js
@@ -4,6 +4,52 @@ for (var key in objects) {
   }
 }
 
+for (var key in objects) {
+  if (! objects.hasOwnProperty(key)) {
+    continue;
+  }
+  hey();
+}
+
+// More statements in loop body than just the if
+for (var key in objects) {
+  if (objects.hasOwnProperty(key)) {
+    hey();
+  }
+  hey();
+}
+
+// No continue
+for (var key in objects) {
+  if (! objects.hasOwnProperty(key)) {
+    hey();
+  }
+  hey();
+}
+
+// Nested loops
+for (var key in objects) {
+  if (! objects.hasOwnProperty(key)) {
+    continue;
+  }
+  
+  // No if statement
+  for (var key2 in objects) {
+    hey();
+    
+    for (var key3 in objects) {
+      if (objects.hasOwnProperty(key3)) {
+        // No continue
+        for (var key4 in objects) {
+          if (! objects.hasOwnProperty(key4)) {
+            hey();
+          }
+        }
+      }
+    }
+  }
+}
+
 var hasOwn = Object.prototype.hasOwnProperty;
 
 for (var p in o) {
@@ -25,6 +71,5 @@ for ( key in objects ) { }
 
 // Let's make sure we continue scanning the rest of the file.
 for (key in objects) {
-    hey();
+  hey();
 }
-

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -696,7 +696,11 @@ exports.forin = function (test) {
 
   // Make sure it fails when forin is true
   TestRun(test)
-    .addError(27, msg)
+    .addError(15, msg)
+    .addError(23, msg)
+    .addError(37, msg)
+    .addError(43, msg)
+    .addError(73, msg)
     .test(src, { es3: true, forin: true });
 
   test.done();


### PR DESCRIPTION
This patch modifies the 'forin' check so that it correctly recognizes
negative conditional checks using hasOwnProperty and continue. For example:

``` javascript
for (var key in collection) {
    if (! collection.hasOwnProperty(key)) {
        continue;
    }
    doSomething();
}
```

In addition, the check was also made smarter with respect to the
specific conditional check. If the hasOwnProperty method is called on
the wrong collection (not the one that is being looped over) or the
argument of the hasOwnProperty method is different from the loop variable,
a warning is raised.

References:

```
Closes GH-229
```

Note that this is just a reopening of the former pull request #1627 against the current master.
