### PR TITLE
Add `await` as a Future Reserved Word

### DIFF
--- a/dist/jshint.js
+++ b/dist/jshint.js
@@ -11019,6 +11019,7 @@ var JSHINT = (function () {
   // Future Reserved Words
 
   FutureReservedWord("abstract");
+  FutureReservedWord("await", { es5: true });
   FutureReservedWord("boolean");
   FutureReservedWord("byte");
   FutureReservedWord("char");


### PR DESCRIPTION
Currently, jshint will incorrectly warn: `['await'] is better written in dot notation.`
