### PR TITLE
[[Fix]] validthis checks do not apply to module or class bodies

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2074,6 +2074,15 @@ var JSHINT = (function() {
   reservevar("Infinity");
   reservevar("null");
   reservevar("this", function(x) {
+    // ModuleBody (and everything contained therein) and ClassBody are
+    // strict by default, therefore cannot subject to "strict-mode violation" checks
+    var verb = funct["(context)"] && funct["(context)"]["(verb)"];
+
+    // "export" implies that this code is within a module
+    if (verb === "class" || verb === "export") {
+      return;
+    }
+
     if (state.directive["use strict"] && !isMethod() &&
         !state.option.validthis && ((funct["(statement)"] &&
         funct["(name)"].charAt(0) > "Z") || funct["(global)"])) {

--- a/tests/unit/fixtures/gh-2217.js
+++ b/tests/unit/fixtures/gh-2217.js
@@ -1,0 +1,31 @@
+export class Value {
+  constructor() {
+    this.a = 1;
+  }
+  method() {
+    return this.a - 1;
+  }
+}
+
+
+export function foo() {
+  this.a = 1;
+}
+
+export default function() {
+  this.a = 1;
+}
+
+class Value {
+  constructor() {
+    this.a = 1;
+  }
+  method() {
+    return this.a - 1;
+  }
+}
+
+
+function foo() {
+  this.a = 1;
+}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1264,6 +1264,15 @@ exports.validthis = function (test) {
   test.done();
 };
 
+exports["validthis checks do not apply to module or class bodies. gh-2217"] = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/gh-2217.js", "utf8");
+
+  TestRun(test)
+    .test(src, {esnext: true});
+
+  test.done();
+};
+
 /*
  * Test string relevant options
  *   multistr   allows multiline strings


### PR DESCRIPTION
ES6 class syntax creates a strict-mode-by-default boundary, which means that all code within the ClassBody is implicitly strict. This is also true of ModuleBody and all things therein.

Closes gh-2217