### PR TITLE
Don't delete lines following lex'd `ignore:end`. Fixes gh-1879

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -358,6 +358,7 @@ Lexer.prototype = {
     var rest = this.input.substr(2);
     var startLine = this.line;
     var startChar = this.char;
+    var self = this;
 
     // Create a comment token object and make sure it
     // has all the data JSHint needs to work with special
@@ -412,6 +413,24 @@ Lexer.prototype = {
           commentType = "globals";
           break;
         default:
+          var options = body.split(":").map(function(v) {
+            return v.replace(/^\s+/, "").replace(/\s+$/, "");
+          });
+
+          if (options.length === 2) {
+            switch (options[0]) {
+            case "ignore":
+              switch (options[1]) {
+              case "start":
+                self.ignoringLinterErrors = true;
+                break;
+              case "end":
+                self.ignoringLinterErrors = false;
+                break;
+              }
+            }
+          }
+
           commentType = str;
         }
       });
@@ -1437,7 +1456,7 @@ Lexer.prototype = {
 
     // If we are ignoring linter errors, replace the input with empty string
     // if it doesn't already at least start or end a multi-line comment
-    if (state.ignoreLinterErrors === true) {
+    if (this.ignoringLinterErrors === true) {
       if (!startsWith("/*", "//") && !endsWith("*/")) {
         this.input = "";
       }

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4947,3 +4947,19 @@ exports.testStrictDirectiveASI = function (test) {
 
   test.done();
 };
+
+exports.testGH1879 = function (test) {
+  var code = [
+    "function Foo() {",
+    "  return;",
+    "  // jshint ignore:start",
+    "  return [];",
+    "  // jshint ignore:end",
+    "}"
+  ];
+
+  TestRun(test)
+    .test(code);
+
+  test.done();
+};


### PR DESCRIPTION
Previously, lines would be cleared (set to the empty string) even after `ignore:end`
is found, if the comment was not processed first.

This change performs some minor comment processing in the lexer itself in order to
solve this problem.

This is a hack, ideas are welcome.

Closes #1879