### PR TITLE
Correct line number reported with "empty block"

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1988,7 +1988,7 @@ var JSHINT = (function () {
     if (!ordinary || !state.option.funcscope) scope = s;
     inblock = b;
     if (ordinary && state.option.noempty && (!a || a.length === 0)) {
-      warning("W035");
+      warning("W035", state.tokens.prev);
     }
     metrics.nestedBlockDepth -= 1;
     return a;

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -305,14 +305,20 @@ exports.curly = function (test) {
 
 /** Option `noempty` prohibits the use of empty blocks. */
 exports.noempty = function (test) {
-  var code = 'for (;;) {}';
+  var code = [
+    "for (;;) {}",
+    "if (true) {",
+    "}",
+    "foo();"
+  ];
 
   // By default, tolerate empty blocks since they are valid JavaScript
   TestRun(test).test(code, { es3: true });
 
   // Do not tolerate, when noempty is true
   TestRun(test)
-    .addError(1, 'Empty block.')
+    .addError(1, "Empty block.")
+    .addError(2, "Empty block.")
     .test(code, { es3: true, noempty: true });
 
   test.done();


### PR DESCRIPTION
Ensure the warning references the line of the opening brace of the block
body.

Resolves gh-1700
