### PR TITLE
informative error when jshintrc is invalid

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -540,7 +540,7 @@ var exports = {
 
       return config;
     } catch (err) {
-      cli.error("Can't parse config file: " + fp +"\n Error:"+err);
+      cli.error("Can't parse config file: " + fp + "\n Error:" + err);
       exports.exit(1);
     }
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -540,7 +540,7 @@ var exports = {
 
       return config;
     } catch (err) {
-      cli.error("Can't parse config file: " + fp);
+      cli.error("Can't parse config file: " + fp +"\n Error:"+err);
       exports.exit(1);
     }
   },


### PR DESCRIPTION
When jshintrc is incorrect, i want to know what happened. 
Therefore i am adding the error message to the error and not just saying that the file couldn't be parsed