### PR TITLE
Formal parameter names can be the same as function name. Fixes gh-1928

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -610,7 +610,8 @@ var JSHINT = (function () {
           }
         }
       } else {
-        if ((!state.option.shadow || _.contains([ "inner", "outer" ], state.option.shadow)) &&
+        if (((!state.option.shadow && !opts.param) ||
+            _.contains([ "inner", "outer" ], state.option.shadow)) &&
             type !== "exception" || funct["(blockscope)"].getlabel(name)) {
           warning("W004", state.tokens.next, name);
         }
@@ -2851,13 +2852,13 @@ var JSHINT = (function () {
             continue;
           } else if (curr.value !== ",") {
             params.push(curr.value);
-            addlabel(curr.value, { type: "unused", token: curr });
+            addlabel(curr.value, { type: "unused", token: curr, param: true });
           }
         }
         return params;
       } else {
         if (parsed.identifier === true) {
-          addlabel(parsed.value, { type: "unused", token: parsed });
+          addlabel(parsed.value, { type: "unused", token: parsed, param: true });
           return [parsed];
         }
       }
@@ -2879,7 +2880,7 @@ var JSHINT = (function () {
           t = tokens[t];
           if (t.id) {
             params.push(t.id);
-            addlabel(t.id, { type: "unused", token: t.token });
+            addlabel(t.id, { type: "unused", token: t.token, param: true });
           }
         }
       } else if (state.tokens.next.value === "...") {
@@ -2889,11 +2890,11 @@ var JSHINT = (function () {
         advance("...");
         ident = identifier(true);
         params.push(ident);
-        addlabel(ident, { type: "unused", token: state.tokens.curr });
+        addlabel(ident, { type: "unused", token: state.tokens.curr, param: true });
       } else {
         ident = identifier(true);
         params.push(ident);
-        addlabel(ident, { type: "unused", token: state.tokens.curr });
+        addlabel(ident, { type: "unused", token: state.tokens.curr, param: true });
       }
 
       // it is a syntax error to have a regular argument after a default argument

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4947,3 +4947,17 @@ exports.testStrictDirectiveASI = function (test) {
 
   test.done();
 };
+
+exports.testGH1928 = function (test) {
+  var code = [
+    "var foo = {",
+    "  bar(bar) {",
+    "    return bar;",
+    "  }",
+    "};"
+  ];
+
+  TestRun(test).test(code, { esnext: true });
+
+  test.done();
+};


### PR DESCRIPTION
(I'm not sure how to name this test --- suggestions welcome)
