### PR TITLE
[[FIX]] Make let variables in the closure shadow predefs

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1897,18 +1897,18 @@ var JSHINT = (function() {
         return this;
       }
 
+      block = funct["(blockscope)"].getlabel(v);
+
       if (typeof s === "function") {
         // Protection against accidental inheritance.
         s = undefined;
-      } else if (!funct["(blockscope)"].current.has(v) && typeof s === "boolean") {
+      } else if (!block && typeof s === "boolean") {
         f = funct;
         funct = functions[0];
         addlabel(v, { type: "var" });
         s = funct;
         funct = f;
       }
-
-      block = funct["(blockscope)"].getlabel(v);
 
       // The name is in scope and defined in the current function.
       if (funct === s || block) {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2605,6 +2605,34 @@ exports["make sure var variables can shadow let variables"] = function (test) {
   test.done();
 };
 
+exports["make sure let variables in the closure of functions shadow predefined globals"] = function (test) {
+  var code = [
+    "function x() {",
+    "  let foo;",
+    "  function y() {",
+    "    foo = {};",
+    "  }",
+    "}"
+  ];
+
+  TestRun(test).test(code, { esnext: true, predef: { foo: false } });
+  test.done();
+};
+
+exports["make sure let variables in the closure of blocks shadow predefined globals"] = function (test) {
+  var code = [
+    "function x() {",
+    "  let foo;",
+    "  {",
+    "    foo = {};",
+    "  }",
+    "}"
+  ];
+
+  TestRun(test).test(code, { esnext: true, predef: { foo: false } });
+  test.done();
+};
+
 exports["test destructuring function as moz"] = function (test) {
   // Example from https://developer.mozilla.org/en-US/docs/JavaScript/New_in_JavaScript/1.7
   var code = [


### PR DESCRIPTION
There is a problem when parsing an identifier that would resolve to a
predefined read-only global through the function scope chain.

When checking the block scope for the same identifier only the innermost
block is considered, so while this works:

    /* global foo: false */
    function x() {
      let foo;
      foo = {};
    }

... a W020 read only warning is generated when moving the assignment
into a subscope:

    /* global foo: false */
    function x() {
      let foo;
      {
        foo = {};
      }
    }

By checking the entire block scope chain for the identifier the
assignment generates no warning, as is expected.