### PR TITLE
Fix bug in parsing of concise method names

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3250,7 +3250,7 @@ var JSHINT = (function () {
               if (!state.option.inESNext()) {
                 warning("W104", state.tokens.curr, "concise methods");
               }
-              doFunction(i, undefined, g);
+              doFunction(null, undefined, g);
             } else {
               advance(":");
               expression(10);

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3778,6 +3778,20 @@ conciseMethods.getWithoutSet = function (test) {
   test.done();
 };
 
+// GH-2022: "Concise method names are colliding with params/variables"
+conciseMethods.nameIsNotLocalVar = function (test) {
+  var code = [
+    "var obj = {",
+    "  foo(foo) {},",
+    "  bar() { var bar; }",
+    "};"
+  ];
+
+  TestRun(test).test(code, {esnext: true});
+
+  test.done();
+};
+
 exports["object short notation: basic"] = function (test) {
   var code = [
     "var foo = 42;",


### PR DESCRIPTION
I started by doing a little house keeping around unit test organization. The bug fix itself is in the second commit:

> When the ES6 concise method syntax is used to declare a method, no new
> entry is created in the local environment record. Because of this, the
> method name should _not_ be interpreted as a local variable, and
> declaring a variable of that name should raise no warnings.
> 
> Resolves gh-2022
