### PR TITLE
[[FIX]] Incorrect 'Unclosed string' when the closing quote is the first character after a newline

### DIFF
--- a/tests/unit/fixtures/strings.js
+++ b/tests/unit/fixtures/strings.js
@@ -25,3 +25,6 @@ function octal_strictmode() {
   var test = "\033\t";
   test = "\0"; // Regression for false positives on \0
 }
+
+test = "closing quote on next line\
+";

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1286,6 +1286,7 @@ exports.strings = function (test) {
     .addError(14, "Bad escaping of EOL. Use option multistr if needed.")
     .addError(15, "Unclosed string.")
     .addError(25, "Octal literals are not allowed in strict mode.")
+    .addError(29, "Bad escaping of EOL. Use option multistr if needed.")
     .test(src, { es3: true });
 
   test.done();


### PR DESCRIPTION
Previously, the end-of-line loop was immediately followed by the non-quote character code. This
meant that the first character after an EOL was always treated as a non-quote character.

Control flow now returns to the quote character check in the while loop condition immediately
after each EOL or character has been handled, so that this check also runs for the first character
on a line.

Closes #1532. (The commit includes the test case provided in #1532 by DelvarWorld.)
Closes #1319.