### PR TITLE
[[FIX]] Disable `futurehostile` option by default

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3429,7 +3429,7 @@ var JSHINT = (function() {
           if (funct["(global)"]) {
             if (predefined[t.id] === false) {
               warning("W079", t.token, t.id);
-            } else if (!state.option.futurehostile) {
+            } else if (state.option.futurehostile === false) {
               if ((!state.option.inES5() && vars.ecmaIdentifiers[5][t.id] === false) ||
                 (!state.option.inESNext() && vars.ecmaIdentifiers[6][t.id] === false)) {
                 warning("W129", t.token, t.id);

--- a/src/options.js
+++ b/src/options.js
@@ -62,6 +62,14 @@ exports.bool = {
     eqeqeq      : true,
 
     /**
+     * This option enables warnings about the use of identifiers which are
+     * defined in future versions of JavaScript. Although overwriting them has
+     * no effect in contexts where they are not implemented, this practice can
+     * cause issues when migrating codebases to newer versions of the language.
+     */
+    futurehostile: true,
+
+    /**
      * This option suppresses warnings about invalid `typeof` operator values.
      * This operator has only [a limited set of possible return
      * values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof).
@@ -351,14 +359,6 @@ exports.bool = {
      * interpreter to do certain optimizations.
     */
     evil        : true,
-
-    /**
-     * This option supresses warnings about the use of identifiers which are
-     * defined in future versions of JavaScript. Although overwriting them has
-     * no effect in contexts where they are not implemented, this practice can
-     * cause issues when migrating codebases to newer versions of the language.
-     */
-    futurehostile: true,
 
     /**
      * This option prohibits the use of unary increment and decrement

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2221,10 +2221,10 @@ exports.futureHostile = function (test) {
     .addError(7, "'Symbol' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
     .addError(8, "'WeakMap' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
     .addError(9, "'WeakSet' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
-    .test(code, { es3: true, es5: false });
+    .test(code, { es3: true, es5: false, futurehostile: false });
 
   TestRun(test, "ES3 with option")
-    .test(code, { es3: true, es5: false, futurehostile: true });
+    .test(code, { es3: true, es5: false });
 
   TestRun(test, "ES5 without option")
     .addError(1, "Redefinition of 'JSON'.")
@@ -2236,17 +2236,14 @@ exports.futureHostile = function (test) {
     .addError(7, "'Symbol' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
     .addError(8, "'WeakMap' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
     .addError(9, "'WeakSet' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
-    .test(code, {});
+    .test(code, { futurehostile: false });
 
   TestRun(test, "ES5 with option")
     .addError(1, "Redefinition of 'JSON'.")
-    .test(code, {
-      futurehostile: true
-    });
+    .test(code, {});
 
   TestRun(test, "ES5 with opt-out")
     .test(code, {
-      futurehostile: true,
       predef: ["-JSON"]
     });
 
@@ -2260,7 +2257,7 @@ exports.futureHostile = function (test) {
     .addError(7, "Redefinition of 'Symbol'.")
     .addError(8, "Redefinition of 'WeakMap'.")
     .addError(9, "Redefinition of 'WeakSet'.")
-    .test(code, { esnext: true });
+    .test(code, { esnext: true, futurehostile: false });
 
   TestRun(test, "ESNext with option")
     .addError(1, "Redefinition of 'JSON'.")
@@ -2272,11 +2269,12 @@ exports.futureHostile = function (test) {
     .addError(7, "Redefinition of 'Symbol'.")
     .addError(8, "Redefinition of 'WeakMap'.")
     .addError(9, "Redefinition of 'WeakSet'.")
-    .test(code, { esnext: true, futurehostile: true });
+    .test(code, { esnext: true });
 
   TestRun(test, "ESNext with opt-out")
     .test(code, {
       esnext: true,
+      futurehostile: false,
       predef: [
         "-JSON",
         "-Map",


### PR DESCRIPTION
When enabled, this option generates a new warning for code that would
otherwise pass. Therefore, it should not be enabled by default until the
next major release of this library.