### PR TITLE
[[FIX]] Correct token reported by `singleGroups`

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2528,7 +2528,7 @@ var JSHINT = (function() {
       }
 
       if (!isNecessary) {
-        warning("W126");
+        warning("W126", opening);
       }
 
       ret.paren = true;

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2048,6 +2048,21 @@ singleGroups.newLine = function(test) {
   test.done();
 };
 
+singleGroups.lineNumber = function (test) {
+  var code = [
+    "var x = (",
+    "  1",
+    ")",
+    ";"
+  ];
+
+  TestRun(test)
+    .addError(1, "Unnecessary grouping operator.")
+    .test(code, { singleGroups: true });
+
+  test.done();
+};
+
 exports.elision = function (test) {
   var code = [
     "var a = [1,,2];",


### PR DESCRIPTION
This should resolve gh-2067.

> Warnings emitted due to the `singleGroups` option should be in terms of
> the opening parenthesis token of the offending grouping operator.