### PR TITLE
Add suiteSetup and suiteTeardown for mocha vars

### DIFF
--- a/dist/jshint-rhino.js
+++ b/dist/jshint-rhino.js
@@ -4988,7 +4988,7 @@ exports.bool = {
     /**
      * This option requires all `for in` loops to filter object's items. The
      * for in statement allows for looping through the names of all of the
-     * properties of an object including those inherited throught the prototype
+     * properties of an object including those inherited through the prototype
      * chain. This behavior can lead to unexpected items in your object so it
      * is generally safer to always filter inherited properties out as shown in
      * the example:
@@ -6675,10 +6675,12 @@ exports.mocha = {
   beforeEach  : false,
   afterEach   : false,
   // TDD
-  suite       : false,
-  test        : false,
-  setup       : false,
-  teardown    : false
+  suite         : false,
+  test          : false,
+  setup         : false,
+  teardown      : false,
+  suiteSetup    : false,
+  suiteTeardown : false
 };
 
 exports.jasmine = {

--- a/dist/jshint.js
+++ b/dist/jshint.js
@@ -4986,7 +4986,7 @@ exports.bool = {
     /**
      * This option requires all `for in` loops to filter object's items. The
      * for in statement allows for looping through the names of all of the
-     * properties of an object including those inherited throught the prototype
+     * properties of an object including those inherited through the prototype
      * chain. This behavior can lead to unexpected items in your object so it
      * is generally safer to always filter inherited properties out as shown in
      * the example:
@@ -6673,10 +6673,12 @@ exports.mocha = {
   beforeEach  : false,
   afterEach   : false,
   // TDD
-  suite       : false,
-  test        : false,
-  setup       : false,
-  teardown    : false
+  suite         : false,
+  test          : false,
+  setup         : false,
+  teardown      : false,
+  suiteSetup    : false,
+  suiteTeardown : false
 };
 
 exports.jasmine = {

--- a/src/vars.js
+++ b/src/vars.js
@@ -675,10 +675,12 @@ exports.mocha = {
   beforeEach  : false,
   afterEach   : false,
   // TDD
-  suite       : false,
-  test        : false,
-  setup       : false,
-  teardown    : false
+  suite         : false,
+  test          : false,
+  setup         : false,
+  teardown      : false,
+  suiteSetup    : false,
+  suiteTeardown : false
 };
 
 exports.jasmine = {


### PR DESCRIPTION
Mocha has introduced suiteSetup() and suiteTeardown() but they are undocumented. We should add it.

See also: https://github.com/mochajs/mocha/issues/310