### PR TITLE
Fix error in tests on Windows

### DIFF
--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1164,12 +1164,12 @@ exports.useStdin = {
     var jshintrc = JSON.stringify({ undef: true });
 
     sinon.stub(shjs, "cat")
-      .withArgs(sinon.match(/\/fake\/\.jshintrc$/)).returns(jshintrc)
+      .withArgs(sinon.match(/[\/\\]fake[\/\\]\.jshintrc$/)).returns(jshintrc)
       .withArgs(sinon.match(/\/\.jshintrc$/)).returns("")
       .withArgs(sinon.match(/\.jshintignore$/)).returns("");
 
     sinon.stub(shjs, "test")
-      .withArgs("-e", sinon.match(/fake\/\.jshintrc$/)).returns(true)
+      .withArgs("-e", sinon.match(/fake[\/\\]\.jshintrc$/)).returns(true)
       .withArgs("-e", sinon.match(/\.jshintrc$/)).returns(false);
 
     cli.exit.restore();
@@ -1223,7 +1223,7 @@ exports.useStdin = {
       .withArgs(sinon.match(/\.jshintignore$/)).returns("");
 
     sinon.stub(shjs, "test")
-      .withArgs("-e", sinon.match(/fake\/\.jshintrc$/)).returns(true)
+      .withArgs("-e", sinon.match(/fake[\/\\]\.jshintrc$/)).returns(true)
       .withArgs("-e", sinon.match(/\.jshintrc$/)).returns(true);
 
     cli.exit.restore();


### PR DESCRIPTION
I've confirmed this fix on a local VM, but this pull request should be a good test for [our shiny new AppVeyor integration](https://github.com/jshint/jshint/pull/1991).

> Stubbed paths must account for platform differences in separator
> characters.
> 
> Resolves gh-1931
