### PR TITLE
Don't issue W088 if identifier is found in function scope or global scope

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4037,7 +4037,9 @@ var JSHINT = (function () {
         case "var":
           break;
         default:
-          if (!funct["(blockscope)"].getlabel(state.tokens.next.value))
+          var ident = state.tokens.next.value;
+          if (!funct["(blockscope)"].getlabel(ident) &&
+              !(scope[ident] || {})[ident])
             warning("W088", state.tokens.next, state.tokens.next.value);
         }
         advance();

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4689,3 +4689,35 @@ exports["Ignore strings containing braces within array literal declarations"] = 
   TestRun(test).test("var a = [ '[' ];");
   test.done();
 };
+
+exports["gh-1016: don't issue W088 if identifier is outside of blockscope"] = function (test) {
+  var code = [
+    "var globalKey;",
+    "function x() {",
+    "  var key;",
+    "  var foo = function () {",
+    "      alert(key);",
+    "  };",
+    "  for (key in {}) {",
+    "      foo();",
+    "  }",
+    "  function y() {",
+    "    for (key in {}) {",
+    "      foo();",
+    "    }",
+    "    for (globalKey in {}) {",
+    "      foo();",
+    "    }",
+    "    for (nonKey in {}) {",
+    "      foo();",
+    "    }",
+    "  }",
+    "}"
+  ];
+
+  TestRun(test)
+    .addError(17, "Creating global 'for' variable. Should be 'for (var nonKey ...'.")
+    .test(code);
+
+  test.done();
+};


### PR DESCRIPTION
This is as quick of a hack as I could come up with to fix this, but it seems to work.

(updating momentarily with a test case that W088 is still emit when expected)

Closes #1016
