### PR TITLE
Make object short notation work if there's a linefeed before end

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -899,6 +899,15 @@ var JSHINT = (function () {
     return t;
   }
 
+  function peekIgnoreEOL() {
+    var i = 0;
+    var t;
+    do {
+      t = peek(i++);
+    } while (t.id === "(endline)");
+    return t;
+  }
+
   // Produce the next token. It looks for programming errors.
 
   function advance(id, t) {
@@ -3245,9 +3254,9 @@ var JSHINT = (function () {
           }
           if (!isclassdef &&
               state.tokens.next.identifier &&
-              (peek().id === "," || peek().id === "}")) {
+              (peekIgnoreEOL().id === "," || peekIgnoreEOL().id === "}")) {
             if (!state.option.inESNext()) {
-              warning("W104", state.tokens.curr, "object short notation");
+              warning("W104", state.tokens.next, "object short notation");
             }
             i = propertyName(true);
             saveProperty(tag + i, state.tokens.next);

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3738,14 +3738,20 @@ exports["object short notation: basic"] = function (test) {
   var code = [
     "var foo = 42;",
     "var bar = {foo};",
-    "var baz = {foo, bar};"
+    "var baz = {foo, bar};",
+    "var biz = {",
+    "  foo,",
+    "  bar",
+    "};"
   ];
 
-  TestRun(test).test(code, {esnext: true});
+  TestRun(test, 1).test(code, {esnext: true});
 
-  TestRun(test)
+  TestRun(test, 2)
     .addError(2, "'object short notation' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
     .addError(3, "'object short notation' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(5, "'object short notation' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(6, "'object short notation' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
     .test(code);
 
   test.done();


### PR DESCRIPTION
Should be a quick review, ping @rwaldron / @jugglinmike

Fixes gh-1923
