### PR TITLE
Remove unnecessary branch

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2052,33 +2052,6 @@ var JSHINT = (function () {
           warning("W037", state.tokens.curr, v);
           break;
         }
-      } else if (funct["(global)"]) {
-        // The name is not defined in the function.  If we are in the global
-        // scope, then we have an undefined variable.
-        //
-        // Operators typeof and delete do not raise runtime errors even if
-        // the base object of a reference is null so no need to display warning
-        // if we're inside of typeof or delete.
-
-        if (typeof predefined[v] !== "boolean") {
-          // Attempting to subscript a null reference will throw an
-          // error, even within the typeof and delete operators
-          if (!(anonname === "typeof" || anonname === "delete") ||
-            (state.tokens.next && (state.tokens.next.value === "." ||
-              state.tokens.next.value === "["))) {
-
-            // if we're in a list comprehension, variables are declared
-            // locally and used before being defined. So we check
-            // the presence of the given variable in the comp array
-            // before declaring it undefined.
-
-            if (!funct["(comparray)"].check(v)) {
-              isundef(funct, "W117", state.tokens.curr, v);
-            }
-          }
-        }
-
-        note_implied(state.tokens.curr);
       } else {
         // If the name is already defined in the current
         // function, but not as outer, then there is a scope error.
@@ -2107,16 +2080,26 @@ var JSHINT = (function () {
           } else if (typeof s !== "object") {
             // Operators typeof and delete do not raise runtime errors even
             // if the base object of a reference is null so no need to
-            //
             // display warning if we're inside of typeof or delete.
-            // Attempting to subscript a null reference will throw an
-            // error, even within the typeof and delete operators
-            if (!(anonname === "typeof" || anonname === "delete") ||
-              (state.tokens.next &&
-                (state.tokens.next.value === "." || state.tokens.next.value === "["))) {
 
-              isundef(funct, "W117", state.tokens.curr, v);
+            if (typeof predefined[v] !== "boolean") {
+              // Attempting to subscript a null reference will throw an
+              // error, even within the typeof and delete operators
+              if (!(anonname === "typeof" || anonname === "delete") ||
+                (state.tokens.next && (state.tokens.next.value === "." ||
+                  state.tokens.next.value === "["))) {
+
+                // if we're in a list comprehension, variables are declared
+                // locally and used before being defined. So we check
+                // the presence of the given variable in the comp array
+                // before declaring it undefined.
+
+                if (!funct["(comparray)"].check(v)) {
+                  isundef(funct, "W117", state.tokens.curr, v);
+                }
+              }
             }
+
             funct[v] = true;
             note_implied(state.tokens.curr);
           } else {


### PR DESCRIPTION
While researching a solution for gh-1881, I started wondering if these two code paths are redundant. Their implementations actually vary in the following ways:
- In the global scope path:
  - the logic is wrapped in the check: `if (typeof predefined[v] !== "boolean") {`
  - list comprehensions are accounted for
- In the function scope path:
  - `funct[v]` is set to `true`

The difference regarding list comprehensions looks more like an oversight than an intentional distinction. I don't understand the other differences well enough to say either way. The fact that the unit tests continue to pass means that either: (1) this is a valid refactoring or (2) there is an issue with code coverage. I'd appreciate the advice of the maintainers to decide which it is.
