### PR TITLE
Fix template literals when end backtick immediately follows newline. Fixes gh-1877

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -909,6 +909,8 @@ Lexer.prototype = {
         // TODO: Parse escape sequence, warn about invalid escae sequences
         value += ch;
         this.skip(1);
+      } else if (ch === '`') {
+        break;
       } else {
         // Otherwise, append the value and continue.
         value += ch;

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -775,6 +775,19 @@ exports.testES6TemplateLiteralsUndef = function (test) {
   test.done();
 };
 
+exports.testES6TemplateLiteralMultiline = function (test) {
+  var src = [
+    'let multiline = `',
+    'this string spans',
+    'multiple lines',
+    '`;'
+  ];
+
+  TestRun(test).test(src, { esnext: true });
+
+  test.done();
+};
+
 exports.testES6ExportStarFrom = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-export-star-from.js", "utf8");
   TestRun(test)


### PR DESCRIPTION
Previously, a backtick which immediately followed a newline would be treated
as part of the template text, rather than as a note to stop processing. This
CL corrects this behaviour.

Closes #1877
