### PR TITLE
[[FIX]] default to empty string in src/cli.js loadIgnores

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -191,7 +191,7 @@ function findFile(name, cwd) {
  * @return {array} a list of files to ignore.
  */
 function loadIgnores(params) {
-  var file = findFile(params.excludePath || ".jshintignore", params.cwd);
+  var file = findFile(params.excludePath || ".jshintignore", params.cwd) || '';
 
   if (!file && !params.exclude) {
     return [];


### PR DESCRIPTION
Related to https://github.com/iojs/io.js/pull/1153.

They added type checking for ~~`path.dirname`~~ the `path` library and this line below fails

````js
return path.join(path.dirname(file), line.trim());
````