### PR TITLE
[[DOCS]] Update link to CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ to a snippet, graffiti outside of Anton's apartment, etc.
 However, before sending a patch, please make sure that the following applies:
 
 * Your commit message follows the [Commit Message Guidelines](#commit-message-guidelines).
-* You have signed the [Contributor's License Agreement](https://docs.google.com/forms/d/1BkEC9ds73aQLF73_kTX-9nhKCBJ8U5aFFUb-_Trt8Bc/viewform).
+* You have signed the [Contributor's License Agreement](https://www.clahub.com/agreements/jshint/jshint).
 * Your patch doesn't have useless merge commits.
 * Your coding style is similar to ours (see below).
 * Your patch is 100% tested. We don't accept any test regressions.


### PR DESCRIPTION
The project now uses the CLAHub service to assist in the process of
verifying contributor agreements.

Here's the status report as displayed by GitHub on an unrelated pull request. In the second half of the image, you can see that CLAHub automatically re-checked the pull request after I signed the agreement:

![jshint-cla](https://cloud.githubusercontent.com/assets/677252/6332512/fdaead7e-bb53-11e4-8dc2-ca7533c3a12b.png)
