### PR TITLE
Improve function name inference

### DIFF
--- a/src/name-stack.js
+++ b/src/name-stack.js
@@ -1,0 +1,74 @@
+"use strict";
+
+function NameStack() {
+  this._stack = [];
+}
+
+Object.defineProperty(NameStack.prototype, "length", {
+  get: function() {
+    return this._stack.length;
+  }
+});
+
+/**
+ * Create a new entry in the stack. Useful for tracking names across
+ * expressions.
+ */
+NameStack.prototype.push = function() {
+  this._stack.push(null);
+};
+
+/**
+ * Discard the most recently-created name on the stack.
+ */
+NameStack.prototype.pop = function() {
+  this._stack.pop();
+};
+
+/**
+ * Update the most recent name on the top of the stack.
+ *
+ * @param {object} token The token to consider as the source for the most
+ *                       recent name.
+ */
+NameStack.prototype.set = function(token) {
+  this._stack[this.length - 1] = token;
+};
+
+/**
+ * Generate a string representation of the most recent name.
+ *
+ * @returns {string}
+ */
+NameStack.prototype.infer = function() {
+  var nameToken = this._stack[this.length - 1];
+  var prefix = "";
+  var type;
+
+  // During expected operation, the topmost entry on the stack will only
+  // reflect the current function's name when the function is declared without
+  // the `function` keyword (i.e. for in-line accessor methods). In other
+  // cases, the `function` expression itself will introduce an empty entry on
+  // the top of the stack, and this should be ignored.
+  if (!nameToken || nameToken.type === "class") {
+    nameToken = this._stack[this.length - 2];
+  }
+
+  if (!nameToken) {
+    return "(empty)";
+  }
+
+  type = nameToken.type;
+
+  if (type !== "(string)" && type !== "(number)" && type !== "(identifier)" && type !== "default") {
+    return "(expression)";
+  }
+
+  if (nameToken.accessorType) {
+    prefix = nameToken.accessorType + " ";
+  }
+
+  return prefix + nameToken.value;
+};
+
+module.exports = NameStack;

--- a/src/state.js
+++ b/src/state.js
@@ -1,4 +1,5 @@
 "use strict";
+var NameStack = require("./name-stack.js");
 
 var state = {
   syntax: {},
@@ -19,6 +20,7 @@ var state = {
     this.tab = "";
     this.cache = {}; // Node.JS doesn't have Map. Sniff.
     this.ignoredLines = {};
+    this.nameStack = new NameStack();
 
     // Blank out non-multi-line-commented lines when ignoring linter errors
     this.ignoreLinterErrors = false;

--- a/tests/unit/fixtures/nestedFunctions-locations.js
+++ b/tests/unit/fixtures/nestedFunctions-locations.js
@@ -35,7 +35,7 @@
     "lastcharacter": 2
   },
   {
-    "name": "\"e\"",
+    "name": "e",
     "param": [
       "x",
       "y"
@@ -53,7 +53,7 @@
     "lastcharacter": 2
   },
   {
-    "name": "\"anonymous\"",
+    "name": "(empty)",
     "line": 24,
     "character": 16,
     "last": 26,
@@ -74,10 +74,164 @@
     "lastcharacter": 56
   },
   {
-    "name": "\"j\"",
+    "name": "j",
     "line": 34,
     "character": 19,
     "last": 34,
     "lastcharacter": 36
+  },
+  {
+    "name": "k",
+    "line": 35,
+    "character": 20,
+    "last": 35,
+    "lastcharacter": 24
+  },
+  {
+    "name": "23",
+    "line": 36,
+    "character": 18,
+    "last": 36,
+    "lastcharacter": 22
+  },
+  {
+    "name": "computedStr",
+    "line": 37,
+    "character": 32,
+    "last": 37,
+    "lastcharacter": 36
+  },
+  {
+    "name": "(expression)",
+    "line": 38,
+    "character": 33,
+    "last": 38,
+    "lastcharacter": 37
+  },
+  {
+    "name": "get getter",
+    "line": 39,
+    "character": 16,
+    "last": 39,
+    "lastcharacter": 20
+  },
+  {
+    "name": "set setter",
+    "line": 40,
+    "character": 16,
+    "last": 40,
+    "lastcharacter": 20
+  },
+  {
+    "name": "(empty)",
+    "line": 43,
+    "character": 17,
+    "last": 43,
+    "lastcharacter": 21
+  },
+  {
+    "name": "(empty)",
+    "line": 48,
+    "character": 27,
+    "last": 48,
+    "lastcharacter": 31
+  },
+  {
+    "name": "(empty)",
+    "line": 50,
+    "character": 37,
+    "last": 50,
+    "lastcharacter": 41
+  },
+  {
+    "name": "(empty)",
+    "line": 52,
+    "character": 13,
+    "last": 52,
+    "lastcharacter": 53
+  },
+  {
+    "name": "l",
+    "line": 52,
+    "character": 34,
+    "last": 52,
+    "lastcharacter": 38
+  },
+  {
+    "name": "(expression)",
+    "line": 52,
+    "character": 69,
+    "last": 52,
+    "lastcharacter": 73
+  },
+  {
+    "name": "viaDot",
+    "line": 54,
+    "character": 21,
+    "last": 54,
+    "lastcharacter": 25
+  },
+  {
+    "name": "viaBracket",
+    "line": 56,
+    "character": 28,
+    "last": 56,
+    "lastcharacter": 32
+  },
+  {
+    "name": "(expression)",
+    "line": 57,
+    "character": 37,
+    "last": 57,
+    "lastcharacter": 41
+  },
+  {
+    "name": "VarDeclClass",
+    "line": 65,
+    "character": 15,
+    "last": 65,
+    "lastcharacter": 19
+  },
+  {
+    "name": "func",
+    "line": 66,
+    "character": 15,
+    "last": 66,
+    "lastcharacter": 19
+  },
+  {
+    "name": "method",
+    "line": 67,
+    "character": 10,
+    "last": 67,
+    "lastcharacter": 14
+  },
+  {
+    "name": "get getter",
+    "line": 68,
+    "character": 14,
+    "last": 68,
+    "lastcharacter": 18
+  },
+  {
+    "name": "set setter",
+    "line": 69,
+    "character": 14,
+    "last": 69,
+    "lastcharacter": 18
+  },
+  {
+    "name": "(empty)",
+    "line": 72,
+    "character": 26,
+    "last": 72,
+    "lastcharacter": 30
+  },
+  {
+    "name": "default",
+    "line": 74,
+    "character": 25,
+    "last": 74,
+    "lastcharacter": 29
   }
 ]

--- a/tests/unit/fixtures/nestedFunctions.js
+++ b/tests/unit/fixtures/nestedFunctions.js
@@ -31,5 +31,44 @@ function g() { return function h     () { return 1+1; };}
 
 // function in object
 var i = {
-	j : function () { return 1+1; }
+	j : function () { return 1+1; },
+	"k" : function() {},
+	23: function() {},
+	["computedStr"] : function() {},
+	["computed" + 3] : function() {},
+	get getter() {},
+	set setter() {}
 };
+
+g.then(function() {});
+
+var unrelated;
+
+// Inferred name values should not extend beyond assignment operations.
+unrelated = {}, (function() {})();
+
+unrelated.unrelated = {}, (function() {})();
+
+g[(function() { var l = function() {}; return l(); }())] = function() {};
+
+g.viaDot = function() {};
+
+g["viaBracket"] = function() {};
+g["expr" + g + "ession"] = function() {};
+
+var VarDeclClass = class {
+  /**
+   * A constructor method is effectively a reference to the class to which it
+   * belongs. This means its name should be reported as the name of the class
+   * itself.
+   */
+  constructor() {}                 // "VarDeclClass"
+  static func() {}                 // "func"
+  method() {}                      // "method"
+  get getter() {}                  // "get getter"
+  set setter() {}                  // "set setter"
+};
+
+var grouping = (function() {});
+
+export default function() {}


### PR DESCRIPTION
When used programmatically from Node.js, [JSHint exposes a `data` function that returns an object with a `functions` key](https://github.com/jshint/jshint/blob/d0b3cfd935c9445f14b37ea9694d8a172a52739a/src/jshint.js#L5307-L5391). This data describes the functions defined in the linted code. Currently, JSHint uses a simple heuristic to infer the name of functions, and this is often incorrect.

In gh-1893, I proposed removing JSHint's function name inference because I believed the `name` property of function to be well-defined by the ECMAScript 5 spec. [I was wrong about that](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name), but @caitp [showed me how the ES6 spec strictly defines what it means for a function to have a name](https://github.com/jshint/jshint/pull/1893#issuecomment-58914855). This patch mimics much of the behavior defined by the specification.

A notable omission is names that are computed from expressions. For instance, the function in the following example should receive the name "Gozer the Traveler":

``` javascript
var name = "Gozer the Traveler";
var obj = {};
obj[name] = function() {};
```

...but this behavior cannot be replicated statically. Instead, such functions are reported as having the name `"(expression)"`.
