### PR TITLE
Class expr identifier

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1172,7 +1172,7 @@ var JSHINT = (function() {
       nobreaknonadjacent(state.tokens.prev, state.tokens.curr);
 
       this.left = left;
-      this.right = doFunction(undefined, undefined, false, { loneArg: left });
+      this.right = doFunction({ type: "arrow", loneArg: left });
       return this;
     };
     return x;
@@ -2467,7 +2467,7 @@ var JSHINT = (function() {
     // current token marks the beginning of a "fat arrow" function and parsing
     // should proceed accordingly.
     if (pn.value === "=>") {
-      return doFunction(null, null, null, { parsedParen: true });
+      return doFunction({ type: "arrow", parsedOpening: true });
     }
 
     var exprs = [];
@@ -2730,14 +2730,22 @@ var JSHINT = (function() {
     return id;
   }
 
-  function functionparams(fatarrow) {
+  /**
+   * @param {Object} [options]
+   * @param {token} [options.loneArg] The argument to the function in cases
+   *                                  where it was defined using the
+   *                                  single-argument shorthand.
+   * @param {bool} [options.parsedOpening] Whether the opening parenthesis has
+   *                                       already been parsed.
+   */
+  function functionparams(options) {
     var next;
     var params = [];
     var ident;
     var tokens = [];
     var t;
     var pastDefault = false;
-    var loneArg = fatarrow && fatarrow.loneArg;
+    var loneArg = options && options.loneArg;
 
     if (loneArg && loneArg.identifier === true) {
       addlabel(loneArg.value, { type: "unused", token: loneArg });
@@ -2746,7 +2754,7 @@ var JSHINT = (function() {
 
     next = state.tokens.next;
 
-    if (!fatarrow || !fatarrow.parsedParen) {
+    if (!options || !options.parsedOpening) {
       advance("(");
     }
 
@@ -2879,30 +2887,38 @@ var JSHINT = (function() {
   }
 
   /**
-   * @param {Object} [fatarrow] In the case that the function being parsed
-   *                            takes the "fat arrow" form, this object will
-   *                            contain details about the in-progress parsing
-   *                            operation.
-   * @param {Token} [fatarrow.loneArg] The argument to the function in cases
-   *                                   where it was defined using the single-
-   *                                   argument shorthand.
-   * @param {bool} [fatarrow.parsedParen] Whether the opening parenthesis has
-   *                                      already been parsed.
+   * @param {Object} [options]
+   * @param {token} [options.name] The identifier belonging to the function (if
+   *                               any)
+   * @param {token} [options.statement] The statement to which the function
+   *                                    belongs
+   * @param {string} [options.type] If specified, either "generator" or "arrow"
+   * @param {token} [options.loneArg] The argument to the function in cases
+   *                                  where it was defined using the
+   *                                  single-argument shorthand
+   * @param {bool} [options.parsedOpening] Whether the opening parenthesis has
+   *                                       already been parsed
    */
-  function doFunction(name, statement, generator, fatarrow) {
-    var f;
+  function doFunction(options) {
+    var f, name, isGenerator, isArrow;
     var oldOption = state.option;
     var oldIgnored = state.ignored;
     var oldScope  = scope;
+
+    if (options) {
+      name = options.name;
+      isGenerator = options.type === "generator";
+      isArrow = options.type === "arrow";
+    }
 
     state.option = Object.create(state.option);
     state.ignored = Object.create(state.ignored);
     scope = Object.create(scope);
 
     funct = functor(name || state.nameStack.infer(), state.tokens.next, scope, {
-      "(statement)": statement,
+      "(statement)": options && options.statement,
       "(context)":   funct,
-      "(generator)": generator ? true : null
+      "(generator)": isGenerator
     });
 
     f = funct;
@@ -2914,22 +2930,22 @@ var JSHINT = (function() {
       addlabel(name, { type: "function" });
     }
 
-    funct["(params)"] = functionparams(fatarrow);
+    funct["(params)"] = functionparams(options);
     funct["(metrics)"].verifyMaxParametersPerFunction(funct["(params)"]);
 
-    if (fatarrow) {
+    if (isArrow) {
       if (!state.option.esnext) {
         warning("W119", state.tokens.curr, "arrow function syntax (=>)");
       }
 
-      if (!fatarrow.loneArg) {
+      if (!options.loneArg) {
         advance("=>");
       }
     }
 
-    block(false, true, true, !!fatarrow);
+    block(false, true, true, isArrow);
 
-    if (!state.option.noyield && generator &&
+    if (!state.option.noyield && isGenerator &&
         funct["(generator)"] !== "yielded") {
       warning("W124", state.tokens.curr);
     }
@@ -3093,7 +3109,6 @@ var JSHINT = (function() {
             warning("W077", t, i);
           }
         } else {
-          g = false;
           if (state.tokens.next.value === "*" && state.tokens.next.type === "(punctuator)") {
             if (!state.option.inESNext()) {
               warning("W104", state.tokens.next, "generator functions");
@@ -3128,7 +3143,7 @@ var JSHINT = (function() {
               if (!state.option.inESNext()) {
                 warning("W104", state.tokens.curr, "concise methods");
               }
-              doFunction(null, undefined, g);
+              doFunction({ type: g ? "generator" : null });
             } else {
               advance(":");
               expression(10);
@@ -3555,7 +3570,7 @@ var JSHINT = (function() {
           advance();
         }
         if (state.tokens.next.value !== "(") {
-          doFunction(undefined, c, false, null);
+          doFunction({ statement: c });
         }
       }
 
@@ -3583,7 +3598,7 @@ var JSHINT = (function() {
 
       propertyName(name);
 
-      doFunction(null, c, isGenerator, null);
+      doFunction({ statement: c, type: isGenerator ? "generator" : null });
     }
 
     checkProperties(props);
@@ -3614,7 +3629,11 @@ var JSHINT = (function() {
     }
     addlabel(i, { type: "unction", token: state.tokens.curr });
 
-    doFunction(i, { statement: true }, generator);
+    doFunction({
+      name: i,
+      statement: { statement: true },
+      type: generator ? "generator" : null
+    });
     if (state.tokens.next.id === "(" && state.tokens.next.line === state.tokens.curr.line) {
       error("E039");
     }
@@ -3633,7 +3652,7 @@ var JSHINT = (function() {
     }
 
     var i = optionalidentifier();
-    var fn = doFunction(i, undefined, generator);
+    var fn = doFunction({ name: i, type: generator ? "generator" : null });
 
     function isVariable(name) { return name[0] !== "("; }
     function isLocal(name) { return fn[name] === "var"; }

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2899,9 +2899,14 @@ var JSHINT = (function() {
    *                                  single-argument shorthand
    * @param {bool} [options.parsedOpening] Whether the opening parenthesis has
    *                                       already been parsed
+   * @param {token} [options.classExprBinding] Define a function with this
+   *                                           identifier in the new function's
+   *                                           scope, mimicking the bahavior of
+   *                                           class expression names within
+   *                                           the body of member functions.
    */
   function doFunction(options) {
-    var f, name, isStatement, isGenerator, isArrow;
+    var f, name, isStatement, classExprBinding, isGenerator, isArrow;
     var oldOption = state.option;
     var oldIgnored = state.ignored;
     var oldScope  = scope;
@@ -2909,6 +2914,7 @@ var JSHINT = (function() {
     if (options) {
       name = options.name;
       isStatement = options.isStatement;
+      classExprBinding = options.classExprBinding;
       isGenerator = options.type === "generator";
       isArrow = options.type === "arrow";
     }
@@ -2930,6 +2936,10 @@ var JSHINT = (function() {
 
     if (name) {
       addlabel(name, { type: "function" });
+    }
+
+    if (classExprBinding) {
+      addlabel(classExprBinding, { type: "function" });
     }
 
     funct["(params)"] = functionparams(options);
@@ -3484,6 +3494,7 @@ var JSHINT = (function() {
     } else if (state.tokens.next.identifier && state.tokens.next.value !== "extends") {
       // BindingIdentifier(opt)
       this.name = identifier();
+      this.namedExpr = true;
     } else {
       this.name = state.nameStack.infer();
     }
@@ -3600,7 +3611,11 @@ var JSHINT = (function() {
 
       propertyName(name);
 
-      doFunction({ isStatement: true, type: isGenerator ? "generator" : null });
+      doFunction({
+        isStatement: true,
+        type: isGenerator ? "generator" : null,
+        classExprBinding: c.namedExpr ? c.name : null
+      });
     }
 
     checkProperties(props);

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2890,8 +2890,9 @@ var JSHINT = (function() {
    * @param {Object} [options]
    * @param {token} [options.name] The identifier belonging to the function (if
    *                               any)
-   * @param {token} [options.statement] The statement to which the function
-   *                                    belongs
+   * @param {boolean} [options.isStatement] Whether the function has been
+   *                                        declared as part of another
+   *                                        statement
    * @param {string} [options.type] If specified, either "generator" or "arrow"
    * @param {token} [options.loneArg] The argument to the function in cases
    *                                  where it was defined using the
@@ -2900,13 +2901,14 @@ var JSHINT = (function() {
    *                                       already been parsed
    */
   function doFunction(options) {
-    var f, name, isGenerator, isArrow;
+    var f, name, isStatement, isGenerator, isArrow;
     var oldOption = state.option;
     var oldIgnored = state.ignored;
     var oldScope  = scope;
 
     if (options) {
       name = options.name;
+      isStatement = options.isStatement;
       isGenerator = options.type === "generator";
       isArrow = options.type === "arrow";
     }
@@ -2916,7 +2918,7 @@ var JSHINT = (function() {
     scope = Object.create(scope);
 
     funct = functor(name || state.nameStack.infer(), state.tokens.next, scope, {
-      "(statement)": options && options.statement,
+      "(statement)": isStatement,
       "(context)":   funct,
       "(generator)": isGenerator
     });
@@ -3570,7 +3572,7 @@ var JSHINT = (function() {
           advance();
         }
         if (state.tokens.next.value !== "(") {
-          doFunction({ statement: c });
+          doFunction({ isStatement: true });
         }
       }
 
@@ -3598,7 +3600,7 @@ var JSHINT = (function() {
 
       propertyName(name);
 
-      doFunction({ statement: c, type: isGenerator ? "generator" : null });
+      doFunction({ isStatement: true, type: isGenerator ? "generator" : null });
     }
 
     checkProperties(props);
@@ -3631,7 +3633,7 @@ var JSHINT = (function() {
 
     doFunction({
       name: i,
-      statement: { statement: true },
+      isStatement: true,
       type: generator ? "generator" : null
     });
     if (state.tokens.next.id === "(" && state.tokens.next.line === state.tokens.curr.line) {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4315,6 +4315,30 @@ exports["class method this"] = function (test) {
   test.done();
 };
 
+exports.classExpression = function (test) {
+  var code = [
+    "void class MyClass {",
+    "  constructor() { MyClass = null; }",
+    "  method() { MyClass = null; }",
+    "  static method() { MyClass = null; }",
+    "  get accessor() { MyClass = null; }",
+    "  set accessor() { MyClass = null; }",
+    "};",
+    "void MyClass;"
+  ];
+
+  TestRun(test)
+    .addError(2, "'MyClass' is a function.")
+    .addError(3, "'MyClass' is a function.")
+    .addError(4, "'MyClass' is a function.")
+    .addError(5, "'MyClass' is a function.")
+    .addError(6, "'MyClass' is a function.")
+    .addError(8, "'MyClass' is not defined.")
+    .test(code, { esnext: true, undef: true });
+
+  test.done();
+};
+
 exports["test for GH-1018"] = function (test) {
   var code = [
     "if (a = 42) {}",


### PR DESCRIPTION
Rather than add yet another optional positional argument to `doFunction`, I bit the bullet and refactored the function to accept a single "options" argument. This is something we've discussed in the past, so I don't think it's too controversial.

I was hoping to find some way to unify the `name` option and the (proposed) `classExprBinding` option since they both create an entry in the function's scope. These attempts resulted in a strange, error prone API that split apart the function's name (as [given to `functor`](https://github.com/jshint/jshint/blob/4e59553f7e2e09ba6c15643fdcb5b4416301148f/src/jshint.js#L2902) and [used in result reporting](https://github.com/jshint/jshint/pull/1971)) from the variable inserted into the function scope. If there's a better way to combine these similar-looking options, I'm all ears!

This should resolve gh-2182. 