### PR TITLE
[[FIX]] Permit "eval" as object key

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1242,6 +1242,27 @@ var JSHINT = (function() {
     return false;
   }
 
+  function isGlobalEval(left, state, funct) {
+    var isGlobal = false;
+
+    // permit methods to refer to an "eval" key in their own context
+    if (left.type === "this" && funct["(context)"] === null) {
+      isGlobal = true;
+    }
+    // permit use of "eval" members of objects
+    else if (left.type === "(identifier)") {
+      if (state.option.node && left.value === "global") {
+        isGlobal = true;
+      }
+
+      else if (state.option.browser && (left.value === "window" || left.value === "document")) {
+        isGlobal = true;
+      }
+    }
+
+    return isGlobal;
+  }
+
   function findNativePrototype(left) {
     var natives = [
       "Array", "ArrayBuffer", "Boolean", "Collator", "DataView", "Date",
@@ -2396,7 +2417,9 @@ var JSHINT = (function() {
     }
 
     if (!state.option.evil && (m === "eval" || m === "execScript")) {
-      warning("W061");
+      if (isGlobalEval(left, state, funct)) {
+        warning("W061");
+      }
     }
 
     return that;
@@ -2588,7 +2611,9 @@ var JSHINT = (function() {
     var e = expression(10), s;
     if (e && e.type === "(string)") {
       if (!state.option.evil && (e.value === "eval" || e.value === "execScript")) {
-        warning("W061", that);
+        if (isGlobalEval(left, state, funct)) {
+          warning("W061");
+        }
       }
 
       countMember(e.value);

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1142,22 +1142,30 @@ exports.testUnCleanedForinifcheckneeded = function (test) {
 
 // gh-738 "eval" as an object key should not cause `W061` warnngs
 exports.testPermitEvalAsKey = function (test) {
-  var src = fs.readFileSync(__dirname + "/fixtures/gh-738.js", "utf8");
+  var srcNode = fs.readFileSync(__dirname + "/fixtures/gh-738-node.js", "utf8");
+  var srcBrowser = fs.readFileSync(__dirname + "/fixtures/gh-738-browser.js", "utf8");
   // global calls to eval should still cause warning.
   // test a mixture of permitted and disallowed calls
   // `global#eval` in `node:true` should still cause warning
   // `(document|window)#eval` in `browser:true` should still cause warning
 
+  // browser globals
   TestRun(test)
-    .addError(21, "eval can be harmful.")
-    .addError(22, "eval can be harmful.")
-    .addError(23, "eval can be harmful.")
-    .addError(25, "eval can be harmful.")
-    .addError(26, "eval can be harmful.")
-    .addError(28, "eval can be harmful.")
-    .addError(29, "eval can be harmful.")
-    .addError(31, "eval can be harmful.")
-    .test(src, { browser: true, node: true });
+  .addError(17, "eval can be harmful.")
+  .addError(19, "eval can be harmful.")
+  .addError(20, "eval can be harmful.")
+  .addError(22, "eval can be harmful.")
+  .addError(23, "eval can be harmful.")
+  .addError(25, "eval can be harmful.")
+  .test(srcBrowser, { browser: true });
+
+  // node globals
+  TestRun(test)
+  .addError(18, "eval can be harmful.")
+  .addError(19, "eval can be harmful.")
+  .addError(20, "eval can be harmful.")
+  .addError(22, "eval can be harmful.")
+  .test(srcNode, { node: true });
 
   test.done();
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1139,3 +1139,26 @@ exports.testUnCleanedForinifcheckneeded = function (test) {
 
   test.done();
 };
+
+// gh-738 "eval" as an object key should not cause `W061` warnngs
+exports.testPermitEvalAsKey = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/gh-738.js", "utf8");
+  // global calls to eval should still cause warning.
+  // test a mixture of permitted and disallowed calls
+  // `global#eval` in `node:true` should still cause warning
+  // `(document|window)#eval` in `browser:true` should still cause warning
+
+  TestRun(test)
+    .addError(21, "eval can be harmful.")
+    .addError(22, "eval can be harmful.")
+    .addError(23, "eval can be harmful.")
+    .addError(25, "eval can be harmful.")
+    .addError(26, "eval can be harmful.")
+    .addError(28, "eval can be harmful.")
+    .addError(29, "eval can be harmful.")
+    .addError(31, "eval can be harmful.")
+    .test(src, { browser: true, node: true });
+
+  test.done();
+
+};

--- a/tests/unit/fixtures/gh-738-browser.js
+++ b/tests/unit/fixtures/gh-738-browser.js
@@ -1,6 +1,3 @@
-/* jshint browser:true */
-/* jshint node:true */
-
 // object with "eval" key
 var obj = {
 	eval: function (str) {
@@ -17,9 +14,6 @@ var obj = {
 obj["eval"]("console.log('hello world');");
 obj.eval("console.log('hello world');");
 
-// global use, forbidden
-global["eval"]("console.log('hello world');");
-global.eval("1+1");
 eval("console.log('hello world');");
 
 window.eval("4+2");

--- a/tests/unit/fixtures/gh-738-node.js
+++ b/tests/unit/fixtures/gh-738-node.js
@@ -1,0 +1,22 @@
+// object with "eval" key
+var obj = {
+	eval: function (str) {
+		return str;
+	},
+	wrapper: function (str) {
+		// method calling "eval" key from context
+		// permitted use
+		return this.eval(str);
+	}
+};
+
+// object-key use, permitted
+obj["eval"]("console.log('hello world');");
+obj.eval("console.log('hello world');");
+
+// global use, forbidden
+global["eval"]("console.log('hello world');");
+global.eval("1+1");
+eval("console.log('hello world');");
+
+this.eval("2+2");

--- a/tests/unit/fixtures/gh-738.js
+++ b/tests/unit/fixtures/gh-738.js
@@ -1,0 +1,31 @@
+/* jshint browser:true */
+/* jshint node:true */
+
+// object with "eval" key
+var obj = {
+	eval: function (str) {
+		return str;
+	},
+	wrapper: function (str) {
+		// method calling "eval" key from context
+		// permitted use
+		return this.eval(str);
+	}
+};
+
+// object-key use, permitted
+obj["eval"]('console.log(\'hello world\');');
+obj.eval('console.log(\'hello world\');');
+
+// global use, forbidden
+global["eval"]('console.log(\'hello world\');');
+global.eval("1+1");
+eval('console.log(\'hello world\');');
+
+window.eval('4+2');
+window['eval']('4+2');
+
+document.eval('4+2');
+document['eval']('4+2');
+
+this.eval('2+2');

--- a/tests/unit/fixtures/gh-738.js
+++ b/tests/unit/fixtures/gh-738.js
@@ -14,18 +14,18 @@ var obj = {
 };
 
 // object-key use, permitted
-obj["eval"]('console.log(\'hello world\');');
-obj.eval('console.log(\'hello world\');');
+obj["eval"]("console.log('hello world');");
+obj.eval("console.log('hello world');");
 
 // global use, forbidden
-global["eval"]('console.log(\'hello world\');');
+global["eval"]("console.log('hello world');");
 global.eval("1+1");
-eval('console.log(\'hello world\');');
+eval("console.log('hello world');");
 
-window.eval('4+2');
-window['eval']('4+2');
+window.eval("4+2");
+window["eval"]("4+2");
 
-document.eval('4+2');
-document['eval']('4+2');
+document.eval("4+2");
+document["eval"]("4+2");
 
-this.eval('2+2');
+this.eval("2+2");


### PR DESCRIPTION
Makes it possible to use "eval" as a key in an object. Previously this
would have emitted a "W061" warning. "eval" used as the key for a
presumed global ("window" in "browser:true" and "global" in
"node:true") will still emit the warning.

Fixes https://github.com/jshint/jshint/issues/738

Adds unit tests for permitting using "eval" as object key