### PR TITLE
Don't raise W083 if a function never touches the outer scope

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3678,6 +3678,7 @@ var JSHINT = (function () {
 
   prefix("function", function () {
     var generator = false;
+
     if (state.tokens.next.value === "*") {
       if (!state.option.inESNext()) {
         warning("W119", state.tokens.curr, "function*");
@@ -3685,10 +3686,20 @@ var JSHINT = (function () {
       advance("*");
       generator = true;
     }
+
     var i = optionalidentifier();
-    doFunction(i, undefined, generator);
+    var fn = doFunction(i, undefined, generator);
+
+    function isVariable(name) { return name[0] !== "("; }
+    function isLocal(name) { return fn[name] === "var"; }
+
     if (!state.option.loopfunc && funct["(loopage)"]) {
-      warning("W083");
+      // If the function we just parsed accesses any non-local variables
+      // trigger a warning. Otherwise, the function is safe even within
+      // a loop.
+      if (_.some(fn, function (val, name) { return isVariable(name) && !isLocal(name); })) {
+        warning("W083");
+      }
     }
     return this;
   });
@@ -4067,7 +4078,7 @@ var JSHINT = (function () {
       if (nextop.value === "in" && state.option.forin) {
         if (state.forinifchecks && state.forinifchecks.length > 0) {
           var check = state.forinifchecks.pop();
-          
+
           if (// No if statement or not the first statement in loop body
               s && s.length > 0 && (typeof s[0] !== "object" || s[0].value !== "if") ||
               // Positive if statement is not the only one in loop body
@@ -4077,7 +4088,7 @@ var JSHINT = (function () {
             warning("W089", this);
           }
         }
-        
+
         // Reset the flag in case no if statement was contained in the loop body
         state.forinifcheckneeded = false;
       }

--- a/tests/unit/fixtures/loopfunc.js
+++ b/tests/unit/fixtures/loopfunc.js
@@ -1,11 +1,27 @@
+var v;
+
 while (true) {
-    var x = function () {};
+    var x = function () { return v; };
 }
 
 for (var i = 0; i < 5; i++) {
-    var y = function () {};
+    var y = function () { return v; };
 }
 
 while (true) {
-    function z() {}
+    function z() { return v; }
+}
+
+while (true) {
+  var a = function () { return 0; };
+}
+
+while (true) {
+  var b = function () { return nonExistent; };
+}
+
+function boo(p) {
+  while (true) {
+    var c = function () { return p; };
+  }
 }

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -719,16 +719,18 @@ exports.loopfunc = function (test) {
 
   // By default, not functions are allowed inside loops
   TestRun(test)
-    .addError(2, "Don't make functions within a loop.")
-    .addError(6, "Don't make functions within a loop.")
-    .addError(10, "Function declarations should not be placed in blocks. Use a function " +
+    .addError(4, "Don't make functions within a loop.")
+    .addError(8, "Don't make functions within a loop.")
+    .addError(20, "Don't make functions within a loop.")
+    .addError(25, "Don't make functions within a loop.")
+    .addError(12, "Function declarations should not be placed in blocks. Use a function " +
             "expression or move the statement to the top of the outer function.")
     .test(src, {es3: true});
 
   // When loopfunc is true, only function declaration should fail.
   // Expressions are okay.
   TestRun(test)
-    .addError(10, "Function declarations should not be placed in blocks. Use a function " +
+    .addError(12, "Function declarations should not be placed in blocks. Use a function " +
             "expression or move the statement to the top of the outer function.")
     .test(src, { es3: true, loopfunc: true });
 


### PR DESCRIPTION
**W083** warns you against using functions within loops, however, it generates a lot of false positives. This patch reduces the number of false positives by checking whether functions access non-local variables. If a function uses only its local variables, then it is safe to be used within loops:

``` javascript
for (var i = 0; i < 10; i++) {
  // This is pretty safe and shouldn't generate W083.
  doSomething(function () { console.log("Hello"); });
}
```

The crux of this implementation is in and around the **isNotLocal** function. **doFunction** returns an object representing the function it just parsed. This object has two types of properties: special properties that start with `(` (e.g. `(scope)`) and all the variables used within that function, by name. Each variable has a value that constitutes its type: **global**, **outer**, **var**, etc. We're interested in **var** because it signifies local variables.
