### PR TITLE
Add Symbol, Reflect and System objects to newEcmaIdentifiers. Fixes gh-1539

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2437,6 +2437,11 @@ var JSHINT = (function () {
         case "JSON":
           warning("W053", state.tokens.prev, c.value);
           break;
+        case "Symbol":
+          if (state.option.esnext) {
+            warning("W053", state.tokens.prev, c.value);
+          }
+          break;
         case "Function":
           if (!state.option.evil) {
             warning("W054");

--- a/src/vars.js
+++ b/src/vars.js
@@ -51,7 +51,10 @@ exports.newEcmaIdentifiers = {
   WeakMap : false,
   WeakSet : false,
   Proxy   : false,
-  Promise : false
+  Promise : false,
+  Reflect : false,
+  Symbol  : false,
+  System  : false
 };
 
 // Global variables commonly provided by a web browser environment.

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1671,3 +1671,19 @@ exports.ignoreDelimiters = function (test) {
 
   test.done();
 };
+
+exports.esnextPredefs = function (test) {
+  var code = [
+    '/* global alert: true */',
+    'var mySym = Symbol("name");',
+    'var myBadSym = new Symbol("name");',
+    'alert(Reflect);',
+    'alert(System);'
+  ];
+
+  TestRun(test)
+    .addError(3, "Do not use Symbol as a constructor.")
+    .test(code, { esnext: true, undef: true });
+
+  test.done();
+};


### PR DESCRIPTION
Also warns when using Symbol as a constructor (called with `new`).

Closes #1539
