### PR TITLE
Revert "Formal parameter names can be the same as function name. Fixes g...

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -447,8 +447,7 @@ var JSHINT = (function () {
           }
         }
       } else {
-        if (((!state.option.shadow && !opts.param) ||
-            _.contains([ "inner", "outer" ], state.option.shadow)) &&
+        if ((!state.option.shadow || _.contains([ "inner", "outer" ], state.option.shadow)) &&
             type !== "exception" || funct["(blockscope)"].getlabel(name)) {
           warning("W004", state.tokens.next, name);
         }
@@ -2736,7 +2735,7 @@ var JSHINT = (function () {
           t = tokens[t];
           if (t.id) {
             params.push(t.id);
-            addlabel(t.id, { type: "unused", token: t.token, param: true });
+            addlabel(t.id, { type: "unused", token: t.token });
           }
         }
       } else if (state.tokens.next.value === "...") {
@@ -2746,11 +2745,11 @@ var JSHINT = (function () {
         advance("...");
         ident = identifier(true);
         params.push(ident);
-        addlabel(ident, { type: "unused", token: state.tokens.curr, param: true });
+        addlabel(ident, { type: "unused", token: state.tokens.curr });
       } else {
         ident = identifier(true);
         params.push(ident);
-        addlabel(ident, { type: "unused", token: state.tokens.curr, param: true });
+        addlabel(ident, { type: "unused", token: state.tokens.curr });
       }
 
       // it is a syntax error to have a regular argument after a default argument

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5136,17 +5136,3 @@ exports.testStrictDirectiveASI = function (test) {
 
   test.done();
 };
-
-exports.testGH1928 = function (test) {
-  var code = [
-    "var foo = {",
-    "  bar(bar) {",
-    "    return bar;",
-    "  }",
-    "};"
-  ];
-
-  TestRun(test).test(code, { esnext: true });
-
-  test.done();
-};


### PR DESCRIPTION
...h-1928"

@rwaldron @caitp For additional context, see [my comment from yesterday morning](https://github.com/jshint/jshint/pull/2026#issuecomment-67017936)

Commit message:

> This reverts commit 248e40bc39c1110ca7eb1d9799804ce005b9d2f5.
> 
> The issue which motivated this change related to the modification of the environment record of ES6 concise methods. That issue was addressed in a more comprehensive and concise manner via commit b95f669dbb62158355c0fb6a7638c7ccf036dc93 and verified with an equivalent unit test.