### PR TITLE
Detect unused variables that are only ever assigned to, but never referenced

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1889,8 +1889,10 @@ var JSHINT = (function() {
         // the name is in a block scope.
         switch (block ? block[v]["(type)"] : funct[v]) {
         case "unused":
-          if (block) block[v]["(type)"] = "var";
-          else funct[v] = "var";
+          if (state.tokens.next.id !== "=") {
+            if (block) block[v]["(type)"] = "var";
+            else funct[v] = "var";
+          }
           break;
         case "unction":
           if (block) block[v]["(type)"] = "function";

--- a/tests/regression/thirdparty.js
+++ b/tests/regression/thirdparty.js
@@ -30,6 +30,7 @@ exports.jQuery_1_7 = function (test) {
     .addError(1607, "'table' is defined but never used.")
     .addError(1710, "'internalKey' is defined but never used.")
     .addError(1813, "'internalKey' is defined but never used.")
+    .addError(2174, "'object' is defined but never used.")
     .addError(2818, "Expected an assignment or function call and instead saw an expression.")
     .addError(2822, "Expected an assignment or function call and instead saw an expression.")
     .addError(2859, "'rnamespaces' is defined but never used.")
@@ -49,6 +50,7 @@ exports.jQuery_1_7 = function (test) {
     .addError(5691, "'i' is defined but never used.")
     .addError(7141, "'i' is defined but never used.")
     .addError(6061, "'cur' is defined but never used.")
+    .addError(9022, "'prevOffsetParent' is defined but never used.")
     .test(src, { undef: true, unused: true }, globals);
 
   test.done();

--- a/tests/unit/fixtures/gh870.js
+++ b/tests/unit/fixtures/gh870.js
@@ -1,4 +1,4 @@
-var s;
+var s; // jshint ignore:line
 var iterator;
 
 while (s = iterator.next()) { // jshint ignore:line

--- a/tests/unit/fixtures/unused.js
+++ b/tests/unit/fixtures/unused.js
@@ -52,3 +52,10 @@ c.delete(hoistedDelete);
 // passed to methods that look like unresolvable-reference-accepting operators.
 function hoistedDelete() {}
 function hoistedTypeof() {}
+
+var i = 1;
+var j = 2;
+var k = 3;
+i = 2;
+j++;
+k += 2;

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -600,8 +600,10 @@ exports.unused = function (test) {
     [15, "'foo' is defined but never used."],
     [20, "'bar' is defined but never used."],
     [22, "'i' is defined but never used."],
+    [23, "'char' is defined but never used."],
     [36, "'cc' is defined but never used."],
-    [39, "'dd' is defined but never used."]
+    [39, "'dd' is defined but never used."],
+    [56, "'i' is defined but never used."]
   ];
 
   var last_param_errors = [
@@ -643,7 +645,7 @@ exports.unused = function (test) {
   vars_run.test(src, { esnext: true, unused: "vars"});
 
   var unused = JSHINT.data().unused;
-  test.equal(12, unused.length);
+  test.equal(14, unused.length);
   test.ok(unused.some(function (err) { return err.line === 1 && err.character == 5 && err.name === "a"; }));
   test.ok(unused.some(function (err) { return err.line === 6 && err.character == 18 && err.name === "f"; }));
   test.ok(unused.some(function (err) { return err.line === 7 && err.character == 9 && err.name === "c"; }));

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4871,6 +4871,7 @@ exports["jshint ignore:start/end should be detected using single line comments"]
 exports["test destructuring function parameters as es5"] = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/destparam.js", "utf8");
   TestRun(test)
+    .addError(1, "'foo' is defined but never used.")
     .addError(4, "'destructuring expression' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
     .addError(4, "'arrow function syntax (=>)' is only available in ES6 (use esnext option).")
     .addError(5, "'destructuring expression' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
@@ -4932,6 +4933,7 @@ exports["test destructuring function parameters as es5"] = function (test) {
 exports["test destructuring function parameters as legacy JS"] = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/destparam.js", "utf8");
   TestRun(test)
+    .addError(1, "'foo' is defined but never used.")
     .addError(4, "'destructuring expression' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
     .addError(4, "'arrow function syntax (=>)' is only available in ES6 (use esnext option).")
     .addError(5, "'destructuring expression' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")


### PR DESCRIPTION
Variables first declared then assigned to are now detected:

    var x;
    x = 1;

A further, more complicated improvement not covered by this patch would be to keep track of the usage of each assigned value of every variable, to detect cases like:

    var x = 1;
    x = x + 1;

Fixes #1994