### PR TITLE
[[FIX]] Revert Issue #1426: Make some Node globals writeable.

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -420,24 +420,21 @@ exports.couch = {
 exports.node = {
   __filename    : false,
   __dirname     : false,
-  GLOBAL        : false,
+  Buffer        : false,
+  console       : false,
   global        : false,
-  module        : false,
-  require       : false,
-
-  // These globals are writeable because Node allows the following
-  // usage pattern: var Buffer = require("buffer").Buffer;
-
-  Buffer        : true,
-  console       : true,
+  GLOBAL        : false,
+  // In Node it is ok to exports = module.exports = foo();
   exports       : true,
-  process       : true,
-  setTimeout    : true,
-  clearTimeout  : true,
-  setInterval   : true,
-  clearInterval : true,
-  setImmediate  : true, // v0.9.1+
-  clearImmediate: true  // v0.9.1+
+  module        : false,
+  process       : false,
+  require       : false,
+  setTimeout    : false,
+  clearTimeout  : false,
+  setInterval   : false,
+  clearInterval : false,
+  setImmediate  : false, // v0.9.1+
+  clearImmediate: false, // v0.9.1+
 };
 
 exports.browserify = {
@@ -446,9 +443,9 @@ exports.browserify = {
   global        : false,
   module        : false,
   require       : false,
-  Buffer        : true,
+  Buffer        : false,
   exports       : true,
-  process       : true
+  process       : false
 };
 
 exports.phantom = {

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -80,10 +80,21 @@ exports.node = function (test) {
 
   TestRun(test)
     .addError(1, "Read only.")
+    .addError(2, "Read only.")
     .test(overwrites, { es3: true, node: true });
 
   TestRun(test)
     .addError(1, "Read only.")
+    .addError(2, "Read only.")
+    .test(overwrites, { es3: true, browserify: true });
+
+  // Make sure that users are able to make globals writable
+  overwrites.unshift("/* globals global:true, Buffer:true */");
+
+  TestRun(test)
+    .test(overwrites, { es3: true, node: true });
+
+  TestRun(test)
     .test(overwrites, { es3: true, browserify: true });
 
   test.done();


### PR DESCRIPTION
Make global variables except `export` readonly in node and browserify
environments.

jshint has options to make global variables writable so that developers can
suppress errors when they really have to do.

BREAKING CHANGE:

This change will add `Read only.` errors to scripts which overwrite global
variables in node and browserify environments.

In order to work around this change, you'll need add a `/* globals foo:true */`
to your scripts to make `foo` writable.
