### PR TITLE
[[FIX]] Assignment is not bad invocation

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2430,7 +2430,8 @@ var JSHINT = (function() {
       }
       if (!left.identifier && left.id !== "." && left.id !== "[" &&
           left.id !== "(" && left.id !== "&&" && left.id !== "||" &&
-          left.id !== "?" && !(state.option.esnext && left["(name)"])) {
+          left.id !== "?" && !(state.option.esnext && left["(name)"]) &&
+          left.id !== "=") {
         warning("W067", that);
       }
     }

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1139,3 +1139,11 @@ exports.testUnCleanedForinifcheckneeded = function (test) {
 
   test.done();
 };
+
+exports.testInvocationAfterAssignment = function (test) {
+  var code = "var foo; (foo = function() { })();";
+
+  TestRun(test).test(code);
+
+  test.done();
+};


### PR DESCRIPTION
There are a multitude of operators that are tested for the left side of
an invocation, as they will evaluate into something that could be a
function. One such missing operator was the assignment operator.

Aside: I know this is something that our CoffeeScript-generated application fails on, and it seems like a reasonable addition.
