### PR TITLE
Minor refactoring and bug fixes

### DIFF
--- a/tests/cli.js
+++ b/tests/cli.js
@@ -548,6 +548,7 @@ exports.group = {
     var dir = __dirname + "/../examples/";
     sinon.stub(process, "cwd").returns(dir);
 
+    cli.clearCachedFiles();
     cli.interpret([
       "node", "jshint", "file.js", "--exclude=exclude.js"
     ]);


### PR DESCRIPTION
Full title: Minor refactoring and bug fixes: windows end lines, findFileResults cache, export.done

Reason for every line change (the new line numbers are used):
(79) home is undefined (forward referenced) at this point so to improve clarity and maintain functionality I returned undefined.
(85) moved home down in the event it isn't needed
(167) path.join includes path.normalize
(177) moved parent down in the event it isn't needed
(183-184) fixed this oversight in caching, previously if not found it would only cache "C:\file", instead of every step, which wouldn't save much time.
(191-193) added js doc for 2 parameters
(203) the exclude file may now use any type of end lines
(221-278) renamed variables to be more meaningful
(278, 295, 360, 378) fixed bug in pattern: windows uses \r\n also compacted regex
(552-560) added the ability to clear the cache. the tests need to use this now that the cache was corrected
(575-579) force the result of loadIgnores to be mapped, previously only opts.ignores was mapped
(724) passed == null is the same as !passed (any falsy value) thus making the ternary that follows redundant. I don't know the possible values of passed

Concerns:
On line 79 I assume you meant to return null instead of undefined but I'm not sure so I kept the same functionality.
I didn't write a unit test for the end lines and I don't know how well supported the different end lines are.
