### PR TITLE
[[FIX]] support absolute path on --exclude and --exclude-path and symbolic links

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -198,7 +198,13 @@ function loadIgnores(params) {
   }
 
   var lines = (file ? shjs.cat(file) : "").split("\n");
-  lines.unshift(params.exclude || "");
+  if(params.exclude && path.isAbsolute(params.exclude)) {
+    var exclude = fs.realpathSync(params.exclude);
+    exclude = exclude.slice(path.resolve(path.dirname(file)).length + 1);
+    lines.unshift(exclude);
+  } else {
+    lines.unshift(params.exclude || "");
+  }
 
   return lines
     .filter(function(line) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -196,10 +196,13 @@ function loadIgnores(params) {
   if (!file && !params.exclude) {
     return [];
   }
-  file = fs.realpathSync(file);
+  if (file)
+    file = fs.realpathSync(file);
 
   var lines = (file ? shjs.cat(file) : "").split("\n");
-  if(params.exclude && path.isAbsolute(params.exclude)) {
+  if (params.exclude && path.resolve(params.exclude) ===
+      path.normalize(params.exclude).replace(RegExp(path.sep + "$"), "")) {
+      // params.exclude is an absolute path
     var exclude = fs.realpathSync(params.exclude);
     exclude = exclude.slice(path.dirname(file).length + 1);
     lines.unshift(exclude);
@@ -229,7 +232,7 @@ function loadIgnores(params) {
  */
 function isIgnored(fp, patterns) {
   return patterns.some(function(ip) {
-    if (minimatch(path.resolve(fp), ip, { nocase: true })) {
+    if (minimatch(fs.realpathSync(fp), ip, { nocase: true })) {
       return true;
     }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -164,7 +164,7 @@ var findFileResults = {};
 function findFile(name, cwd) {
   cwd = cwd || process.cwd();
 
-  var filename = path.normalize(path.join(cwd, name));
+  var filename = path.resolve(cwd, name);
   if (findFileResults[filename] !== undefined) {
     return findFileResults[filename];
   }
@@ -196,11 +196,12 @@ function loadIgnores(params) {
   if (!file && !params.exclude) {
     return [];
   }
+  file = fs.realpathSync(file);
 
   var lines = (file ? shjs.cat(file) : "").split("\n");
   if(params.exclude && path.isAbsolute(params.exclude)) {
     var exclude = fs.realpathSync(params.exclude);
-    exclude = exclude.slice(path.resolve(path.dirname(file)).length + 1);
+    exclude = exclude.slice(path.dirname(file).length + 1);
     lines.unshift(exclude);
   } else {
     lines.unshift(params.exclude || "");

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -3,6 +3,7 @@
 var path  = require("path");
 var shjs  = require("shelljs");
 var sinon = require("sinon");
+var fs    = require("fs");
 
 var cliPath = path.resolve(__dirname, "../src/cli.js");
 var cli;
@@ -539,6 +540,10 @@ exports.group = {
 
     gather.returns([]);
 
+    var dirname = fs.realpathSync(__dirname);
+    this.sinon.stub(fs, "realpathSync", function(p) {
+      return path.resolve(p).replace(__dirname, dirname);
+    });
     this.sinon.stub(shjs, "test")
       .withArgs("-e", sinon.match(/.*/)).returns(true);
 
@@ -627,6 +632,10 @@ exports.group = {
     var dir = __dirname + "/../examples/";
     var files = [];
     this.sinon.stub(process, "cwd").returns(dir);
+    var dirname = fs.realpathSync(__dirname);
+    this.sinon.stub(fs, "realpathSync", function(p) {
+      return path.resolve(p).replace(__dirname, dirname);
+    });
 
     var demoFiles = [
       [ /file2?\.js$/, "console.log('Hello');" ],


### PR DESCRIPTION
add support for absolute path on `--exclude` and `--exclude-path` plus better symbolic links handling for these two options and for symbolic link to files to lint.

This should fix https://github.com/jshint/jshint/issues/1552 and https://github.com/plone/plone.recipe.codeanalysis/issues/73