### PR TITLE
[[FIX]] remove unused var

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -56,7 +56,6 @@ exports.register = function(linter) {
 
   linter.on("String", function style_scanQuotes(data) {
     var quotmark = linter.getOption("quotmark");
-    var esnext = linter.getOption("esnext");
     var code;
 
     if (!quotmark) {


### PR DESCRIPTION
Cleanup lint error from 7e80490 which removed a check using the `esnext` var.

cc @caitp 