### PR TITLE
[[FIX]] Do not crash on improper use of `delete`

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2224,7 +2224,11 @@ var JSHINT = (function() {
   state.syntax["--"].exps = true;
   prefix("delete", function() {
     var p = expression(10);
-    if (!p || (p.id !== "." && p.id !== "[")) {
+    if (!p) {
+      return this;
+    }
+
+    if (p.id !== "." && p.id !== "[") {
       warning("W051");
     }
     this.first = p;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5261,3 +5261,12 @@ exports.testStrictDirectiveASI = function (test) {
 
   test.done();
 };
+
+exports.dereferenceDelete = function (test) {
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw '.'.")
+    .addError(1, "Missing semicolon.")
+    .test("delete.foo();");
+
+  test.done();
+};


### PR DESCRIPTION
This should resolve gh-2168

Commit message:

> In valid JavaScript code, when the `delete` token is parsed as a prefix,
> it will be followed by an expression of some kind. Invalid code may
> include any sequence of characters after the `delete` token, and JSHint
> should be capable of gracefully warning about the syntax error.
>
> Avoid crashing in cases where the `delete` appears as a "prefix" token
> but is not followed by an expression.