### PR TITLE
[[FIX]] Remove tautological condition

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2480,7 +2480,7 @@ var JSHINT = (function() {
           break;
         }
 
-        if (pn1.value !== "=>" && state.option.nocomma) {
+        if (state.option.nocomma) {
           warning("W127");
         }
 


### PR DESCRIPTION
The parsing logic for the `(` prefix token returns early if the token is
determined to mark the beginning of an arrow function parameter list.
Logic that follows can safely assume that the token is *not* part of an
arrow function parameter lists, and explicit conditions to verify this
are unnecessary.