### PR TITLE
WIP: Parse ES6 ComputedPropertyNames. Fixes gh-1845

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3255,11 +3255,21 @@ var JSHINT = (function () {
 
             expression(10);
           } else {
-            i = propertyName();
-            saveProperty(tag + i, state.tokens.next);
+            if (state.tokens.next.value === "[") {
+              // ComputedPropertyName
+              advance();
+              if (!state.option.esnext) {
+                warning("W119", state.tokens.curr, "computed property names");
+              }
+              i = expression(10);
+              advance("]");
+            } else {
+              i = propertyName();
+              saveProperty(tag + i, state.tokens.next);
 
-            if (typeof i !== "string") {
-              break;
+              if (typeof i !== "string") {
+                break;
+              }
             }
 
             if (state.tokens.next.value === "(") {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3747,6 +3747,39 @@ exports["object short notation: mixed"] = function (test) {
   test.done();
 };
 
+exports["object ComputedPropertyName"] = function (test) {
+  var code = [
+    "function fn(obj) {}",
+    "function p() { return 'key'; }",
+    "var vals = [1];",
+    "var a = 7;",
+    "var o1 = {",
+      "[a++]: true,",
+      "obj: { [a++ + 1]: true },",
+      "[a + 3]() {},",
+      "[p()]: true,",
+      "[vals[0]]: true,",
+      "[(1)]: true,",
+    "};",
+    "fn({ [a / 7]: true });"
+  ];
+
+  TestRun(test).test(code, { esnext: true });
+
+  TestRun(test)
+    .addError(6, "'computed property names' is only available in ES6 (use esnext option).")
+    .addError(7, "'computed property names' is only available in ES6 (use esnext option).")
+    .addError(8, "'concise methods' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(8, "'computed property names' is only available in ES6 (use esnext option).")
+    .addError(9, "'computed property names' is only available in ES6 (use esnext option).")
+    .addError(10, "'computed property names' is only available in ES6 (use esnext option).")
+    .addError(11, "'computed property names' is only available in ES6 (use esnext option).")
+    .addError(13, "'computed property names' is only available in ES6 (use esnext option).")
+  .test(code);
+
+  test.done();
+};
+
 exports["spread & rest operator support"] = function (test) {
   var code = [
     // spread operator


### PR DESCRIPTION
Does not yet do any proper linting of the computed expression, and has no way of determing duplicate
property names. Needs some work, but the basics should be okay I think.

Fixes gh-1845
