### PR TITLE
Add AppVeyor testing for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ JSHint, A Static Code Analysis Tool for JavaScript
 [Blog](http://jshint.com/blog/) • [Twitter](https://twitter.com/jshint/) \]
 
 [![Build Status](https://travis-ci.org/jshint/jshint.svg?branch=master)](https://travis-ci.org/jshint/jshint)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/h3nsbuegaes4aakt/branch/appveyor?svg=true)](https://ci.appveyor.com/project/XhmikosR/jshint/branch/appveyor)
 [![NPM version](https://badge.fury.io/js/jshint.svg)](http://badge.fury.io/js/jshint)
 
 JSHint is a community-driven tool to detect errors and potential problems

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: "{build}"
+
+environment:
+  matrix:
+    - nodejs_version: 0.10
+
+install:
+  - npm install
+
+build: off
+
+test_script:
+  - node --version && npm --version
+  - npm test
+
+# uncomment the following lines after tests pass
+#cache:
+#  - node_modules                                        # local npm modules
+#  - C:\Users\appveyor\AppData\Roaming\npm\node_modules  # global npm modules


### PR DESCRIPTION
Things we need before merging
- [ ] Someone should add JSHint in AppVeyor themselves and should post the badge code so that I update the patch.
- [ ] Enable cache for the npm modules; this requires the build to pass first to actually have an effect, see #1931 too.

Example: https://ci.appveyor.com/project/XhmikosR/jshint

/CC @caitp @jugglinmike @rwaldron
