### PR TITLE
Intl global in ECMAScript Internationalization API 1.0 (ECMA-402)

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -145,6 +145,7 @@ exports.browser = {
   HTMLVideoElement     : false,
   history              : false,
   Image                : false,
+  Intl                 : false,
   length               : false,
   localStorage         : false,
   location             : false,


### PR DESCRIPTION
Intl is now a standard global for browsers, defined in:
http://www.ecma-international.org/ecma-402/1.0/#sec-8

It's supported by all major browsers except Safari:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl

…and Safari plans to add it:
https://bugs.webkit.org/show_bug.cgi?id=90906
