### PR TITLE
Allow paren-wrapped function literals with `immed`

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2610,7 +2610,7 @@ var JSHINT = (function () {
     advance(")", this);
     if (state.option.immed && exprs[0] && exprs[0].id === "function") {
       if (state.tokens.next.id !== "(" &&
-        (state.tokens.next.id !== "." || (peek().value !== "call" && peek().value !== "apply"))) {
+        (state.tokens.next.id !== ".")) {
         warning("W068", this);
       }
     }

--- a/tests/unit/fixtures/immed.js
+++ b/tests/unit/fixtures/immed.js
@@ -29,3 +29,9 @@ var g = (function () {
 var h = (function () {
     return;
 }.call(null, true, undefined));
+
+// gh-1737: Necessary wrapping function in parens is marked as unnecessary by
+// the immed option
+var i = (function() {
+    return;
+}).should.not['throw']();


### PR DESCRIPTION
@rwaldron I initially included the test case in a separate file dedicated to this issue in the `tests/unit/fixtures/` directory, but the current placement seems a little more discoverable/less cluttered. Let me know if/where you'd like me to move it!

This should resolve gh-1737

Commit message:

> Function literals must be wrapped in parenthesis if their properties are
> to be accessed. Ensure that this syntax does not trigger warnings when
> the `immed` option is set.
> 
> The native Function prototype may be extended with any arbitrary
> property, making the current property whitelisting approach
> inappropriate.
