### PR TITLE
bugfix: exported generator functions

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4320,7 +4320,11 @@ var JSHINT = (function () {
       this.block = true;
       advance("function");
       exported[state.tokens.next.value] = ok;
-      state.tokens.next.exported = true;
+      if(state.tokens.next.value === "*") {
+        peek().exported = true;
+      } else {
+        state.tokens.next.exported = true;
+      }
       state.syntax["function"].fud();
     } else if (state.tokens.next.id === "class") {
       this.block = true;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2640,6 +2640,18 @@ exports["esnext generator with yield delegation, gh-1544"] = function(test) {
   test.done();
 };
 
+exports["esnext generator export"] = function(test) {
+
+  var options = { unused: true, esnext: true };
+
+  TestRun(test, 1)
+    .test(
+  "export function* myFunc() { yield 1; }",
+  options);
+
+  test.done();
+};
+
 exports["mozilla generator"] = function (test) {
   // example taken from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [


### PR DESCRIPTION
Prevents 'unused' warning to be thrown on exported generator function.