### PR TITLE
Added missing comma in .jshintrc

### DIFF
--- a/examples/.jshintrc
+++ b/examples/.jshintrc
@@ -77,7 +77,7 @@
     "prototypejs"   : false,    // Prototype and Scriptaculous
     "qunit"         : false,    // QUnit
     "rhino"         : false,    // Rhino
-    "shelljs"       : false     // ShellJS
+    "shelljs"       : false,     // ShellJS
     "worker"        : false,    // Web Workers
     "wsh"           : false,    // Windows Scripting Host
     "yui"           : false,    // Yahoo User Interface


### PR DESCRIPTION
Just a minor fix in the .jshintrc where there was missing a comma, making the jshint command fail with 
'ERROR: Can't parse config file: /../.jshintrc'
