### PR TITLE
Removed "test: " from test titles. Fixes #1952

### DIFF
--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -790,7 +790,7 @@ exports.testHtml = function (test) {
   test.done();
 };
 
-exports["test: destructuring var in function scope"] = function (test) {
+exports["destructuring var in function scope"] = function (test) {
   var code = [
     "function foobar() {",
     "  var [ a, b, c ] = [ 1, 2, 3 ];",
@@ -846,7 +846,7 @@ exports["test: destructuring var in function scope"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring var as moz"] = function (test) {
+exports["destructuring var as moz"] = function (test) {
   var code = [
     "var [ a, b, c ] = [ 1, 2, 3 ];",
     "var [ a ] = [ 1 ];",
@@ -873,7 +873,7 @@ exports["test: destructuring var as moz"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring var as esnext"] = function (test) {
+exports["destructuring var as esnext"] = function (test) {
   var code = [
     "var [ a, b, c ] = [ 1, 2, 3 ];",
     "var [ a ] = [ 1 ];",
@@ -900,7 +900,7 @@ exports["test: destructuring var as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring var as es5"] = function (test) {
+exports["destructuring var as es5"] = function (test) {
   var code = [
     "var [ a, b, c ] = [ 1, 2, 3 ];",
     "var [ a ] = [ 1 ];",
@@ -938,7 +938,7 @@ exports["test: destructuring var as es5"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring var as legacy JS"] = function (test) {
+exports["destructuring var as legacy JS"] = function (test) {
   var code = [
     "var [ a, b, c ] = [ 1, 2, 3 ];",
     "var [ a ] = [ 1 ];",
@@ -976,7 +976,7 @@ exports["test: destructuring var as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring var errors"] = function (test) {
+exports["destructuring var errors"] = function (test) {
   var code = [
     "var [ a, b, c ] = [ 1, 2, 3 ];",
     "var [ a ] = [ 1 ];",
@@ -1016,7 +1016,7 @@ exports["test: destructuring var errors"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring const as moz"] = function (test) {
+exports["destructuring const as moz"] = function (test) {
   var code = [
     "const [ a, b, c ] = [ 1, 2, 3 ];",
     "const [ d ] = [ 1 ];",
@@ -1054,7 +1054,7 @@ exports["test: destructuring const as moz"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring const as esnext"] = function (test) {
+exports["destructuring const as esnext"] = function (test) {
   var code = [
     "const [ a, b, c ] = [ 1, 2, 3 ];",
     "const [ d ] = [ 1 ];",
@@ -1088,7 +1088,7 @@ exports["test: destructuring const as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring const as es5"] = function (test) {
+exports["destructuring const as es5"] = function (test) {
   var code = [
     "const [ a, b, c ] = [ 1, 2, 3 ];",
     "const [ d ] = [ 1 ];",
@@ -1140,7 +1140,7 @@ exports["test: destructuring const as es5"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring const as legacy JS"] = function (test) {
+exports["destructuring const as legacy JS"] = function (test) {
   var code = [
     "const [ a, b, c ] = [ 1, 2, 3 ];",
     "const [ d ] = [ 1 ];",
@@ -1192,7 +1192,7 @@ exports["test: destructuring const as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring const errors"] = function (test) {
+exports["destructuring const errors"] = function (test) {
   var code = [
     "const [ a, b, c ] = [ 1, 2, 3 ];",
     "const [ a, b, c ] = [ 1, 2, 3 ];",
@@ -1229,7 +1229,7 @@ exports["test: destructuring const errors"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring globals as moz"] = function (test) {
+exports["destructuring globals as moz"] = function (test) {
   var code = [
     "var a, b, c, d, h, w, o;",
     "[ a, b, c ] = [ 1, 2, 3 ];",
@@ -1248,7 +1248,7 @@ exports["test: destructuring globals as moz"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring globals as esnext"] = function (test) {
+exports["destructuring globals as esnext"] = function (test) {
   var code = [
     "var a, b, c, d, h, w, o;",
     "[ a, b, c ] = [ 1, 2, 3 ];",
@@ -1267,7 +1267,7 @@ exports["test: destructuring globals as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring globals as es5"] = function (test) {
+exports["destructuring globals as es5"] = function (test) {
   var code = [
     "var a, b, c, d, h, w, o;",
     "[ a, b, c ] = [ 1, 2, 3 ];",
@@ -1293,7 +1293,7 @@ exports["test: destructuring globals as es5"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring globals as legacy JS"] = function (test) {
+exports["destructuring globals as legacy JS"] = function (test) {
   var code = [
     "var a, b, c, d, h, w, o;",
     "[ a, b, c ] = [ 1, 2, 3 ];",
@@ -1319,7 +1319,7 @@ exports["test: destructuring globals as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring globals with syntax error"] = function (test) {
+exports["destructuring globals with syntax error"] = function (test) {
   var code = [
     "var a, b, c;",
     "[ a ] = [ z ];",
@@ -1356,7 +1356,7 @@ exports["test: destructuring globals with syntax error"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring assign of empty values as moz"] = function (test) {
+exports["destructuring assign of empty values as moz"] = function (test) {
   var code = [
     "var [ a ] = [ 1, 2 ];",
     "var [ c, d ] = [ 1 ];",
@@ -1374,7 +1374,7 @@ exports["test: destructuring assign of empty values as moz"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring assign of empty values as esnext"] = function (test) {
+exports["destructuring assign of empty values as esnext"] = function (test) {
   var code = [
     "var [ a ] = [ 1, 2 ];",
     "var [ c, d ] = [ 1 ];",
@@ -1392,7 +1392,7 @@ exports["test: destructuring assign of empty values as esnext"] = function (test
   test.done();
 };
 
-exports["test: destructuring assign of empty values as es5"] = function (test) {
+exports["destructuring assign of empty values as es5"] = function (test) {
   var code = [
     "var [ a ] = [ 1, 2 ];",
     "var [ c, d ] = [ 1 ];",
@@ -1413,7 +1413,7 @@ exports["test: destructuring assign of empty values as es5"] = function (test) {
   test.done();
 };
 
-exports["test: destructuring assign of empty values as JS legacy"] = function (test) {
+exports["destructuring assign of empty values as JS legacy"] = function (test) {
   var code = [
     "var [ a ] = [ 1, 2 ];",
     "var [ c, d ] = [ 1 ];",
@@ -1435,7 +1435,7 @@ exports["test: destructuring assign of empty values as JS legacy"] = function (t
   test.done();
 };
 
-exports["test: array element assignment inside array"] = function (test) {
+exports["array element assignment inside array"] = function (test) {
   var code = [
     "var a1 = {};",
     "var a2 = [function f() {a1[0] = 1;}];",
@@ -1447,7 +1447,7 @@ exports["test: array element assignment inside array"] = function (test) {
   test.done();
 };
 
-exports["test: let statement as moz"] = function (test) {
+exports["let statement as moz"] = function (test) {
   var code = [
     "let x = 1;",
     "{",
@@ -1467,7 +1467,7 @@ exports["test: let statement as moz"] = function (test) {
   test.done();
 };
 
-exports["test: let statement as esnext"] = function (test) {
+exports["let statement as esnext"] = function (test) {
   var code = [
     "let x = 1;",
     "{",
@@ -1487,7 +1487,7 @@ exports["test: let statement as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: let statement as es5"] = function (test) {
+exports["let statement as es5"] = function (test) {
   var code = [
     "let x = 1;",
     "{",
@@ -1510,7 +1510,7 @@ exports["test: let statement as es5"] = function (test) {
   test.done();
 };
 
-exports["test: let statement as legacy JS"] = function (test) {
+exports["let statement as legacy JS"] = function (test) {
   var code = [
     "let x = 1;",
     "{",
@@ -1533,7 +1533,7 @@ exports["test: let statement as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: let statement out of scope as moz"] = function (test) {
+exports["let statement out of scope as moz"] = function (test) {
   var code = [
     "let x = 1;",
     "{",
@@ -1557,7 +1557,7 @@ exports["test: let statement out of scope as moz"] = function (test) {
   test.done();
 };
 
-exports["test: let statement out of scope as esnext"] = function (test) {
+exports["let statement out of scope as esnext"] = function (test) {
   var code = [
     "let x = 1;",
     "{",
@@ -1581,7 +1581,7 @@ exports["test: let statement out of scope as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: let statement out of scope as es5"] = function (test) {
+exports["let statement out of scope as es5"] = function (test) {
   var code = [
     "let x = 1;",
     "{",
@@ -1608,7 +1608,7 @@ exports["test: let statement out of scope as es5"] = function (test) {
   test.done();
 };
 
-exports["test: let statement out of scope as legacy JS"] = function (test) {
+exports["let statement out of scope as legacy JS"] = function (test) {
   var code = [
     "let x = 1;",
     "{",
@@ -1635,7 +1635,7 @@ exports["test: let statement out of scope as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: let statement in functions as moz"] = function (test) {
+exports["let statement in functions as moz"] = function (test) {
   var code = [
     "let x = 1;",
     "function foo() {",
@@ -1657,7 +1657,7 @@ exports["test: let statement in functions as moz"] = function (test) {
   test.done();
 };
 
-exports["test: let statement in functions as esnext"] = function (test) {
+exports["let statement in functions as esnext"] = function (test) {
   var code = [
     "let x = 1;",
     "function foo() {",
@@ -1679,7 +1679,7 @@ exports["test: let statement in functions as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: let statement in functions as es5"] = function (test) {
+exports["let statement in functions as es5"] = function (test) {
   var code = [
     "let x = 1;",
     "function foo() {",
@@ -1704,7 +1704,7 @@ exports["test: let statement in functions as es5"] = function (test) {
   test.done();
 };
 
-exports["test: let statement in functions as legacy JS"] = function (test) {
+exports["let statement in functions as legacy JS"] = function (test) {
   var code = [
     "let x = 1;",
     "function foo() {",
@@ -1729,7 +1729,7 @@ exports["test: let statement in functions as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: let statement not in scope as moz"] = function (test) {
+exports["let statement not in scope as moz"] = function (test) {
   var code = [
     "let x = 1;",
     "function foo() {",
@@ -1757,7 +1757,7 @@ exports["test: let statement not in scope as moz"] = function (test) {
   test.done();
 };
 
-exports["test: let statement not in scope as esnext"] = function (test) {
+exports["let statement not in scope as esnext"] = function (test) {
   var code = [
     "let x = 1;",
     "function foo() {",
@@ -1785,39 +1785,7 @@ exports["test: let statement not in scope as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: let statement not in scope as es5"] = function (test) {
-  var code = [
-    "let x = 1;",
-    "function foo() {",
-    "  let y = 3 ;",
-    "  let bar = function () {",
-    "    print(x);",
-    "    let z = 2;",
-    "  };",
-    "  print(z);",
-    "}",
-    "print(y);",
-    "bar();",
-    "foo();",
-  ];
-
-  TestRun(test)
-    .addError(1, "'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
-    .addError(3, "'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
-    .addError(4, "'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
-    .addError(6, "'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
-    .addError(6, "'z' is defined but never used.")
-    .addError(3, "'y' is defined but never used.")
-    .addError(4, "'bar' is defined but never used.")
-    .addError(8, "'z' is not defined.")
-    .addError(10, "'y' is not defined.")
-    .addError(11, "'bar' is not defined.")
-    .test(code, {unused: true, undef: true, predef: ["print"]}); // es5
-
-  test.done();
-};
-
-exports["test: let statement not in scope as legacy JS"] = function (test) {
+exports["let statement not in scope as es5"] = function (test) {
   var code = [
     "let x = 1;",
     "function foo() {",
@@ -1844,12 +1812,44 @@ exports["test: let statement not in scope as legacy JS"] = function (test) {
     .addError(8, "'z' is not defined.")
     .addError(10, "'y' is not defined.")
     .addError(11, "'bar' is not defined.")
+    .test(code, {unused: true, undef: true, predef: ["print"]}); // es5
+
+  test.done();
+};
+
+exports["let statement not in scope as legacy JS"] = function (test) {
+  var code = [
+    "let x = 1;",
+    "function foo() {",
+    "  let y = 3 ;",
+    "  let bar = function () {",
+    "    print(x);",
+    "    let z = 2;",
+    "  };",
+    "  print(z);",
+    "}",
+    "print(y);",
+    "bar();",
+    "foo();",
+  ];
+
+  TestRun(test)
+    .addError(1, "'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(3, "'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(4, "'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(6, "'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(6, "'z' is defined but never used.")
+    .addError(3, "'y' is defined but never used.")
+    .addError(4, "'bar' is defined but never used.")
+    .addError(8, "'z' is not defined.")
+    .addError(10, "'y' is not defined.")
+    .addError(11, "'bar' is not defined.")
     .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
 
-exports["test: let statement in for loop as moz"] = function (test) {
+exports["let statement in for loop as moz"] = function (test) {
   var code = [
     "var obj={foo: 'bar', bar: 'foo'};",
     "for ( let [n, v] in Iterator(obj) ) {",
@@ -1875,7 +1875,7 @@ exports["test: let statement in for loop as moz"] = function (test) {
   test.done();
 };
 
-exports["test: let statement in for loop as esnext"] = function (test) {
+exports["let statement in for loop as esnext"] = function (test) {
   var code = [
     "var obj={foo: 'bar', bar: 'foo'};",
     "for ( let [n, v] in Iterator(obj) ) {",
@@ -1901,7 +1901,7 @@ exports["test: let statement in for loop as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: let statement in for loop as es5"] = function (test) {
+exports["let statement in for loop as es5"] = function (test) {
   var code = [
     "var obj={foo: 'bar', bar: 'foo'};",
     "for ( let [n, v] in Iterator(obj) ) {",
@@ -1933,7 +1933,7 @@ exports["test: let statement in for loop as es5"] = function (test) {
   test.done();
 };
 
-exports["test: let statement in for loop as legacy JS"] = function (test) {
+exports["let statement in for loop as legacy JS"] = function (test) {
   var code = [
     "var obj={foo: 'bar', bar: 'foo'};",
     "for ( let [n, v] in Iterator(obj) ) {",
@@ -1965,7 +1965,7 @@ exports["test: let statement in for loop as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: let statement in destructured for loop as moz"] = function (test) {
+exports["let statement in destructured for loop as moz"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "var people = [",
@@ -2000,7 +2000,7 @@ exports["test: let statement in destructured for loop as moz"] = function (test)
   test.done();
 };
 
-exports["test: let statement in destructured for loop as esnext"] = function (test) {
+exports["let statement in destructured for loop as esnext"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "var people = [",
@@ -2035,7 +2035,7 @@ exports["test: let statement in destructured for loop as esnext"] = function (te
   test.done();
 };
 
-exports["test: let statement in destructured for loop as es5"] = function (test) {
+exports["let statement in destructured for loop as es5"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "var people = [",
@@ -2071,7 +2071,7 @@ exports["test: let statement in destructured for loop as es5"] = function (test)
   test.done();
 };
 
-exports["test: let statement in destructured for loop as legacy JS"] = function (test) {
+exports["let statement in destructured for loop as legacy JS"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "var people = [",
@@ -2107,7 +2107,7 @@ exports["test: let statement in destructured for loop as legacy JS"] = function 
   test.done();
 };
 
-exports["test: let statement (as seen in jetpack)"] = function (test) {
+exports["let statement (as seen in jetpack)"] = function (test) {
   // Example taken from jetpack/addons sdk library from Mozilla project
   var code = [
     "const { Cc, Ci } = require('chrome');",
@@ -2131,7 +2131,7 @@ exports["test: let statement (as seen in jetpack)"] = function (test) {
   test.done();
 };
 
-exports["test: let statement (as seen in jetpack) as esnext"] = function (test) {
+exports["let statement (as seen in jetpack) as esnext"] = function (test) {
   // Example taken from jetpack/addons sdk library from Mozilla project
   var code = [
     "const { Cc, Ci } = require('chrome');",
@@ -2156,7 +2156,7 @@ exports["test: let statement (as seen in jetpack) as esnext"] = function (test) 
   test.done();
 };
 
-exports["test: let statement (as seen in jetpack) as es5"] = function (test) {
+exports["let statement (as seen in jetpack) as es5"] = function (test) {
   // Example taken from jetpack/addons sdk library from Mozilla project
   var code = [
     "const { Cc, Ci } = require('chrome');",
@@ -2184,7 +2184,7 @@ exports["test: let statement (as seen in jetpack) as es5"] = function (test) {
   test.done();
 };
 
-exports["test: let statement (as seen in jetpack) as legacy JS"] = function (test) {
+exports["let statement (as seen in jetpack) as legacy JS"] = function (test) {
   // Example taken from jetpack/addons sdk library from Mozilla project
   var code = [
     "const { Cc, Ci } = require('chrome');",
@@ -2212,7 +2212,7 @@ exports["test: let statement (as seen in jetpack) as legacy JS"] = function (tes
   test.done();
 };
 
-exports["test: let block and let expression"] = function (test) {
+exports["let block and let expression"] = function (test) {
   // Example taken from jetpack/addons sdk library from Mozilla project
   var code = [
     "let (x=1, y=2, z=3)",
@@ -2227,7 +2227,7 @@ exports["test: let block and let expression"] = function (test) {
   test.done();
 };
 
-exports["test: let block and let expression as esnext"] = function (test) {
+exports["let block and let expression as esnext"] = function (test) {
   // Example taken from jetpack/addons sdk library from Mozilla project
   var code = [
     "let (x=1, y=2, z=3)",
@@ -2246,7 +2246,7 @@ exports["test: let block and let expression as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: let block and let expression as es5"] = function (test) {
+exports["let block and let expression as es5"] = function (test) {
   // Example taken from jetpack/addons sdk library from Mozilla project
   var code = [
     "let (x=1, y=2, z=3)",
@@ -2268,7 +2268,7 @@ exports["test: let block and let expression as es5"] = function (test) {
   test.done();
 };
 
-exports["test: let block and let expression as legacy JS"] = function (test) {
+exports["let block and let expression as legacy JS"] = function (test) {
   // Example taken from jetpack/addons sdk library from Mozilla project
   var code = [
     "let (x=1, y=2, z=3)",
@@ -2424,7 +2424,7 @@ exports["test destructuring function as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: invalid for each"] = function (test) {
+exports["invalid for each"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "for each (let i = 0; i<15; ++i) {",
@@ -2439,7 +2439,7 @@ exports["test: invalid for each"] = function (test) {
   test.done();
 };
 
-exports["test: invalid for each as esnext"] = function (test) {
+exports["invalid for each as esnext"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "for each (let i = 0; i<15; ++i) {",
@@ -2455,7 +2455,7 @@ exports["test: invalid for each as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: invalid for each as ES5"] = function (test) {
+exports["invalid for each as ES5"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "for each (let i = 0; i<15; ++i) {",
@@ -2472,7 +2472,7 @@ exports["test: invalid for each as ES5"] = function (test) {
   test.done();
 };
 
-exports["test: invalid for each as legacy JS"] = function (test) {
+exports["invalid for each as legacy JS"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "for each (let i = 0; i<15; ++i) {",
@@ -2488,7 +2488,7 @@ exports["test: invalid for each as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: esnext generator"] = function (test) {
+exports["esnext generator"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function* fib() {",
@@ -2509,7 +2509,7 @@ exports["test: esnext generator"] = function (test) {
   test.done();
 };
 
-exports["test: esnext generator as moz extension"] = function (test) {
+exports["esnext generator as moz extension"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function* fib() {",
@@ -2531,7 +2531,7 @@ exports["test: esnext generator as moz extension"] = function (test) {
   test.done();
 };
 
-exports["test: esnext generator as es5"] = function (test) {
+exports["esnext generator as es5"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function* fib() {",
@@ -2555,7 +2555,7 @@ exports["test: esnext generator as es5"] = function (test) {
   test.done();
 };
 
-exports["test: esnext generator as legacy JS"] = function (test) {
+exports["esnext generator as legacy JS"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function* fib() {",
@@ -2579,7 +2579,7 @@ exports["test: esnext generator as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: esnext generator without yield"] = function (test) {
+exports["esnext generator without yield"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function* fib() {",
@@ -2601,7 +2601,7 @@ exports["test: esnext generator without yield"] = function (test) {
   test.done();
 };
 
-exports["test: esnext generator without yield and check turned off"] = function (test) {
+exports["esnext generator without yield and check turned off"] = function (test) {
   var code = [
     "function* emptyGenerator() {}",
 
@@ -2613,7 +2613,7 @@ exports["test: esnext generator without yield and check turned off"] = function 
   test.done();
 };
 
-exports["test: esnext generator with yield delegation, gh-1544"] = function(test) {
+exports["esnext generator with yield delegation, gh-1544"] = function(test) {
   var code = [
     "function* G() {",
     "  yield* (function*(){})();",
@@ -2633,7 +2633,7 @@ exports["test: esnext generator with yield delegation, gh-1544"] = function(test
   test.done();
 };
 
-exports["test: mozilla generator"] = function (test) {
+exports["mozilla generator"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function fib() {",
@@ -2653,7 +2653,7 @@ exports["test: mozilla generator"] = function (test) {
   test.done();
 };
 
-exports["test: mozilla generator as esnext"] = function (test) {
+exports["mozilla generator as esnext"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function fib() {",
@@ -2675,7 +2675,7 @@ exports["test: mozilla generator as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: yield statement within try-catch"] = function (test) {
+exports["yield statement within try-catch"] = function (test) {
   // see issue: https://github.com/jshint/jshint/issues/1505
   var code = [
     "function* fib() {",
@@ -2695,7 +2695,7 @@ exports["test: yield statement within try-catch"] = function (test) {
   test.done();
 };
 
-exports["test: mozilla generator as es5"] = function (test) {
+exports["mozilla generator as es5"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function fib() {",
@@ -2718,7 +2718,7 @@ exports["test: mozilla generator as es5"] = function (test) {
   test.done();
 };
 
-exports["test: mozilla generator as legacy JS"] = function (test) {
+exports["mozilla generator as legacy JS"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function fib() {",
@@ -2741,7 +2741,7 @@ exports["test: mozilla generator as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: array comprehension"] = function (test) {
+exports["array comprehension"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function *range(begin, end) {",
@@ -2783,7 +2783,7 @@ exports["gh-1856 mistakenly identified as array comprehension"] = function (test
   test.done();
 };
 
-exports["test: moz-style array comprehension"] = function (test) {
+exports["moz-style array comprehension"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function range(begin, end) {",
@@ -2802,7 +2802,7 @@ exports["test: moz-style array comprehension"] = function (test) {
   test.done();
 };
 
-exports["test: array comprehension with for..of"] = function (test) {
+exports["array comprehension with for..of"] = function (test) {
   // example adapted from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function *range(begin, end) {",
@@ -2821,7 +2821,7 @@ exports["test: array comprehension with for..of"] = function (test) {
   test.done();
 };
 
-exports["test: moz-style array comprehension with for..of"] = function (test) {
+exports["moz-style array comprehension with for..of"] = function (test) {
   // example adapted from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function range(begin, end) {",
@@ -2840,7 +2840,7 @@ exports["test: moz-style array comprehension with for..of"] = function (test) {
   test.done();
 };
 
-exports["test: array comprehension with unused variables"] = function (test) {
+exports["array comprehension with unused variables"] = function (test) {
   var code = [
     "var ret = [for (i of unknown) i];",
     "print('ret:', ret);",
@@ -2852,7 +2852,7 @@ exports["test: array comprehension with unused variables"] = function (test) {
   test.done();
 };
 
-exports["test: moz-style array comprehension with unused variables"] = function (test) {
+exports["moz-style array comprehension with unused variables"] = function (test) {
   var code = [
     "var ret = [i for (i of unknown)];",
     "print('ret:', ret);",
@@ -2864,7 +2864,7 @@ exports["test: moz-style array comprehension with unused variables"] = function 
   test.done();
 };
 
-exports["test: moz-style array comprehension as esnext"] = function (test) {
+exports["moz-style array comprehension as esnext"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function range(begin, end) {",
@@ -2889,7 +2889,7 @@ exports["test: moz-style array comprehension as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: array comprehension as es5"] = function (test) {
+exports["array comprehension as es5"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function *range(begin, end) {",
@@ -2915,7 +2915,7 @@ exports["test: array comprehension as es5"] = function (test) {
   test.done();
 };
 
-exports["test: moz-style array comprehension as es5"] = function (test) {
+exports["moz-style array comprehension as es5"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function range(begin, end) {",
@@ -2944,7 +2944,7 @@ exports["test: moz-style array comprehension as es5"] = function (test) {
   test.done();
 };
 
-exports["test: array comprehension as legacy JS"] = function (test) {
+exports["array comprehension as legacy JS"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function range(begin, end) {",
@@ -2969,7 +2969,7 @@ exports["test: array comprehension as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: moz-style array comprehension as legacy JS"] = function (test) {
+exports["moz-style array comprehension as legacy JS"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [
     "function range(begin, end) {",
@@ -2998,7 +2998,7 @@ exports["test: moz-style array comprehension as legacy JS"] = function (test) {
   test.done();
 };
 
-exports['test: array comprehension with dest array at global scope'] = function (test) {
+exports['array comprehension with dest array at global scope'] = function (test) {
   var code = [
     "[for ([i, j] of [[0,0], [1,1], [2,2]]) [i, j] ];",
     "var destarray_comparray_1 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, [j, j] ]];",
@@ -3010,7 +3010,7 @@ exports['test: array comprehension with dest array at global scope'] = function 
   test.done();
 };
 
-exports['test: moz-style array comprehension with dest array at global scope'] = function (test) {
+exports['moz-style array comprehension with dest array at global scope'] = function (test) {
   var code = [
     "[ [i, j] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
     "var destarray_comparray_1 = [ [i, [j, j] ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
@@ -3022,7 +3022,7 @@ exports['test: moz-style array comprehension with dest array at global scope'] =
   test.done();
 };
 
-exports['test: moz-style array comprehension with dest array at global scope as esnext'] = function (test) {
+exports['moz-style array comprehension with dest array at global scope as esnext'] = function (test) {
   var code = [
     "[ [i, j] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
     "var destarray_comparray_1 = [ [i, [j, j] ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
@@ -3040,7 +3040,7 @@ exports['test: moz-style array comprehension with dest array at global scope as 
   test.done();
 };
 
-exports['test: array comprehension with dest array at global scope as es5'] = function (test) {
+exports['array comprehension with dest array at global scope as es5'] = function (test) {
   var code = [
     "[for ([i, j] of [[0,0], [1,1], [2,2]]) [i, j] ];",
     "var destarray_comparray_1 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, [j, j] ] ];",
@@ -3058,7 +3058,7 @@ exports['test: array comprehension with dest array at global scope as es5'] = fu
   test.done();
 };
 
-exports['test: moz-style array comprehension with dest array at global scope as es5'] = function (test) {
+exports['moz-style array comprehension with dest array at global scope as es5'] = function (test) {
   var code = [
     "[ [i, j] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
     "var destarray_comparray_1 = [ [i, [j, j] ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
@@ -3082,7 +3082,7 @@ exports['test: moz-style array comprehension with dest array at global scope as 
   test.done();
 };
 
-exports['test: array comprehension with dest array at global scope as JS legacy'] = function (test) {
+exports['array comprehension with dest array at global scope as JS legacy'] = function (test) {
   var code = [
     "[for ([i, j] of [[0,0], [1,1], [2,2]]) [i, j] ];",
     "var destarray_comparray_1 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, [j, j] ] ];",
@@ -3100,7 +3100,7 @@ exports['test: array comprehension with dest array at global scope as JS legacy'
   test.done();
 };
 
-exports['test: moz-style array comprehension with dest array at global scope as JS legacy'] = function (test) {
+exports['moz-style array comprehension with dest array at global scope as JS legacy'] = function (test) {
   var code = [
     "[ [i, j] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
     "var destarray_comparray_1 = [ [i, [j, j] ] for each ([i, j] in [[0,0], [1,1], [2,2]])];",
@@ -3124,7 +3124,7 @@ exports['test: moz-style array comprehension with dest array at global scope as 
   test.done();
 };
 
-exports["test: array comprehension imbrication with dest array"] = function (test) {
+exports["array comprehension imbrication with dest array"] = function (test) {
   var code = [
     "[for ([i, j] of [for ([a, b] of [[2,2], [3,4]]) [a, b] ]) [i, j] ];"
   ];
@@ -3135,7 +3135,7 @@ exports["test: array comprehension imbrication with dest array"] = function (tes
   test.done();
 };
 
-exports["test: moz-style array comprehension imbrication with dest array"] = function (test) {
+exports["moz-style array comprehension imbrication with dest array"] = function (test) {
   var code = [
     "[ [i, j] for ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
   ];
@@ -3146,7 +3146,7 @@ exports["test: moz-style array comprehension imbrication with dest array"] = fun
   test.done();
 };
 
-exports["test: moz-style array comprehension imbrication with dest array using for..of"] = function (test) {
+exports["moz-style array comprehension imbrication with dest array using for..of"] = function (test) {
   var code = [
     "[ [i, j] for ([i, j] of [[a, b] for ([a, b] of [[2,2], [3,4]])]) ];"
   ];
@@ -3157,7 +3157,7 @@ exports["test: moz-style array comprehension imbrication with dest array using f
   test.done();
 };
 
-exports["test: moz-style array comprehension imbrication with dest array as esnext"] = function (test) {
+exports["moz-style array comprehension imbrication with dest array as esnext"] = function (test) {
   var code = [
     "[ [i, j] for each ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
   ];
@@ -3169,7 +3169,7 @@ exports["test: moz-style array comprehension imbrication with dest array as esne
   test.done();
 };
 
-exports["test: array comprehension imbrication with dest array as es5"] = function (test) {
+exports["array comprehension imbrication with dest array as es5"] = function (test) {
   var code = [
     "[for ([i, j] of [for ([a, b] of [[2,2], [3,4]]) [a, b] ]) [i, j] ];"
   ];
@@ -3183,7 +3183,7 @@ exports["test: array comprehension imbrication with dest array as es5"] = functi
   test.done();
 };
 
-exports["test: moz-style array comprehension imbrication with dest array as es5"] = function (test) {
+exports["moz-style array comprehension imbrication with dest array as es5"] = function (test) {
   var code = [
     "[for ([i, j] of [for ([a, b] of [[2,2], [3,4]]) [a, b] ]) [i, j] ];"
   ];
@@ -3197,7 +3197,7 @@ exports["test: moz-style array comprehension imbrication with dest array as es5"
   test.done();
 };
 
-exports["test: array comprehension imbrication with dest array as legacy JS"] = function (test) {
+exports["array comprehension imbrication with dest array as legacy JS"] = function (test) {
   var code = [
     "[ [i, j] for each ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
 
@@ -3215,7 +3215,7 @@ exports["test: array comprehension imbrication with dest array as legacy JS"] = 
   test.done();
 };
 
-exports["test: moz-style array comprehension imbrication with dest array as legacy JS"] = function (test) {
+exports["moz-style array comprehension imbrication with dest array as legacy JS"] = function (test) {
   var code = [
     "[ [i, j] for each ([i, j] in [[a, b] for each ([a, b] in [[2,2], [3,4]])]) ];"
 
@@ -3233,7 +3233,7 @@ exports["test: moz-style array comprehension imbrication with dest array as lega
   test.done();
 };
 
-exports["test: no false positive array comprehension"] = function (test) {
+exports["no false positive array comprehension"] = function (test) {
   var code = [
     "var foo = []; for (let i in [1,2,3]) { print(i); }"
   ];
@@ -3309,7 +3309,7 @@ exports["try catch filters as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: function closure expression"] = function (test) {
+exports["function closure expression"] = function (test) {
   var code = [
     "let (arr = [1,2,3]) {",
     "  arr.every(function (o) o instanceof Object);",
@@ -3321,7 +3321,7 @@ exports["test: function closure expression"] = function (test) {
   test.done();
 };
 
-exports["test: function closure expression as esnext"] = function (test) {
+exports["function closure expression as esnext"] = function (test) {
   var code = [
     "var arr = [1,2,3];",
     "arr.every(function (o) o instanceof Object);",
@@ -3334,7 +3334,7 @@ exports["test: function closure expression as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: function closure expression as es5"] = function (test) {
+exports["function closure expression as es5"] = function (test) {
   var code = [
     "var arr = [1,2,3];",
     "arr.every(function (o) o instanceof Object);",
@@ -3347,7 +3347,7 @@ exports["test: function closure expression as es5"] = function (test) {
   test.done();
 };
 
-exports["test: function closure expression as legacy JS"] = function (test) {
+exports["function closure expression as legacy JS"] = function (test) {
   var code = [
     "var arr = [1,2,3];",
     "arr.every(function (o) o instanceof Object);",
@@ -3360,7 +3360,7 @@ exports["test: function closure expression as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: for of as esnext"] = function (test) {
+exports["for of as esnext"] = function (test) {
   var code = [
     "for (let x of [1,2,3,4]) {",
     "    print(x);",
@@ -3373,7 +3373,7 @@ exports["test: for of as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: for of as es5"] = function (test) {
+exports["for of as es5"] = function (test) {
   var code = [
     "for (let x of [1,2,3,4]) {",
     "    print(x);",
@@ -3390,7 +3390,7 @@ exports["test: for of as es5"] = function (test) {
   test.done();
 };
 
-exports["test: for of as legacy JS"] = function (test) {
+exports["for of as legacy JS"] = function (test) {
   var code = [
     "for (let x of [1,2,3,4]) {",
     "    print(x);",
@@ -3407,7 +3407,7 @@ exports["test: for of as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: try multi-catch for moz extensions"] = function (test) {
+exports["try multi-catch for moz extensions"] = function (test) {
   var code = [
     "try {",
     "    print('X');",
@@ -3425,7 +3425,7 @@ exports["test: try multi-catch for moz extensions"] = function (test) {
   test.done();
 };
 
-exports["test: try multi-catch as esnext"] = function (test) {
+exports["try multi-catch as esnext"] = function (test) {
   var code = [
     "try {",
     "    print('X');",
@@ -3445,7 +3445,7 @@ exports["test: try multi-catch as esnext"] = function (test) {
   test.done();
 };
 
-exports["test: try multi-catch as es5"] = function (test) {
+exports["try multi-catch as es5"] = function (test) {
   var code = [
     "try {",
     "    print('X');",
@@ -3465,7 +3465,7 @@ exports["test: try multi-catch as es5"] = function (test) {
   test.done();
 };
 
-exports["test: try multi-catch as legacy JS"] = function (test) {
+exports["try multi-catch as legacy JS"] = function (test) {
   var code = [
     "try {",
     "    print('X');",
@@ -3486,7 +3486,7 @@ exports["test: try multi-catch as legacy JS"] = function (test) {
   test.done();
 };
 
-exports["test: no let not directly within a block"] = function (test) {
+exports["no let not directly within a block"] = function (test) {
   var code = [
     "if (true) let x = 1;",
     "function foo() {",


### PR DESCRIPTION
Many of the unit tests had title beginning with "test: ". This creates
useless noise in the test output because we already know each line is
the result of test.

This commit removes these prefixes.
