### PR TITLE
Remove dead code

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1507,7 +1507,6 @@ var JSHINT = (function() {
   }
 
   function statement() {
-    var values;
     var i = indent, r, s = scope, t = state.tokens.next;
 
     if (t.id === ";") {
@@ -1544,22 +1543,6 @@ var JSHINT = (function() {
       }
     }
 
-    // detect a destructuring assignment
-    if (_.has(["[", "{"], t.value)) {
-      if (lookupBlockType().isDestAssign) {
-        if (!state.option.inESNext()) {
-          warning("W104", state.tokens.curr, "destructuring expression");
-        }
-        values = destructuringExpression();
-        values.forEach(function(tok) {
-          isundef(funct, "W117", tok.token, tok.id);
-        });
-        advance("=");
-        destructuringExpressionMatch(values, expression(10, true));
-        advance(";");
-        return;
-      }
-    }
     if (t.identifier && !res && peek().id === ":") {
       advance();
       advance(":");


### PR DESCRIPTION
Latest coverage report on `master` (demonstrating deadness): https://coveralls.io/files/414078989#L1548

Commit message:

>    The `_.has` utility method checks for the existence of the provided
>    properties as "own" values of the given object. The removed code
>    erroneously uses it to check attributes of an Array. The first branch is
>    (incorrectly) token when statements begin with identifiers/literals "0",
>    "1", or "length", and the nested branch depends on the block type which
>    is never a destructuring assignment in this case.
>    
>    This code has been unreachable since its original introduction into the
>    codebase [1]. Removing it has no effect on the behavior of JSHint.
>    
>    [1] commit fbf34a5
>        Author: Guyzmo <guyzmo+github@m0g.net>
>        Date:   Wed Mar 6 15:12:15 2013 +0100
>    
>        fixed destructuring assign in global context. Updated tests. cf #883