### PR TITLE
Add XDomainRequest to browser env too

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -344,6 +344,7 @@ exports.browser = {
   WebSocket            : false,
   window               : false,
   Worker               : false,
+  XDomainRequest       : false,
   XMLHttpRequest       : false,
   XMLSerializer        : false,
   XPathEvaluator       : false,


### PR DESCRIPTION
I think [`XDomainRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XDomainRequest) should be added to the browser environment.

It already is part of the `wsh` environment (see #264), but it might also appear in IE9 compatible code which I wouldn't classify as a `Windows Script Host` environment so using `wsh` in my config feels weird.

I don't know about your policy reagrding vendor-specific features, so feel free to reject this PR. I do think most of us still have to support IE9 when writing browser code though.
