### PR TITLE
[[FIX]] Don't treat referenced globals as locally defined

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -445,7 +445,7 @@ var JSHINT = (function() {
     }
 
     if (_.has(funct, name) && !funct["(global)"]) {
-      if (funct[name] === true) {
+      if (_.contains([ true, "global" ], funct[name])) {
         if (state.option.latedef) {
           if ((state.option.latedef === true && _.contains([funct[name], type], "unction")) ||
               !_.contains([funct[name], type], "unction")) {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2605,6 +2605,19 @@ exports["make sure var variables can shadow let variables"] = function (test) {
   test.done();
 };
 
+exports["make sure variables may shadow globals in functions after they are referenced"] = function (test) {
+  var code = [
+    "var foo;",
+    "function x() {",
+    "  foo();",
+    "  var foo;",
+    "}"
+  ];
+
+  TestRun(test).test(code);
+  test.done();
+};
+
 exports["test destructuring function as moz"] = function (test) {
   // Example from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [


### PR DESCRIPTION
In this example, `foo` would be considered already defined when reaching
the `var` statement in the function:

    var foo;
    function x() {
      foo();
      var foo;
    }

This is because after parsing the first reference to foo it would appear
in the `funct` scope as "global". The `addlabel` function would then
treat it as already defined instead of simply referenced.

By handling global variables with the same branch as referenced
variables in `addlabel`, no warning for redefinition is generated, which
is the expected behavior.

Fixes #2138