### PR TITLE
Merge similar code paths

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3098,7 +3098,7 @@ var JSHINT = (function () {
 
   (function (x) {
     x.nud = function (isclassdef) {
-      var b, f, i, p, t, g;
+      var b, f, i, p, t, g, nextVal, propDesc;
       var props = {}; // All properties, including accessors
       var tag = "";
 
@@ -3162,8 +3162,9 @@ var JSHINT = (function () {
           tag = "static ";
         }
 
-        if (state.tokens.next.value === "get" && peek().id !== ":") {
-          advance("get");
+        nextVal = state.tokens.next.value;
+        if (peek().id !== ":" && (nextVal === "get" || nextVal === "set")) {
+          advance(nextVal);
 
           if (!state.option.inES5(!isclassdef)) {
             error("E034");
@@ -3181,13 +3182,22 @@ var JSHINT = (function () {
           // It is a Syntax Error if PropName of MethodDefinition is
           // "constructor" and SpecialMethod of MethodDefinition is true.
           if (isclassdef && i === "constructor") {
-            error("E049", state.tokens.next, "class getter method", i);
+            if (nextVal === "get") {
+              propDesc = "class getter method";
+            } else {
+              propDesc = "class setter method";
+            }
+            error("E049", state.tokens.next, propDesc, i);
           }
 
           // We don't want to save this getter unless it's an actual getter
           // and not an ES6 concise method
           if (i) {
-            saveGetter(tag + i);
+            if (nextVal === "get") {
+              saveGetter(tag + i);
+            } else {
+              saveSetter(tag + i, state.tokens.next);
+            }
           }
 
           t = state.tokens.next;
@@ -3195,43 +3205,9 @@ var JSHINT = (function () {
           p = f["(params)"];
 
           // Don't warn about getter/setter pairs if this is an ES6 concise method
-          if (i && p) {
+          if (nextVal === "get" && i && p) {
             warning("W076", t, p[0], i);
-          }
-        } else if (state.tokens.next.value === "set" && peek().id !== ":") {
-          advance("set");
-
-          if (!state.option.inES5(!isclassdef)) {
-            error("E034");
-          }
-
-          i = propertyName();
-
-          // ES6 allows for get() {...} and set() {...} method
-          // definition shorthand syntax, so we don't produce an error
-          // if the esnext option is enabled.
-          if (!i && !state.option.inESNext()) {
-            error("E035");
-          }
-
-          // It is a Syntax Error if PropName of MethodDefinition is
-          // "constructor" and SpecialMethod of MethodDefinition is true.
-          if (isclassdef && i === "constructor") {
-            error("E049", state.tokens.next, "class setter method", i);
-          }
-
-          // We don't want to save this getter unless it's an actual getter
-          // and not an ES6 concise method
-          if (i) {
-            saveSetter(tag + i, state.tokens.next);
-          }
-
-          t = state.tokens.next;
-          f = doFunction();
-          p = f["(params)"];
-
-          // Don't warn about getter/setter pairs if this is an ES6 concise method
-          if (i && (!p || p.length !== 1)) {
+          } else if (nextVal === "set" && i && (!p || p.length !== 1)) {
             warning("W077", t, i);
           }
         } else {


### PR DESCRIPTION
Not trying to be a busy body here: this helps avoid further duplication in name inference logic I'm working on for gh-1893.

> The paths for ES5 "getter" and "setter" attributes share enough code to
> warrant combination.
