### PR TITLE
Support escaped backticks in template literals

### DIFF
--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -773,9 +773,10 @@ exports.testES6ModulesNameSpaceImportsAffectUnused = function (test) {
 exports.testES6TemplateLiterals = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-template-literal.js", "utf8");
   TestRun(test)
-    .addError(11, "Unclosed template literal.")
-    .addError(12, "Expected an identifier and instead saw '(end)'.")
-    .addError(12, "Missing semicolon.")
+    .addError(14, "Octal literals are not allowed in strict mode.")
+    .addError(17, "Unclosed template literal.")
+    .addError(18, "Expected an identifier and instead saw '(end)'.")
+    .addError(18, "Missing semicolon.")
     .test(src, { esnext: true });
   test.done();
 };

--- a/tests/unit/fixtures/es6-template-literal.js
+++ b/tests/unit/fixtures/es6-template-literal.js
@@ -8,4 +8,10 @@ can`;
 
 var escaped = `one = \`${one}\``;
 
+function octal_strictmode() {
+  "use strict";
+
+  var test = `\033\t`;
+}
+
 var unterminated = `${one}

--- a/tests/unit/fixtures/strings.js
+++ b/tests/unit/fixtures/strings.js
@@ -17,6 +17,8 @@ this is a faulty multiline string in javascript";
 
 test = "\033\t";
 
+test = "unnecessary \` escaping";
+
 function octal_strictmode() {
   "use strict";
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1174,7 +1174,8 @@ exports.strings = function (test) {
     .addError(9, "Unclosed string.")
     .addError(10, "Unclosed string.")
     .addError(15, "Unclosed string.")
-    .addError(23, "Octal literals are not allowed in strict mode.")
+    .addError(20, "Bad or unnecessary escaping.")
+    .addError(25, "Octal literals are not allowed in strict mode.")
     .test(src, { es3: true, multistr: true });
 
   TestRun(test)
@@ -1184,7 +1185,8 @@ exports.strings = function (test) {
     .addError(10, "Unclosed string.")
     .addError(14, "Bad escaping of EOL. Use option multistr if needed.")
     .addError(15, "Unclosed string.")
-    .addError(23, "Octal literals are not allowed in strict mode.")
+    .addError(20, "Bad or unnecessary escaping.")
+    .addError(25, "Octal literals are not allowed in strict mode.")
     .test(src, { es3: true });
 
   test.done();


### PR DESCRIPTION
This is a totally valid use but since the lexer just looks for the next
backtick as a marker for the end of the literal, things fall apart
quickly.

I added this use to the fixture, as well as one for literals without templates... just in case.
