### PR TITLE
[[FIX]] Prevent beginning array from being confused for JSON

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4609,7 +4609,7 @@ var JSHINT = (function() {
         ret.isBlock = true;
         ret.notJson = true;
       }
-    } while (bracketStack > 0 && pn.id !== "(end)" && i < 15);
+    } while (bracketStack > 0 && pn.id !== "(end)");
     return ret;
   };
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1170,3 +1170,14 @@ exports.testPermitEvalAsKey = function (test) {
   test.done();
 
 };
+
+// gh-2194 jshint confusing arrays at beginning of file with JSON
+exports.beginningArraysAreNotJSON = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/gh-2194.js", "utf8");
+
+  TestRun(test)
+  .test(src);
+
+  test.done();
+
+};

--- a/tests/unit/fixtures/gh-2194.js
+++ b/tests/unit/fixtures/gh-2194.js
@@ -1,0 +1,3 @@
+[ 'w','a','f','f','l','e','s','a','r','e','a','w','e','s','o','m','e' ].map(function(letter) {
+  return letter;
+});


### PR DESCRIPTION
src/jshint.js was reading an array at the beginning of a file as JSON instead
of a code block. The parser read the '(begin)' token and then looped 15 times
looking for an end to the block, didn't find it, and considered itself to be
parsing JSON. JSON must use *only* double quotes to be valid, so single quotes
caused warnings.

[JSON spec](http://www.ietf.org/rfc/rfc4627.txt)
