### PR TITLE
Remove Set from the ECMAScript5 reserved words

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -36,7 +36,6 @@ exports.ecmaIdentifiers = {
   RangeError         : false,
   ReferenceError     : false,
   RegExp             : false,
-  Set                : false,
   String             : false,
   SyntaxError        : false,
   TypeError          : false,


### PR DESCRIPTION
Set is an ECMAScript 6 proposal; in 5 it must be required or manually defined. This fixes an erroneous "Redefinition of..." warning.

(Set is already in the `newEcmaIdentifiers` object, so it didn't need to be added)