### PR TITLE
Test Browser Build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -3,36 +3,36 @@
 
 "use strict";
 
-var browserify = require("browserify");
-var bundle     = browserify();
 var path       = require("path");
-var version    = require("../package.json").version;
+var build      = require("../scripts/build");
 require("shelljs/make");
 
 var distDir    = path.join(__dirname, "../dist");
-var srcDir     = path.join(__dirname, "../src");
 
 if (!test("-e", distDir))
   mkdir(distDir);
 
-bundle.require(srcDir + "/jshint.js", { expose: "jshint" });
-bundle.bundle(function (err, src) {
-  var web   = distDir + "/jshint.js";
-  var rhino = distDir + "/jshint-rhino.js";
+build("web", function(err, version, src) {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
 
-  [ "/*! " + version + " */",
-    "var JSHINT;",
-    "if (typeof window === 'undefined') window = {};",
-    "(function () {",
-      "var require;",
-      src,
-      "JSHINT = require('jshint').JSHINT;",
-      "if (typeof exports === 'object' && exports) exports.JSHINT = JSHINT;",
-    "}());"
-  ].join("\n").to(web);
+  src.to(distDir + "/jshint.js");
+  console.log("Built: " + version + " (web)");
+});
 
-  ("#!/usr/bin/env rhino\nvar window = {};\n" + cat(web, srcDir + "/platforms/rhino.js")).to(rhino);
-  chmod("+x", rhino);
+build("rhino", function(err, version, src) {
+  var dest;
 
-  echo("Built: " + version);
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  dest  = distDir + "/jshint-rhino.js";
+  chmod("+x", dest);
+
+  src.to(dest);
+  console.log("Built: " + version + " (Rhino)");
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "coverage": "istanbul -- cover ./node_modules/.bin/nodeunit tests/unit",
     "data": "node scripts/generate-identifier-data",
     "pretest": "jshint src && jscs src",
-    "test": "nodeunit tests tests/regression tests/unit"
+    "test-cli": "nodeunit tests/cli.js",
+    "test-regression": "nodeunit tests/regression",
+    "test-unit": "nodeunit tests/unit",
+    "test": "npm run test-unit && npm run test-cli && npm run test-regression"
   },
 
   "main": "./src/jshint.js",

--- a/package.json
+++ b/package.json
@@ -24,14 +24,17 @@
   },
 
   "scripts": {
+    "browser-test-server": "node tests/helpers/browser/server",
     "build": "node bin/build",
     "coverage": "istanbul -- cover ./node_modules/.bin/nodeunit tests/unit",
     "data": "node scripts/generate-identifier-data",
     "pretest": "jshint src && jscs src",
+    "test-browser": "node tests/browser",
     "test-cli": "nodeunit tests/cli.js",
+    "test-node": "npm run test-unit && npm run test-cli && npm run test-regression",
     "test-regression": "nodeunit tests/regression",
     "test-unit": "nodeunit tests/unit",
-    "test": "npm run test-unit && npm run test-cli && npm run test-regression"
+    "test": "npm run test-node && npm run test-browser"
   },
 
   "main": "./src/jshint.js",
@@ -55,6 +58,8 @@
     "jshint":        "2.6.x",
     "mock-stdin":    "0.3.x",
     "nodeunit":      "0.9.x",
+    "phantom":       "~0.7.2",
+    "phantomjs":     "1.9.13",
     "regenerate":    "1.2.x",
     "sinon":         "1.12.x",
     "unicode-6.3.0": "0.1.x"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,13 +11,16 @@ var targets = ["web", "rhino"];
 module.exports = function(target, done) {
   var bundle = browserify();
 
+  done = done || function() {};
+
   if (targets.indexOf(target) === -1) {
     done(new Error("Unrecognized target: '" + target + "'"));
     return;
   }
 
   bundle.require(srcDir + "/jshint.js", { expose: "jshint" });
-  bundle.bundle(function(err, src) {
+
+  return bundle.bundle(function(err, src) {
     var wrapped;
 
     if (err) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var browserify = require("browserify");
+var path       = require("path");
+var version    = require("../package.json").version;
+
+var srcDir     = path.join(__dirname, "../src");
+
+var targets = ["web", "rhino"];
+
+module.exports = function(target, done) {
+  var bundle = browserify();
+
+  if (targets.indexOf(target) === -1) {
+    done(new Error("Unrecognized target: '" + target + "'"));
+    return;
+  }
+
+  bundle.require(srcDir + "/jshint.js", { expose: "jshint" });
+  bundle.bundle(function(err, src) {
+    var wrapped;
+
+    if (err) {
+      done(err);
+      return;
+    }
+
+    wrapped = [ "/*! " + version + " */",
+      "var JSHINT;",
+      "if (typeof window === 'undefined') window = {};",
+      "(function () {",
+        "var require;",
+        src,
+        "JSHINT = require('jshint').JSHINT;",
+        "if (typeof exports === 'object' && exports) exports.JSHINT = JSHINT;",
+      "}());"
+    ];
+
+    if (target === "rhino") {
+      wrapped.splice(0, 0, "#!/usr/bin/env rhino", "var window = {};");
+    }
+
+    done(null, version, wrapped.join("\n"));
+  });
+};

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -1,0 +1,47 @@
+"use strict";
+
+var path = require("path");
+var phantom = require("phantom");
+var createTestServer = require("./helpers/browser/server");
+var options = {
+  /**
+   * The `phantom` module provides a Node.js API for the PhantomJS binary,
+   * while the `phantomjs` module includes the binary itself.
+   */
+  path: path.dirname(require("phantomjs").path) + "/",
+
+  /**
+   * Disable the optional `weak` module due to installation difficulties in
+   * Windows environments.
+   */
+  dnodeOpts: {
+    weak: false
+  }
+};
+var port = process.env.NODE_PORT || 8045;
+
+phantom.create(function(ph) {
+  ph.createPage(function(page) {
+    createTestServer(port, function(server) {
+      page.onConsoleMessage(function(str) {
+        console.log(str);
+      });
+
+      page.set("onCallback", function(err) {
+        ph.exit();
+        server.close();
+        if (err) {
+          process.exit(1);
+        }
+      });
+
+      page.set("onError", function(msg, trace) {
+        console.error(msg);
+        console.error(trace);
+        process.exit(1);
+      });
+
+      page.open("http://localhost:" + port, function () {});
+    });
+  });
+}, options);

--- a/tests/helpers/browser/fixture-fs.js
+++ b/tests/helpers/browser/fixture-fs.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var resolve = require("path").resolve;
+
+exports.readFileSync = function(path) {
+  return window.JSHintTestFixtures[resolve(path)];
+};

--- a/tests/helpers/browser/index.html
+++ b/tests/helpers/browser/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8"></meta>
+    <title>JSHint Browser Build Testing Server</title>
+  </head>
+  <body>
+  <script>
+    /**
+     * PhantomJS does not define a `Function.prototype.bind` implementation, so
+     * a polyfill is necessary.
+     * Source:
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+     */
+    if (!Function.prototype.bind) {
+      Function.prototype.bind = function(oThis) {
+        if (typeof this !== "function") {
+          // closest thing possible to the ECMAScript 5
+          // internal IsCallable function
+          throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+        }
+
+        var aArgs   = Array.prototype.slice.call(arguments, 1),
+            fToBind = this,
+            fNOP    = function() {},
+            fBound  = function() {
+              return fToBind.apply(this instanceof fNOP && oThis
+                     ? this
+                     : oThis,
+                     aArgs.concat(Array.prototype.slice.call(arguments)));
+            };
+
+        fNOP.prototype = this.prototype;
+        fBound.prototype = new fNOP();
+
+        return fBound;
+      };
+    }
+  </script>
+  <script src="jshint.js"></script>
+  <script src="tests.js"></script>
+  </body>
+</html>

--- a/tests/helpers/browser/run-all.js.tmpl
+++ b/tests/helpers/browser/run-all.js.tmpl
@@ -1,0 +1,56 @@
+(function() {
+  "use strict";
+  var nodeunit = require("nodeunit");
+  var callPhantom = window.callPhantom;
+  var tests;
+
+  /**
+   * `window.callPhantom` is used as the control flow communication channel
+   * between the document and the PhantomJS context (where available). Because
+   * of this, it should not be available to other scripts on the page.
+   */
+  window.callPhantom = null;
+
+  /**
+   * Nodeunit's "browser" reporter expects Nodeunit to be available on the
+   * global scope. Expose it in all cases to promote consistency between the
+   * PhantomJS and "true" browser execution contexts.
+   */
+  window.nodeunit = nodeunit;
+
+  tests = {
+    {{ INJECT_TEST_INCLUDES }}
+  };
+
+  function runHeadless() {
+    /**
+     * Source:
+     * https://github.com/caolan/nodeunit/blob/60b7d67250a8005fcca6d71a18697c9bdc6613bd/bin/nodeunit.json
+     */
+    var colors = {
+      error_prefix: "\u001B[31m",
+      error_suffix: "\u001B[39m",
+      ok_prefix: "\u001B[32m",
+      ok_suffix: "\u001B[39m",
+      bold_prefix: "\u001B[1m",
+      bold_suffix: "\u001B[22m",
+      assertion_prefix: "\u001B[35m",
+      assertion_suffix: "\u001B[39m"
+    };
+    nodeunit.reporters.default.run(tests, colors, function(err) {
+      callPhantom(err ? err : null);
+    });
+  }
+
+  function runHeadful() {
+    var reporter = require("nodeunit/lib/reporters/browser");
+
+    reporter.run(tests);
+  }
+
+  if (/PhantomJS/.test(navigator.userAgent)) {
+    runHeadless();
+  } else {
+    runHeadful();
+  }
+}());

--- a/tests/helpers/browser/server.js
+++ b/tests/helpers/browser/server.js
@@ -1,0 +1,213 @@
+"use strict";
+var fs = require("fs");
+var http = require("http");
+var Stream = require("stream");
+var path = require("path");
+var url = require("url");
+
+var browserify = require("browserify");
+var buildJSHint = require(__dirname + "/../../../scripts/build");
+
+var mainPath = path.resolve(
+  __dirname + "/../../../" + require("../../../package.json").main
+);
+var contentTypes = {
+  ".html": "text/html",
+  ".js": "application/javascript"
+};
+
+var streams = {
+  fixtures: function() {
+    var fixtureDir = __dirname + "/../../unit/fixtures";
+    var fixtureStream = new Stream.Readable();
+    fixtureStream._read = fixtureStream.write = function() {};
+
+    fs.readdir(fixtureDir, function(err, files) {
+      var src = "";
+      var fsCache = {};
+
+      if (err) {
+        done(err);
+        return;
+      }
+
+      files.forEach(function(fileName) {
+        var relativeName = "/tests/unit/fixtures/" + fileName;
+
+        fsCache[relativeName] = fs.readFileSync(
+          fixtureDir + "/" + fileName, { encoding: "utf-8" }
+        );
+      });
+
+      src += [
+        "(function() {",
+        "  window.JSHintTestFixtures = " + JSON.stringify(fsCache) + ";",
+        "}());"
+      ].join("\n");
+      fixtureStream.push(src);
+      fixtureStream.push(null);
+    });
+
+    return fixtureStream;
+  },
+
+  /**
+   * This script is dependent on the contents of the unit test file directory.
+   * It must be generated dynamically for two reasons:
+   *
+   * 1. So that Browserify includes the test files in the generated bundle
+   * 2. So that Nodeunit is explicitly invoked with the tests
+   *
+   * Although #1 could be addressed through the Browserify API itself, #2 means
+   * that passively including the modules will not result in test
+   * execution--some code generation is required.
+   */
+  runAllScript: function() {
+    var testDir = "../../unit";
+    var stream = new Stream.Readable();
+    stream._read = stream.write = function() {};
+
+    fs.readdir(__dirname + "/" + testDir, function(err, allFiles) {
+      var testIncludes = allFiles.filter(function(file) {
+          return /\.js$/i.test(file);
+        }).map(function(file) {
+          return "\"" + file + "\": require(\"" + testDir + "/" + file + "\")";
+        }).join(",\n");
+
+      fs.readFile(__dirname + "/run-all.js.tmpl", function(err, src) {
+        stream.push(
+          String(src).replace(/{{\s*INJECT_TEST_INCLUDES\s*}}/, testIncludes)
+        );
+        stream.push(null);
+      });
+    });
+
+    return stream;
+  }
+};
+
+var build = {
+  "index.html": function(done) {
+    fs.readFile(__dirname + "/index.html", done);
+  },
+
+  "jshint.js": function(done) {
+    buildJSHint("web", function(err, version, src) {
+      done(err, src);
+    });
+  },
+
+  "tests.js": function(done) {
+    var bundle = browserify({
+      insertGlobalVars: {
+        /**
+         * Ensure that the value of `__dirname` uses Unix path separator across
+         * all platforms.
+         *
+         * By default, Browserify defines the `__dirname` global using the
+         * system's native file separator character, but its implementation of
+         * `path.resolve` (as used in `fixture-fs.js`) only includes the Unix
+         * implementation. This inconsistency does not impact file lookup on
+         * either platform, but when path strings are used as key values (as is
+         * the case in `fixture-fs.js`), the separator character must be
+         * consistent.
+         */
+        __dirname: function() {
+          return "'/tests/unit'";
+        }
+      }
+    });
+    var includedFaker = false;
+
+    bundle.require(
+      fs.createReadStream(__dirname + "/fixture-fs.js"),
+      { expose: "fs" }
+    );
+    bundle.add(streams.fixtures());
+    bundle.add(streams.runAllScript(), { basedir: __dirname });
+
+    /**
+     * When Browserify attempts to bundle the JSHint source, inject a simple
+     * "global extraction module"--a CommonJS module that simply exposes the
+     * globally-defined JSHint instance. This ensures that the tests run
+     * against the version of JSHint built with the project's build script (see
+     * above) and not a version dynamically included in the current bundle for
+     * test files.
+     */
+    bundle.transform(function(filename) {
+      var faker;
+
+      if (filename === mainPath) {
+        includedFaker = true;
+        faker = new Stream.Readable();
+        faker._read = faker.write = function() {};
+        faker.push("exports.JSHINT = window.JSHINT;");
+        faker.push(null);
+        return faker;
+      }
+
+      return new Stream.PassThrough();
+    });
+
+    bundle.bundle(function(err, src) {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      if (!includedFaker) {
+        done(new Error(
+          "JSHint extraction module not included in bundled test build."
+        ));
+        return;
+      }
+
+      done(null, src);
+    });
+  }
+};
+
+module.exports = function(port, done) {
+  var server = http.createServer(function(req, res) {
+    var pathname = url.parse(req.url).pathname.slice(1) || "index.html";
+    var contentType = contentTypes[path.extname(pathname)];
+
+    if (!Object.hasOwnProperty.call(build, pathname)) {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+
+    build[pathname](function(err, src) {
+      if (err) {
+        res.statusCode = 500;
+        res.end(err.message);
+        return;
+      }
+
+      res.setHeader("content-type", contentType);
+      res.setHeader(
+        "Cache-Control", "private, no-cache, no-store, must-revalidate"
+      );
+      res.setHeader("Expires", "-1");
+      res.setHeader("Pragma", "no-cache");
+
+      res.end(src);
+    });
+  });
+
+  server.listen(port, function() {
+    done(server);
+  });
+};
+
+
+if (require.main === module) {
+  console.log("Starting JSHint browser build testing server.");
+  console.log(
+    "(override default port via the NODE_PORT environmental variable)"
+  );
+
+  module.exports(process.env.NODE_PORT || 8045, function(server) {
+    console.log("Server now listening on port " + server.address().port);
+  });
+}

--- a/tests/helpers/testhelper.js
+++ b/tests/helpers/testhelper.js
@@ -30,7 +30,7 @@
 
 'use strict';
 
-var JSHINT = require('../../src/jshint.js').JSHINT;
+var JSHINT = require("../..").JSHINT;
 
 if (exports.setup === undefined || exports.setup === null) {
   exports.setup = {};

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var JSHINT  = require('../../src/jshint.js').JSHINT;
+var JSHINT  = require("../..").JSHINT;
 var fs      = require('fs');
 var TestRun = require("../helpers/testhelper").setup.testRun;
 

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var JSHINT  = require('../../src/jshint.js').JSHINT;
+var JSHINT  = require("../..").JSHINT;
 var fs      = require('fs');
 var TestRun = require("../helpers/testhelper").setup.testRun;
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -6,7 +6,7 @@
 
 "use strict";
 
-var JSHINT = require('../../src/jshint.js').JSHINT;
+var JSHINT = require("../..").JSHINT;
 var fs = require('fs');
 var TestRun = require('../helpers/testhelper').setup.testRun;
 var fixture = require('../helpers/fixture').fixture;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-var JSHINT  = require('../../src/jshint.js').JSHINT;
+var JSHINT  = require("../..").JSHINT;
 var fs    = require('fs');
 var TestRun = require("../helpers/testhelper").setup.testRun;
 var path    = require("path");


### PR DESCRIPTION
Back in November, we learned that the browser build of JSHint was broken
through issue gh-1993. This was caused when this project's dependency on
Browserify was updated to a new major version. Although this could have been
avoided with a more careful review process, fundamental problems like this can
(and should) be detected automatically.

There are many ways to test the build version of JSHint. The simplest would
involve assuring that, when loaded in a browser, a `JSHINT` function is defined
in the global scope. Even this simple test may have been enough to catch the
regression described above.

Although easy to implement, this test would fail to catch a wide array of bugs
that could come about when bundling the project and executing the bundle in a
browser. We could define some additional tests that assert basic functionality,
but those tests would be redundant with the project's unit tests and would
never provide the same coverage.

This changest introduces a testing process that bundles all of the project's
unit tests and executes them in the browser. Approaching the problem this way
provides the best code coverage possible while minimizing duplication, but it
comes at the expense of simplicity. I've tried to make the new testing
infrastructure as simple as possible, and I've documented the pieces that I
think need documentation.

Beyond simply running the tests, I had a few goals:

- **Report parity with the current unit test suite** - the output of `npm run
  test-browser` is identical to the output of `npm run test-unit`)
- **Ability to run the tests in a local browser for manual debugging** -
  running `npm run browser-test-server` initiates a simple web server whose
  index page executes the unit tests)
- **Avoidance of temporary files** - JSHint is re-built with every test run but
  not written to disk. This precludes mistakes like accidental inclusion of
  test builds in future commits without necessitating special `.gitignore`
  rules.

I think that's about it!