### PR TITLE
[[FIX]] Parse nested templates

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -826,7 +826,7 @@ var JSHINT = (function() {
       return true;
     }
     if (isInfix(next) === isInfix(curr) || (curr.id === "yield" && state.option.inMoz(true))) {
-      return curr.line !== next.line;
+      return curr.line !== startLine(next);
     }
     return false;
   }
@@ -877,7 +877,7 @@ var JSHINT = (function() {
 
     var isDangerous =
       state.option.asi &&
-      state.tokens.prev.line < state.tokens.curr.line &&
+      state.tokens.prev.line !== startLine(state.tokens.curr) &&
       _.contains(["]", ")"], state.tokens.prev.id) &&
       _.contains(["[", "("], state.tokens.curr.id);
 
@@ -951,23 +951,27 @@ var JSHINT = (function() {
 
   // Functions for conformance of style.
 
+  function startLine(token) {
+    return token.startLine || token.line;
+  }
+
   function nobreaknonadjacent(left, right) {
     left = left || state.tokens.curr;
     right = right || state.tokens.next;
-    if (!state.option.laxbreak && left.line !== right.line) {
+    if (!state.option.laxbreak && left.line !== startLine(right)) {
       warning("W014", right, right.value);
     }
   }
 
   function nolinebreak(t) {
     t = t || state.tokens.curr;
-    if (t.line !== state.tokens.next.line) {
+    if (t.line !== startLine(state.tokens.next)) {
       warning("E022", t, t.value);
     }
   }
 
   function nobreakcomma(left, right) {
-    if (left.line !== right.line) {
+    if (left.line !== startLine(right)) {
       if (!state.option.laxcomma) {
         if (comma.first) {
           warning("I001");
@@ -1494,7 +1498,7 @@ var JSHINT = (function() {
         // the same line *and* option lastsemic is on, ignore the warning.
         // Otherwise, complain about missing semicolon.
         if (!state.option.lastsemic || state.tokens.next.id !== "}" ||
-          state.tokens.next.line !== state.tokens.curr.line) {
+          startLine(state.tokens.next) !== state.tokens.curr.line) {
           warningAt("W033", state.tokens.curr.line, state.tokens.curr.character);
         }
       }
@@ -1987,7 +1991,7 @@ var JSHINT = (function() {
     type: "(template)",
     lbp: 0,
     identifier: false,
-    fud: doTemplateLiteral
+    nud: doTemplateLiteral
   };
 
   type("(template middle)", function() {
@@ -2638,7 +2642,7 @@ var JSHINT = (function() {
     } else if (blocktype.isDestAssign && !state.option.inESNext()) {
       warning("W104", state.tokens.curr, "destructuring assignment");
     }
-    var b = state.tokens.curr.line !== state.tokens.next.line;
+    var b = state.tokens.curr.line !== startLine(state.tokens.next);
     this.first = [];
     if (b) {
       indent += state.option.indent;
@@ -3048,7 +3052,7 @@ var JSHINT = (function() {
       var b, f, i, p, t, g, nextVal;
       var props = {}; // All properties, including accessors
 
-      b = state.tokens.curr.line !== state.tokens.next.line;
+      b = state.tokens.curr.line !== startLine(state.tokens.next);
       if (b) {
         indent += state.option.indent;
         if (state.tokens.next.from === indent + state.option.indent) {
@@ -4108,7 +4112,7 @@ var JSHINT = (function() {
       nolinebreak(this);
 
     if (state.tokens.next.id !== ";" && !state.tokens.next.reach) {
-      if (state.tokens.curr.line === state.tokens.next.line) {
+      if (state.tokens.curr.line === startLine(state.tokens.next)) {
         if (funct[v] !== "label") {
           warning("W090", state.tokens.next, v);
         } else if (scope[v] !== funct) {
@@ -4135,7 +4139,7 @@ var JSHINT = (function() {
       nolinebreak(this);
 
     if (state.tokens.next.id !== ";" && !state.tokens.next.reach) {
-      if (state.tokens.curr.line === state.tokens.next.line) {
+      if (state.tokens.curr.line === startLine(state.tokens.next)) {
         if (funct[v] !== "label") {
           warning("W090", state.tokens.next, v);
         } else if (scope[v] !== funct) {
@@ -4155,7 +4159,7 @@ var JSHINT = (function() {
 
 
   stmt("return", function() {
-    if (this.line === state.tokens.next.line) {
+    if (this.line === startLine(state.tokens.next)) {
       if (state.tokens.next.id !== ";" && !state.tokens.next.reach) {
         this.first = expression(0);
 
@@ -4198,7 +4202,7 @@ var JSHINT = (function() {
       advance("*");
     }
 
-    if (this.line === state.tokens.next.line || !state.option.inMoz(true)) {
+    if (this.line === startLine(state.tokens.next) || !state.option.inMoz(true)) {
       if (delegatingYield ||
           (state.tokens.next.id !== ";" && !state.tokens.next.reach && state.tokens.next.nud)) {
 

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1998,6 +1998,10 @@ var JSHINT = (function() {
     return this;
   });
 
+  type("(no subst template)", function() {
+    return this;
+  });
+
   type("(regexp)", function() {
     return this;
   });

--- a/src/lex.js
+++ b/src/lex.js
@@ -35,7 +35,8 @@ var Token = {
 };
 
 var Context = {
-  Template: 1
+  Block: 1,
+  Template: 2
 };
 
 // Object that handles postponed lexing verifications that checks the parsed
@@ -224,13 +225,30 @@ Lexer.prototype = {
     case ")":
     case ";":
     case ",":
-    case "{":
-    case "}":
     case "[":
     case "]":
     case ":":
     case "~":
     case "?":
+      return {
+        type: Token.Punctuator,
+        value: ch1
+      };
+
+    // A block/object opener
+    case "{":
+      this.context.push(Context.Block);
+      return {
+        type: Token.Punctuator,
+        value: ch1
+      };
+
+    // A block/object closer
+    case "}":
+      if (!this.inContext(Context.Block)) {
+        return null;
+      }
+      this.context.pop();
       return {
         type: Token.Punctuator,
         value: ch1

--- a/src/lex.js
+++ b/src/lex.js
@@ -31,7 +31,8 @@ var Token = {
   RegExp: 9,
   TemplateHead: 10,
   TemplateMiddle: 11,
-  TemplateTail: 12
+  TemplateTail: 12,
+  NoSubstTemplate: 13
 };
 
 var Context = {
@@ -1060,8 +1061,8 @@ Lexer.prototype = {
       }
     }
 
-    // Final value is either StringLiteral or TemplateTail
-    tokenType = tokenType === Token.TemplateHead ? Token.StringLiteral : Token.TemplateTail;
+    // Final value is either NoSubstTemplate or TemplateTail
+    tokenType = tokenType === Token.TemplateHead ? Token.NoSubstTemplate : Token.TemplateTail;
     this.skip(1);
     this.context.pop();
 
@@ -1667,6 +1668,15 @@ Lexer.prototype = {
           value: token.value
         });
         return create("(template tail)", token.value);
+
+      case Token.NoSubstTemplate:
+        this.trigger("NoSubstTemplate", {
+          line: this.line,
+          char: this.char,
+          from: this.from,
+          value: token.value
+        });
+        return create("(no subst template)", token.value);
 
       case Token.Identifier:
         this.trigger("Identifier", {

--- a/src/lex.js
+++ b/src/lex.js
@@ -1076,8 +1076,7 @@ Lexer.prototype = {
       value: value,
       startLine: startLine,
       startChar: startChar,
-      isUnclosed: false,
-      quote: "`"
+      isUnclosed: false
     };
   },
 

--- a/src/lex.js
+++ b/src/lex.js
@@ -245,10 +245,9 @@ Lexer.prototype = {
 
     // A block/object closer
     case "}":
-      if (!this.inContext(Context.Block)) {
-        return null;
+      if (this.inContext(Context.Block)) {
+        this.context.pop();
       }
-      this.context.pop();
       return {
         type: Token.Punctuator,
         value: ch1

--- a/src/style.js
+++ b/src/style.js
@@ -63,11 +63,6 @@ exports.register = function(linter) {
       return;
     }
 
-    // If quotmark is enabled, return if this is a template literal.
-    if (esnext && data.quote === "`") {
-      return;
-    }
-
     // If quotmark is set to 'single' warn about all double-quotes.
 
     if (quotmark === "single" && data.quote !== "'") {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -775,9 +775,9 @@ exports.testES6TemplateLiterals = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-template-literal.js", "utf8");
   TestRun(test)
     .addError(14, "Octal literals are not allowed in strict mode.")
-    .addError(17, "Unclosed template literal.")
-    .addError(18, "Expected an identifier and instead saw '(end)'.")
-    .addError(18, "Missing semicolon.")
+    .addError(19, "Unclosed template literal.")
+    .addError(20, "Expected an identifier and instead saw '(end)'.")
+    .addError(20, "Missing semicolon.")
     .test(src, { esnext: true });
   test.done();
 };

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -844,6 +844,76 @@ exports.testES6TemplateLiteralsAreNotDirectives = function (test) {
   test.done();
 };
 
+exports.testES6TemplateLiteralReturnValue = function (test) {
+  var src = [
+    'function sayHello(to) {',
+    '  return `Hello, ${to}!`;',
+    '}',
+    'print(sayHello("George"));'
+  ];
+
+  TestRun(test).test(src, { esnext: true });
+
+  var src = [
+    'function* sayHello(to) {',
+    '  yield `Hello, ${to}!`;',
+    '}',
+    'print(sayHello("George"));'
+  ];
+
+  TestRun(test).test(src, { esnext: true });
+
+  test.done();
+};
+
+exports.testES6TemplateLiteralMultilineReturnValue = function (test) {
+  var src = [
+    'function sayHello(to) {',
+    '  return `Hello, ',
+    '    ${to}!`;',
+    '}',
+    'print(sayHello("George"));'
+  ];
+
+  TestRun(test).test(src, { esnext: true });
+
+  var src = [
+    'function* sayHello(to) {',
+    '  yield `Hello, ',
+    '    ${to}!`;',
+    '}',
+    'print(sayHello("George"));'
+  ];
+
+  TestRun(test).test(src, { esnext: true });
+
+  test.done();
+};
+
+exports.tesMultilineReturnValueStringLiteral = function (test) {
+  var src = [
+    'function sayHello(to) {',
+    '  return "Hello, \\',
+    '    " + to;',
+    '}',
+    'print(sayHello("George"));'
+  ];
+
+  TestRun(test).test(src, { multistr: true });
+
+  var src = [
+    'function* sayHello(to) {',
+    '  yield "Hello, \\',
+    '    " + to;',
+    '}',
+    'print(sayHello("George"));'
+  ];
+
+  TestRun(test).test(src, { esnext: true, multistr: true });
+
+  test.done();
+};
+
 exports.testES6ExportStarFrom = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-export-star-from.js", "utf8");
   TestRun(test)

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -775,9 +775,9 @@ exports.testES6TemplateLiterals = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-template-literal.js", "utf8");
   TestRun(test)
     .addError(14, "Octal literals are not allowed in strict mode.")
-    .addError(19, "Unclosed template literal.")
-    .addError(20, "Expected an identifier and instead saw '(end)'.")
-    .addError(20, "Missing semicolon.")
+    .addError(21, "Unclosed template literal.")
+    .addError(22, "Expected an identifier and instead saw '(end)'.")
+    .addError(22, "Missing semicolon.")
     .test(src, { esnext: true });
   test.done();
 };

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -818,6 +818,32 @@ exports.testES6TemplateLiteralMultiline = function (test) {
   test.done();
 };
 
+exports.testES6TemplateLiteralsAreNotDirectives = function (test) {
+  var src = [
+    "function fn() {",
+    "`use strict`;",
+    "return \"\\077\";",
+    "}"
+  ];
+
+  TestRun(test)
+    .addError(2, "Expected an assignment or function call and instead saw an expression.")
+    .test(src, { esnext: true });
+
+  var src2 = [
+    "function fn() {",
+    "`${\"use strict\"}`;",
+    "return \"\\077\";",
+    "}"
+  ];
+
+  TestRun(test)
+    .addError(2, "Expected an assignment or function call and instead saw an expression.")
+    .test(src2, { esnext: true });
+
+  test.done();
+};
+
 exports.testES6ExportStarFrom = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-export-star-from.js", "utf8");
   TestRun(test)

--- a/tests/unit/fixtures/es6-template-literal.js
+++ b/tests/unit/fixtures/es6-template-literal.js
@@ -14,4 +14,6 @@ function octal_strictmode() {
   var test = `\033\t`;
 }
 
+var nested = `Look and ${ `Nested ${ `whoaaa` } template` } listen`;
+
 var unterminated = `${one}

--- a/tests/unit/fixtures/es6-template-literal.js
+++ b/tests/unit/fixtures/es6-template-literal.js
@@ -16,4 +16,6 @@ function octal_strictmode() {
 
 var nested = `Look and ${ `Nested ${ `whoaaa` } template` } listen`;
 
+var innerobj = `Template with ${ {obj: "literal"} } inside`;
+
 var unterminated = `${one}


### PR DESCRIPTION
ES6 template literals are nestable, jshint's parser is capable, but it's lexer isn't. This patch adds the concept of a stack of contexts to the lexer, replacing the previous boolean flag. This context stack pattern is borrowed from the awesome Acorn parser project, where it's used to enable more than just template literals.

Fixes: #2151
Fixes: #2082
Fixes: #1814