### PR TITLE
[[DOCS]] Introduce a mail mapping file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,25 @@
+Anton Kovalyov <anton@kovalyov.net> Anton Kovalyov <anton@medium.com>
+Rob Wu <gwnRob@gmail.com> Rob Wu <rob@robwu.nl>
+XhmikosR <xhmikosr@gmail.com> XhmikosR <xhmikosr@users.sourceforge.net>
+Thomas Peikert <t.s.peikert@gmail.com> Thomas Peikert <T.Peikert@skyfillers.com>
+Charmander <~@charmander.me> Charmander <campersander@gmail.com>
+Domenic Denicola <d@domenic.me> Domenic Denicola <domenic@domenicdenicola.com>
+Josh Perez <josh@goatslacker.com> Josh Perez <josh.perez@palm.com>
+Thomas Boyt <me@thomasboyt.com> Thomas Boyt <thomas.boyt@venmo.com>
+Jan Prachař <jan.prachar@gmail.com> Jan Prachař <jan.prachar@wikidi.com>
+Nikolay S. Frantsev <code@frantsev.ru> Nikolay S. Frantsev <privatbank@frantsev.ru>
+Caitlin Potter <caitpotter88@gmail.com> Caitlin Potter <snowball@defpixel.com>
+shahyar <jshint@yar.gs> shahyar <shahyar@gmail.com>
+Travis Kaufman <travis.kaufman@gmail.com> Travis Kaufman <tkaufman@appnexus.com>
+Juan Pablo Buritica <buritica@gmail.com> Juan Pablo Buritica <juanpablo@buritica.org>
+Jonah Kagan <jonahkagan@gmail.com> Jonah Kagan <jonah.kagan@clever.com>
+Jared Jacobs <jaredjacobs@gmail.com> Jared Jacobs <jared@42go.com>
+James Beavers <jamesjbeavers@gmail.com> James Beavers <jjbeaver@us.ibm.com>
+Mariusz Nowak <medyk@medikoo.com> Mariusz Nowak <mariusz@medikoo.com>
+Dominic Barnes <dominic@dbarnes.info> Dominic Barnes <dbarnes@treetopllc.com>
+Dominic Barnes <dominic@dbarnes.info> Dominic Barnes <contact@dominicbarnes.us>
+Timothy Yung <yungsters@gmail.com> yungsters <yungsters@fb.com>
+Carl Ekerot <kalle@implode.se> Carl Ekerot <carl.ekerot@lunicore.se>
+Ryan Cannon <ryan@ryancannon.com> Ryan Cannon <ryan@ryancannon.com>
+Rob Friesel <rob@founddrama.net> Rob Friesel <robf@dealer.com>
+Felix Gnass <fgnass@gmail.com> Felix Gnass <felix.gnass@neteye.de>


### PR DESCRIPTION
Some contributors have authored commits using different e-mail
addresses. Add a `.mailmap` file to allow git to correlate the identity
of these contributors across e-mail addresses.