### PR TITLE
Don't warn on unused exports + Do warn on export declarations outside global scope

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4338,6 +4338,11 @@ var JSHINT = (function () {
       ok = false;
     }
 
+    if (!funct["(global)"] || !funct["(blockscope)"].atTop()) {
+      error("E053", state.tokens.curr);
+      ok = false;
+    }
+
     if (state.tokens.next.value === "*") {
       advance("*");
       advance("from");

--- a/src/messages.js
+++ b/src/messages.js
@@ -67,7 +67,8 @@ var errors = {
   E049: "A {a} cannot be named '{b}'.",
   E050: "Mozilla requires the yield expression to be parenthesized here.",
   E051: "Regular parameters cannot come after default parameters.",
-  E052: "Unclosed template literal."
+  E052: "Unclosed template literal.",
+  E053: "Export declaration must be in global scope."
 };
 
 var warnings = {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4756,3 +4756,47 @@ exports.testES6UnusedExports = function (test) {
 
   test.done();
 };
+
+exports.testES6BlockExports = function (test) {
+  var code = [
+    "var broken = true;",
+    "var broken2 = false;",
+    "function funcScope() {",
+    "  export let exportLet = 42;",
+    "  export var exportVar = 43;",
+    "  export const exportConst = 44;",
+    "  export function exportedFn() {}",
+    "  export {",
+    "    broken,",
+    "    broken2",
+    "  };",
+    "}",
+    "if (true) {",
+    "  export let conditionalExportLet = 42;",
+    "  export var conditionalExportVar = 43;",
+    "  export const conditionalExportConst = 44;",
+    "  export function conditionalExportedFn() {}",
+    "  export {",
+    "    broken,",
+    "    broken2",
+    "  };",
+    "}",
+    "funcScope();"
+  ];
+
+  TestRun(test)
+    .addError(4, "Export declaration must be in global scope.")
+    .addError(5, "Export declaration must be in global scope.")
+    .addError(6, "Export declaration must be in global scope.")
+    .addError(7, "Export declaration must be in global scope.")
+    .addError(8, "Export declaration must be in global scope.")
+    .addError(14, "Export declaration must be in global scope.")
+    .addError(15, "Export declaration must be in global scope.")
+    .addError(16, "Export declaration must be in global scope.")
+    .addError(17, "Export declaration must be in global scope.")
+    .addError(17, "Function declarations should not be placed in blocks. Use a function expression or move the statement to the top of the outer function.")
+    .addError(18, "Export declaration must be in global scope.")
+    .test(code, { esnext: true, unused: true });
+
+  test.done();
+};


### PR DESCRIPTION
It's really two separate bugs, but just one patch! It looks to me like export
declarations outside of "global scope" (or whatever the module scope is), is a
syntax error --- traceur will report it as such, so we should probably throw up on it.
