### PR TITLE
Make default report machine readable

### DIFF
--- a/src/reporters/default.js
+++ b/src/reporters/default.js
@@ -3,7 +3,7 @@
 module.exports = {
   reporter: function (results, data, opts) {
     var len = results.length;
-    var str = '';
+    var str = "";
     var prevfile;
 
     opts = opts || {};
@@ -17,8 +17,7 @@ module.exports = {
       }
       prevfile = file;
 
-      str += file  + ': line ' + error.line + ', col ' +
-        error.character + ', ' + error.reason;
+      str += file + ":" + error.line + ":" + error.character + ": " + error.reason;
 
       if (opts.verbose) {
         str += ' (' + error.code + ')';


### PR DESCRIPTION
Most preprocessors and compilers use the format
"FILENAME:LINE:COL:MESSAGE" for logging errors to stderr.  This
makes the report machine readable by existing tools.

Also many text editors lets you navigate directly to that location
when activated.
