### PR TITLE
[[FIX]] es6: export on var, let, const exports all variables, not just the first one

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -863,7 +863,7 @@ var JSHINT = (function() {
       funct["(blockscope)"].stack();
       advance("let");
       advance("(");
-      state.syntax["let"].fud.call(state.syntax["let"].fud);
+      state.tokens.prev.fud();
       advance(")");
     }
 
@@ -3415,12 +3415,12 @@ var JSHINT = (function() {
         tokens = destructuringExpression();
         lone = false;
       } else {
-        if (inexport) {
-          exported[state.tokens.next.value] = true;
-          state.tokens.next.exported = true;
-        }
         tokens = [ { id: identifier(), token: state.tokens.curr } ];
         lone = true;
+        if (inexport) {
+          exported[state.tokens.curr.value] = true;
+          state.tokens.curr.exported = true;
+        }
       }
       for (var t in tokens) {
         if (tokens.hasOwnProperty(t)) {
@@ -3486,12 +3486,12 @@ var JSHINT = (function() {
         tokens = destructuringExpression();
         lone = false;
       } else {
-        if (inexport) {
-          exported[state.tokens.next.value] = true;
-          state.tokens.next.exported = true;
-        }
         tokens = [ { id: identifier(), token: state.tokens.curr } ];
         lone = true;
+        if (inexport) {
+          exported[state.tokens.curr.value] = true;
+          state.tokens.curr.exported = true;
+        }
       }
       for (var t in tokens) {
         if (tokens.hasOwnProperty(t)) {
@@ -3576,12 +3576,12 @@ var JSHINT = (function() {
         tokens = destructuringExpression();
         lone = false;
       } else {
-        if (inexport) {
-          exported[state.tokens.next.value] = true;
-          state.tokens.next.exported = true;
-        }
         tokens = [ { id: identifier(), token: state.tokens.curr.value } ];
         lone = true;
+        if (inexport) {
+          exported[state.tokens.curr.value] = true;
+          state.tokens.curr.exported = true;
+        }
       }
       for (var t in tokens) {
         if (tokens.hasOwnProperty(t)) {
@@ -4169,13 +4169,13 @@ var JSHINT = (function() {
 
       if (state.tokens.next.id === "var") {
         advance("var");
-        state.syntax["var"].fud.call(state.syntax["var"].fud, { prefix: true });
+        state.tokens.curr.fud({ prefix: true });
       } else if (state.tokens.next.id === "let") {
         advance("let");
         // create a new block scope
         letscope = true;
         funct["(blockscope)"].stack();
-        state.syntax["let"].fud.call(state.syntax["let"].fud, { prefix: true });
+        state.tokens.curr.fud({ prefix: true });
       } else if (!state.tokens.next.identifier) {
         error("E030", state.tokens.next, state.tokens.next.type);
         advance();
@@ -4242,13 +4242,13 @@ var JSHINT = (function() {
       if (state.tokens.next.id !== ";") {
         if (state.tokens.next.id === "var") {
           advance("var");
-          state.syntax["var"].fud.call(state.syntax["var"].fud);
+          state.tokens.curr.fud();
         } else if (state.tokens.next.id === "let") {
           advance("let");
           // create a new block scope
           letscope = true;
           funct["(blockscope)"].stack();
-          state.syntax["let"].fud.call(state.syntax["let"].fud);
+          state.tokens.curr.fud();
         } else {
           for (;;) {
             expression(0, "for");
@@ -4601,15 +4601,15 @@ var JSHINT = (function() {
     if (state.tokens.next.id === "var") {
       // ExportDeclaration :: export VariableStatement
       advance("var");
-      state.syntax["var"].fud.call(state.syntax["var"].fud, { inexport:true });
+      state.tokens.curr.fud({ inexport:true });
     } else if (state.tokens.next.id === "let") {
       // ExportDeclaration :: export VariableStatement
       advance("let");
-      state.syntax["let"].fud.call(state.syntax["let"].fud, { inexport:true });
+      state.tokens.curr.fud({ inexport:true });
     } else if (state.tokens.next.id === "const") {
       // ExportDeclaration :: export VariableStatement
       advance("const");
-      state.syntax["const"].fud.call(state.syntax["const"].fud, { inexport:true });
+      state.tokens.curr.fud({ inexport:true });
     } else if (state.tokens.next.id === "function") {
       // ExportDeclaration :: export Declaration
       this.block = true;

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -723,7 +723,9 @@ exports.testES6ModulesNamedExportsAffectUnused = function (test) {
     "export var b = { baz: 'baz' };",
     "export function boo() { return z; }",
     "export class MyClass { }",
-    "export var one = 1, two = 2;"
+    "export var varone = 1, vartwo = 2;",
+    "export const constone = 1, consttwo = 2;",
+    "export let letone = 1, lettwo = 2;"
   ];
 
   TestRun(test)

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -722,7 +722,8 @@ exports.testES6ModulesNamedExportsAffectUnused = function (test) {
     "export { a, x };",
     "export var b = { baz: 'baz' };",
     "export function boo() { return z; }",
-    "export class MyClass { }"
+    "export class MyClass { }",
+    "export var one = 1, two = 2;"
   ];
 
   TestRun(test)


### PR DESCRIPTION
Fixes #2248 

Looks like code will have to be expanded again to work with export and de-structuring in the same var/let/const but I think its alot more work. This looks to me like a move in the right direction and fixes the bug and add tests.

I've signed the CLA.