### PR TITLE
Support generators in class body

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3446,6 +3446,7 @@ var JSHINT = (function () {
   function classbody(c) {
     var name;
     var isStatic;
+    var isGenerator;
     var getset;
     var props = {};
     var staticProps = {};
@@ -3453,7 +3454,13 @@ var JSHINT = (function () {
     for (var i = 0; state.tokens.next.id !== "}"; ++i) {
       name = state.tokens.next;
       isStatic = false;
+      isGenerator = false;
       getset = null;
+      if (name.id === "*") {
+        isGenerator = true;
+        advance("*");
+        name = state.tokens.next;
+      }
       if (name.id === "[") {
         name = computedPropertyName();
       } else if (isPropertyName(name)) {
@@ -3461,6 +3468,10 @@ var JSHINT = (function () {
         advance();
         computed = false;
         if (name.identifier && name.value === "static") {
+          if (checkPunctuators(state.tokens.next, ["*"])) {
+            isGenerator = true;
+            advance("*");
+          }
           if (isPropertyName(state.tokens.next) || state.tokens.next.id === "[") {
             computed = state.tokens.next.id === "[";
             isStatic = true;
@@ -3523,7 +3534,7 @@ var JSHINT = (function () {
 
       propertyName(name);
 
-      doFunction(null, c, false, null);
+      doFunction(null, c, isGenerator, null);
     }
 
     checkProperties(props);

--- a/tests/unit/fixtures/nestedFunctions-locations.js
+++ b/tests/unit/fixtures/nestedFunctions-locations.js
@@ -221,17 +221,31 @@
     "lastcharacter": 18
   },
   {
+    "name": "genMethod",
+    "line": 70,
+    "character": 14,
+    "last": 70,
+    "lastcharacter": 18
+  },
+  {
+    "name": "staticGenMethod",
+    "line": 71,
+    "character": 27,
+    "last": 71,
+    "lastcharacter": 31
+  },
+  {
     "name": "(empty)",
-    "line": 72,
+    "line": 74,
     "character": 26,
-    "last": 72,
+    "last": 74,
     "lastcharacter": 30
   },
   {
     "name": "default",
-    "line": 74,
+    "line": 76,
     "character": 25,
-    "last": 74,
+    "last": 76,
     "lastcharacter": 29
   }
 ]

--- a/tests/unit/fixtures/nestedFunctions.js
+++ b/tests/unit/fixtures/nestedFunctions.js
@@ -67,6 +67,8 @@ var VarDeclClass = class {
   method() {}                      // "method"
   get getter() {}                  // "get getter"
   set setter() {}                  // "set setter"
+  *genMethod() {}                  // "genMethod"
+  static *staticGenMethod() {}     // "staticGenMethod"
 };
 
 var grouping = (function() {});

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4199,6 +4199,14 @@ exports["class and method naming"] = function (test) {
     "  set lonely() {}",
     "  set lonel2",
     "            () {}",
+    "  *validGenerator() { yield; }",
+    "  static *validStaticGenerator() { yield; }",
+    "  *[1]() { yield; }",
+    "  static *[1]() { yield; }",
+    "  * ['*']() { yield; }",
+    "  static *['*']() { yield; }",
+    "  * [('*')]() { yield; }",
+    "  static *[('*')]() { yield; }",
     "}"
   ];
   var run = TestRun(test)


### PR DESCRIPTION
I was getting errors about generators in ES6 classes.

This commit fixes that issue. It also adds several lines of positive tests to guard against regression, including several suggested by rwaldron.

For reference, generators in classes are in the latest ES6 draft spec and work well with 6to5.

NB: I'm resubmitting this PR as Coveralls on Travis kept looking for a nonexistent commit. Original PR was [#2059](https://github.com/jshint/jshint/pull/2059)