### PR TITLE
[[FIX]] Correctly enforce maxparams:0

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3110,7 +3110,7 @@ var JSHINT = (function() {
       verifyMaxParametersPerFunction: function(params) {
         params = params || [];
 
-        if (state.option.maxparams && params.length > state.option.maxparams) {
+        if (_.isNumber(state.option.maxparams) && params.length > state.option.maxparams) {
           warning("W072", functionStartToken, params.length);
         }
       },

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1618,6 +1618,10 @@ exports.maxparams = function (test) {
     .test(src, { es3: true, maxparams: 3 });
 
   TestRun(test)
+    .addError(4, "This function has too many parameters. (3)")
+    .test(src, {es3: true, maxparams: 0 });
+
+  TestRun(test)
     .test(src, { es3: true });
 
   test.done();


### PR DESCRIPTION
It protects against a relatively benign edge case, but it is absolutely incorrect behavior for the parser to fail to enforce `maxparams` when it is set to 0.

Previously setting maxparams:0 would cause the check to short-circuit,
permitting any number of parameters without issuing a warning. This PR
fixes the bug by testing whether maxparams is a number, instead of
whether it is truthy.

