### PR TITLE
[[FIX]] Remove dead code for parameter parsing

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2452,7 +2452,6 @@ var JSHINT = (function() {
   }, 155, true).exps = true;
 
   prefix("(", function() {
-    var bracket, brackets = [];
     var pn = state.tokens.next, pn1, i = -1;
     var ret, triggerFnExpr;
     var parens = 1;
@@ -2484,16 +2483,8 @@ var JSHINT = (function() {
 
     if (state.tokens.next.id !== ")") {
       for (;;) {
-        if (pn.value === "=>" && _.contains(["{", "["], state.tokens.next.value)) {
-          bracket = state.tokens.next;
-          bracket.left = destructuringExpression();
-          brackets.push(bracket);
-          for (var t in bracket.left) {
-            exprs.push(bracket.left[t].token);
-          }
-        } else {
-          exprs.push(expression(10));
-        }
+        exprs.push(expression(10));
+
         if (state.tokens.next.id !== ",") {
           break;
         }
@@ -2509,9 +2500,6 @@ var JSHINT = (function() {
       }
     }
 
-    if (state.tokens.next.value === "=>") {
-      return exprs;
-    }
     if (!exprs.length) {
       return;
     }


### PR DESCRIPTION
Relevant coverage reports:

- https://coveralls.io/files/423822073#L2488
- https://coveralls.io/files/423822073#L2513

Commit message:

> The removed code was made superfluous by a recent commit that unified
> logic for function parameter parsing [1]. Since then, it has been
> unreachable so it is safe to remove.
> 
> [1] Title: Re-use code to parse "fat arrow" function params
>     Commit: 7430ee539ca2fe1a443b71908b5c36d1689581f5