### PR TITLE
More class linting fixes. Fixes gh-1956

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2203,7 +2203,8 @@ var JSHINT = (function () {
   reservevar("Infinity");
   reservevar("null");
   reservevar("this", function (x) {
-    if (state.directive["use strict"] && !state.option.validthis && ((funct["(statement)"] &&
+    if (state.directive["use strict"] && !isMethod() &&
+        !state.option.validthis && ((funct["(statement)"] &&
         funct["(name)"].charAt(0) > "Z") || funct["(global)"])) {
       warning("W040", x);
     }
@@ -2786,6 +2787,12 @@ var JSHINT = (function () {
   });
 
 
+  function isMethod() {
+    return funct["(statement)"] && funct["(statement)"].type === "class" ||
+           funct["(context)"] && funct["(context)"]["(verb)"] === "class";
+  }
+
+
   function isPropertyName(token) {
     return token.identifier || token.id === "(string)" || token.id === "(number)";
   }
@@ -2813,6 +2820,9 @@ var JSHINT = (function () {
           advance();
         }
       }
+    } else if (typeof id === "object") {
+      if (id.id === "(string)" || id.id === "(identifier)") id = id.value;
+      else if (id.id === "(number)") id = id.value.toString();
     }
 
     if (id === "hasOwnProperty") {
@@ -3650,7 +3660,7 @@ var JSHINT = (function () {
         error("E049", name, "class method", "prototype");
       }
 
-      doFunction(name, c, false, null);
+      doFunction(!computed && propertyName(name), c, false, null);
     }
   }
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4186,6 +4186,28 @@ exports["class and method naming"] = function (test) {
   test.done();
 };
 
+exports["class method this"] = function (test) {
+  var code = [
+  "class C {",
+  "  constructor(x) {",
+  "    this._x = x;",
+  "  }",
+  "  x() { return this._x; }",
+  "  static makeC(x) { return new this(x); }",
+  "  0() { return this._x + 0; }",
+  "  ['foo']() { return this._x + 6; }",
+  "  'test'() { return this._x + 'test'; }",
+  "  bar() { function notCtor() { return this; } notCtor(); }",
+  "}"
+  ];
+
+  TestRun(test)
+    .addError(10, "Possible strict violation.")
+    .test(code, {esnext: true});
+
+  test.done();
+};
+
 exports["test for GH-1018"] = function (test) {
   var code = [
     "if (a = 42) {}",


### PR DESCRIPTION
- Pass function name to doFunction() as a string literal or false, rather than as
  a token.
- Do not emit possible strict violation warnings when `this` is used in a class method.
  (`this` is ordinarily either an instance or the class itself).

Fixes gh-1956
