### PR TITLE
Fix bug in "unreachable" warning

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -261,7 +261,6 @@ var JSHINT = (function () {
     lex,
     member,
     membersOnly,
-    noreach,
     predefined,    // Global variables defined by option
 
     scope,  // The current scope
@@ -1632,9 +1631,9 @@ var JSHINT = (function () {
   }
 
 
-  function reachable(s) {
+  function reachable(controlToken) {
     var i = 0, t;
-    if (state.tokens.next.id !== ";" || noreach) {
+    if (state.tokens.next.id !== ";" || controlToken.inBracelessBlock) {
       return;
     }
     for (;;) {
@@ -1654,7 +1653,7 @@ var JSHINT = (function () {
           break;
         }
 
-        warning("W027", t, t.value, s);
+        warning("W027", t, t.value, controlToken.value);
         break;
       }
     }
@@ -1972,12 +1971,11 @@ var JSHINT = (function () {
         warning("W116", state.tokens.next, "{", state.tokens.next.value);
       }
 
-      noreach = true;
+      state.tokens.next.inBracelessBlock = true;
       indent += state.option.indent;
       // test indentation only if statement is in new line
       a = [statement()];
       indent -= state.option.indent;
-      noreach = false;
 
       delete funct["(nolet)"];
     }
@@ -4228,7 +4226,9 @@ var JSHINT = (function () {
         advance();
       }
     }
-    reachable("break");
+
+    reachable(this);
+
     return this;
   }).exps = true;
 
@@ -4255,7 +4255,9 @@ var JSHINT = (function () {
     } else if (!funct["(loopage)"]) {
       warning("W052", state.tokens.next, this.value);
     }
-    reachable("continue");
+
+    reachable(this);
+
     return this;
   }).exps = true;
 
@@ -4277,7 +4279,9 @@ var JSHINT = (function () {
         nolinebreak(this); // always warn (Line breaking error)
       }
     }
-    reachable("return");
+
+    reachable(this);
+
     return this;
   }).exps = true;
 
@@ -4329,7 +4333,9 @@ var JSHINT = (function () {
   stmt("throw", function () {
     nolinebreak(this);
     this.first = expression(20);
-    reachable("throw");
+
+    reachable(this);
+
     return this;
   }).exps = true;
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4583,6 +4583,25 @@ exports.unreachable = {
       .test(src);
 
     test.done();
+  },
+  // Regression test for GH-1387 "false positive: Unreachable 'x' after 'return'"
+  nestedBraceless: function (test) {
+    var src = [
+      "(function() {",
+      "  var x;",
+      "  if (!x)",
+      "    return function() {",
+      "      if (!x) x = 0;",
+      "      return;",
+      "    };",
+      "  return;",
+      "}());"
+    ];
+
+    TestRun(test)
+      .test(src);
+
+    test.done();
   }
 };
 


### PR DESCRIPTION
While working on GH-1387, I found that the project has no tests for W027. The first commit adds some basic tests, and the second commit (message below) addresses the bug.

> Ensure that when braceless block bodies contain braceless block bodies
> (as is possible when the single statement has a function expression),
> the parser correctly differentiates between branches when detecting
> unreachable statements.
> 
> Achieve this by using a token decorator attribute (which is local to the
> statement) instead of a global variable (which cannot account for
> nesting).
> 
> Resolves GH-1387
