### PR TITLE
[[FIX]] allow trailing comma in inline options

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -502,7 +502,11 @@ var JSHINT = (function() {
 
   function doOption() {
     var nt = state.tokens.next;
-    var body = nt.body.split(",").map(function(s) { return s.trim(); });
+    var body = nt.body.split(",").map(function(s) {
+      return s.trim();
+    }).filter(function(s) {
+      return s.length > 0;
+    });
     var predef = {};
 
     if (nt.type === "globals") {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -286,6 +286,15 @@ exports.jslintUnrecognized = function (test) {
   test.done();
 };
 
+exports.optionsElidedComma = function (test) {
+  var src = "/*jshint asi: true, */ /*global a, */ var b = a";
+
+  TestRun(test)
+    .test(src);
+
+  test.done();
+};
+
 exports.caseExpressions = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/caseExpressions.js', 'utf8');
   TestRun(test)


### PR DESCRIPTION
Allows options to have a useless trailing comma after them.