### PR TITLE
Relax restriction on parens around function exprs

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2625,7 +2625,7 @@ var JSHINT = (function () {
     advance(")", this);
     if (state.option.immed && exprs[0] && exprs[0].id === "function") {
       if (state.tokens.next.id !== "(" &&
-        (state.tokens.next.id !== ".")) {
+        state.tokens.next.id !== "." && state.tokens.next.id !== "[") {
         warning("W068", this);
       }
     }

--- a/tests/unit/fixtures/immed.js
+++ b/tests/unit/fixtures/immed.js
@@ -35,3 +35,5 @@ var h = (function () {
 var i = (function() {
     return;
 }).should.not['throw']();
+
+(function() {})[i ? 'call' : 'apply']();


### PR DESCRIPTION
I have no use case for this feature, real or imagined, but the current behavior is inconsistent.

Commit message:

> Parenthesis are required to dereference anonymous function expressions
> with bracket notation.
