### PR TITLE
Fix browserified jshint version. Fixes #1993

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,7 +4,7 @@
 "use strict";
 
 var browserify = require("browserify");
-var bundle     = browserify("./src/jshint.js");
+var bundle     = browserify();
 var path       = require("path");
 var version    = require("../package.json").version;
 require("shelljs/make");


### PR DESCRIPTION
Previously `./src/jshint.js` file was referenced twice: in `browserify("./src/jshint.js")` and `bundle.require(srcDir + "/jshint.js", { expose: "jshint" })`
