### PR TITLE
Improve null-reference-accepting operators

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -931,10 +931,6 @@ var JSHINT = (function () {
       break;
     }
 
-    if (state.tokens.curr.identifier) {
-      state.prevIdentifier = state.tokens.curr;
-    }
-
     if (id && state.tokens.next.id !== id) {
       if (t) {
         if (state.tokens.next.id === "(end)") {
@@ -2038,7 +2034,6 @@ var JSHINT = (function () {
       var s = scope[v];
       var f;
       var block;
-      var prevIdentifier;
 
       if (typeof s === "function") {
         // Protection against accidental inheritance.
@@ -2103,25 +2098,13 @@ var JSHINT = (function () {
             warning("W039", state.tokens.curr, v);
             note_implied(state.tokens.curr);
           } else if (typeof s !== "object") {
-            // Operators typeof and delete do not raise runtime errors even
-            // if the base object of a reference is null so no need to
-            //
-            // display warning if we're inside of typeof or delete.
-            // Attempting to subscript a null reference will throw an
-            // error, even within the typeof and delete operators
-            prevIdentifier = state.prevIdentifier && state.prevIdentifier.value;
-            if (!(prevIdentifier === "typeof" || prevIdentifier === "delete") ||
-              (state.tokens.next &&
-                (state.tokens.next.value === "." || state.tokens.next.value === "["))) {
+            // if we're in a list comprehension, variables are declared
+            // locally and used before being defined. So we check
+            // the presence of the given variable in the comp array
+            // before declaring it undefined.
 
-              // if we're in a list comprehension, variables are declared
-              // locally and used before being defined. So we check
-              // the presence of the given variable in the comp array
-              // before declaring it undefined.
-
-              if (!funct["(comparray)"].check(v)) {
-                isundef(funct, "W117", state.tokens.curr, v);
-              }
+            if (!funct["(comparray)"].check(v)) {
+              isundef(funct, "W117", state.tokens.curr, v);
             }
 
             // Explicitly mark the variable as used within function scopes
@@ -2399,6 +2382,12 @@ var JSHINT = (function () {
       warning("W051");
     }
     this.first = p;
+
+    // The `delete` operator accepts unresolvable references when not in strict
+    // mode, so the operand may be undefined.
+    if (p.identifier && !state.directive["use strict"]) {
+      p.forgiveUndef = true;
+    }
     return this;
   }).exps = true;
 
@@ -2435,7 +2424,17 @@ var JSHINT = (function () {
     return this;
   });
 
-  prefix("typeof", "typeof");
+  prefix("typeof", (function () {
+    var p = expression(150);
+    this.first = p;
+
+    // The `typeof` operator accepts unresolvable references, so the operand
+    // may be undefined.
+    if (p.identifier) {
+      p.forgiveUndef = true;
+    }
+    return this;
+  }));
   prefix("new", function () {
     var c = expression(155), i;
     if (c && c.id !== "function") {
@@ -5235,7 +5234,7 @@ var JSHINT = (function () {
       for (i = 0; i < JSHINT.undefs.length; i += 1) {
         k = JSHINT.undefs[i].slice(0);
 
-        if (markDefined(k[2].value, k[0])) {
+        if (markDefined(k[2].value, k[0]) || k[2].forgiveUndef) {
           clearImplied(k[2].value, k[2].line);
         } else if (state.option.undef) {
           warning.apply(warning, k.slice(1));

--- a/tests/unit/fixtures/undef.js
+++ b/tests/unit/fixtures/undef.js
@@ -22,3 +22,13 @@ var fn = function () {
         delete localUndef.attr;
     }
 };
+
+// Extraneous grouping operators will not cause a warning
+if (typeof(undef)) {}
+if (typeof((undef))) {}
+
+// Any other expression that includes the null reference should trigger an
+// error
+if (typeof undef()) {}
+if (typeof +undef) {}
+if (typeof(undef, 0)) {}

--- a/tests/unit/fixtures/unused.js
+++ b/tests/unit/fixtures/unused.js
@@ -41,3 +41,14 @@ function bazbaz() {
 }
 
 bazbaz();
+
+// GH-1881 "jshint considers user delete() function as keyword, not function,
+// yields 'function not used' for argument"
+var c = {};
+c.typeof(hoistedTypeof);
+c.delete(hoistedDelete);
+
+// These functions should be recognized as "in use" even though they are being
+// passed to methods that look like unresolvable-reference-accepting operators.
+function hoistedDelete() {}
+function hoistedTypeof() {}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -529,6 +529,9 @@ exports.undef = function (test) {
     .addError(19, "'localUndef' is not defined.")
     .addError(21, "'localUndef' is not defined.")
     .addError(22, "'localUndef' is not defined.")
+    .addError(32, "'undef' is not defined.")
+    .addError(33, "'undef' is not defined.")
+    .addError(34, "'undef' is not defined.")
     .test(src, { es3: true, undef: true });
 
   // Regression test for GH-668.
@@ -538,6 +541,44 @@ exports.undef = function (test) {
 
   test.ok(JSHINT(src));
   test.ok(!JSHINT.data().implieds);
+
+  JSHINT("if (typeof foobar) {}", { undef: true });
+  test.ok(!JSHINT.data().implieds);
+
+  test.done();
+};
+
+exports.undefToOpMethods = function (test) {
+  TestRun(test)
+    .addError(2, "'undef' is not defined.")
+    .addError(3, "'undef' is not defined.")
+    .test([
+      "var obj;",
+      "obj.delete(undef);",
+      "obj.typeof(undef);"
+    ], { undef: true });
+
+  test.done();
+};
+
+/**
+ * In strict mode, the `delete` operator does not accept unresolvable
+ * references:
+ *
+ * http://es5.github.io/#x11.4.1
+ *
+ * This will only be apparent in cases where the user has suppressed warnings
+ * about deleting variables.
+ */
+exports.undefDeleteStrict = function (test) {
+  TestRun(test)
+    .addError(3, "'aNullReference' is not defined.")
+    .test([
+      "(function() {",
+      "  'use strict';",
+      "  delete aNullReference;",
+      "}());"
+    ], { undef: true, "-W051": false });
 
   test.done();
 };


### PR DESCRIPTION
Operators `typeof` and `delete` both accept null references, so JSHint
should not warn when their sole operand is a undefined variable, nor
should that identifier be included in the `implieds` array of the
generated report.

A runtime error will occur if the operand is an expression containing
the undefined identifier, so a warning should be issued in this case.

This patch also addresses an existing bug where property identifiers
with values "typeof" or "delete" were incorrectly interpreted as unary
operators when marking variables as unused.

Resolves gh-1881
