### PR TITLE
Unescape identifiers when checking

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4518,7 +4518,7 @@ var JSHINT = (function () {
         unstack: function () {
           _current.variables.filter(function (v) {
             if (v.unused)
-              warning("W098", v.token, v.value);
+              warning("W098", v.token, v.raw_text || v.value);
             if (v.undef)
               isundef(v.funct, "W117", v.token, v.value);
           });
@@ -5002,6 +5002,7 @@ var JSHINT = (function () {
       var warnUnused = function (name, tkn, type, unused_opt) {
         var line = tkn.line;
         var chr  = tkn.from;
+        var raw_name = tkn.raw_text || name;
 
         if (unused_opt === undefined) {
           unused_opt = state.option.unused;
@@ -5019,7 +5020,7 @@ var JSHINT = (function () {
 
         if (unused_opt) {
           if (warnable_types[unused_opt] && warnable_types[unused_opt].indexOf(type) !== -1) {
-            warningAt("W098", line, chr, name);
+            warningAt("W098", line, chr, raw_name);
           }
         }
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -378,6 +378,18 @@ exports.insideEval = function (test) {
   test.done();
 };
 
+exports.escapedEvil = function (test) {
+  var code = [
+    "\\u0065val(\"'test'\");"
+  ];
+
+  TestRun(test)
+    .addError(1, "eval can be harmful.")
+    .test(code, { evil: false });
+
+  test.done();
+};
+
 // Regression test for GH-394.
 exports.noExcOnTooManyUndefined = function (test) {
   var code = 'a(); b();';


### PR DESCRIPTION
Replace escape sequences in identifiers with unescaped codepoints during
processing, such that \u0065val is the same as eval. This helps to prevent
nasty uses of unwanted features from escaping detection.

Identifier tokens now provide a `raw_text` property which access the actual
text of the identifier used in source code. This allows the same error
messages to be reported as previously.

Closes #1885
