### PR TITLE
Do not infer anonymous function names

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -53,7 +53,7 @@ var console = require("console-browserify");
 var JSHINT = (function () {
   "use strict";
 
-  var anonname, // The guessed name for anonymous functions.
+  var prevIdentifier, // The value of the most recently parsed identifier
     api, // Extension API
 
     // These are operators that should not be used with the ! operator.
@@ -921,8 +921,8 @@ var JSHINT = (function () {
       break;
     }
 
-    if (state.tokens.curr.type === "(string)" || state.tokens.curr.identifier) {
-      anonname = state.tokens.curr.value;
+    if (state.tokens.curr.identifier) {
+      prevIdentifier = state.tokens.curr.value;
     }
 
     if (id && state.tokens.next.id !== id) {
@@ -1037,7 +1037,6 @@ var JSHINT = (function () {
     advance();
 
     if (initial) {
-      anonname = "anonymous";
       funct["(verb)"] = state.tokens.curr.value;
     }
 
@@ -2093,7 +2092,7 @@ var JSHINT = (function () {
             // display warning if we're inside of typeof or delete.
             // Attempting to subscript a null reference will throw an
             // error, even within the typeof and delete operators
-            if (!(anonname === "typeof" || anonname === "delete") ||
+            if (!(prevIdentifier === "typeof" || prevIdentifier === "delete") ||
               (state.tokens.next &&
                 (state.tokens.next.value === "." || state.tokens.next.value === "["))) {
 
@@ -2970,7 +2969,7 @@ var JSHINT = (function () {
     state.ignored = Object.create(state.ignored);
     scope = Object.create(scope);
 
-    funct = functor(name || "\"" + anonname + "\"", state.tokens.next, scope, {
+    funct = functor(name || "\"anonymous\"", state.tokens.next, scope, {
       "(statement)": statement,
       "(context)":   funct,
       "(generator)": generator ? true : null

--- a/tests/unit/fixtures/nestedFunctions-locations.js
+++ b/tests/unit/fixtures/nestedFunctions-locations.js
@@ -30,7 +30,7 @@
     "lastcharacter": 2
   },
   {
-    "name": "\"e\"",
+    "name": "\"anonymous\"",
     "param": ["x", "y"],
     "line": 16,
     "character": 23,
@@ -66,7 +66,7 @@
     "lastcharacter": 56
   },
   {
-    "name": "\"j\"",
+    "name": "\"anonymous\"",
     "line": 34,
     "character": 19,
     "last": 34,


### PR DESCRIPTION
This patch disables function name inference in the report generated when JSHint is used programatically. As noted in the commit message, I've had to guess at the rationale behind the functionality--it seems like it's there to make the report more informative. @valueof does that sound right to you?

I'm proposing it be removed because:
1. It's semantically inaccurate. An anonymous function is still anonymous even if it is assigned to a variable/property when it is first created.
2. It's prone to bugs, for example, in the report for the code below:
   
   ``` js
   function a() {};
   a(function() {});
   ```
   
     both functions are listed as having the name "a". JSHint must be reporting millions of functions named `then` at the moment :P

An alternative response would be to address edge cases like the example in `#2`, but in light of `#1`, I thought I'd start by proposing removal instead. 

(I've split this into two commits to help facilitate review. The first just adds whitespace to a test file.)
