### PR TITLE
Fix `.jshintrc` resolution

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -74,18 +74,18 @@ function deprecated(text, alt) {
 function findConfig(file) {
   var dir  = path.dirname(path.resolve(file));
   var envs = getHomeDir();
-
-  if (!envs)
-    return home;
-
-  var home = path.normalize(path.join(envs, ".jshintrc"));
-
   var proj = findFile(".jshintrc", dir);
+  var home;
+
   if (proj)
     return proj;
 
-  if (shjs.test("-e", home))
-    return home;
+  else if (envs) {
+    home = path.normalize(path.join(envs, ".jshintrc"));
+
+    if (shjs.test("-e", home))
+      return home;
+  }
 
   return null;
 }


### PR DESCRIPTION
The current layout of the `findConfig` appears to contain an error which results in no `.jshintrc` being found if the user does not have one of the defined 'home' environment variables; I'm sure 99.9% of people will never run into this, but there is a small percentage of us out there who work with very, very bespoke systems ;)

This is a really tricky one to test as the tests themselves fail if you unset your home environment variable - however this PR does not change any functionality, just makes it a bit more explicit :)