### PR TITLE
[[FIX]] Correct behavior of `singleGroups`

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2166,7 +2166,10 @@ var JSHINT = (function() {
   infix("in", "in", 120);
   infix("instanceof", "instanceof", 120);
   infix("+", function(left, that) {
-    var right = expression(130);
+    var right;
+    that.left = left;
+    that.right = right = expression(130);
+
     if (left && right && left.id === "(string)" && right.id === "(string)") {
       left.value += right.value;
       left.character = right.character;
@@ -2175,8 +2178,7 @@ var JSHINT = (function() {
       }
       return left;
     }
-    that.left = left;
-    that.right = right;
+
     return that;
   }, 130);
   prefix("+", "num");

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1808,6 +1808,8 @@ singleGroups.bindingPower.singleExpr = function (test) {
     "var i = 2 * (3 - 4 - 5) * 6;",
     "var j = (a = 1) + 2;",
     "var j = (a += 1) / 2;",
+    "var k = 'foo' + ('bar' ? 'baz' : 'qux');",
+    "var l = 1 + (0 || 3);",
     // Invalid forms:
     "var j = 2 * ((3 - 4) - 5) * 6;",
     "var k = 2 * (3 - (4 - 5)) * 6;",
@@ -1831,8 +1833,6 @@ singleGroups.bindingPower.singleExpr = function (test) {
   ];
 
   TestRun(test)
-    .addError(12, "Unnecessary grouping operator.")
-    .addError(13, "Unnecessary grouping operator.")
     .addError(14, "Unnecessary grouping operator.")
     .addError(15, "Unnecessary grouping operator.")
     .addError(16, "Unnecessary grouping operator.")
@@ -1850,6 +1850,8 @@ singleGroups.bindingPower.singleExpr = function (test) {
     .addError(28, "Unnecessary grouping operator.")
     .addError(29, "Unnecessary grouping operator.")
     .addError(30, "Unnecessary grouping operator.")
+    .addError(31, "Unnecessary grouping operator.")
+    .addError(32, "Unnecessary grouping operator.")
     .test(code, { singleGroups: true });
 
   test.done();


### PR DESCRIPTION
Parsing logic can generally infer if the current token begins an
expression by referencing the `left` property of the previous token. The
`singleGroups` option relies on this behavior in order to recognize
situations where operator binding power makes the grouping operator
necessary.

Parsing of the "addition" operator should be made consistent with the
other infix operators: the token's `left` property should be set *prior
to* parsing the right-hand-side expression.

This should resolve gh-2139