### PR TITLE
[[FIX]] Accept `get` and `set` as ID properties

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3200,7 +3200,17 @@ var JSHINT = (function() {
         }
 
         nextVal = state.tokens.next.value;
-        if (peek().id !== ":" && (nextVal === "get" || nextVal === "set")) {
+        if (state.tokens.next.identifier &&
+            (peekIgnoreEOL().id === "," || peekIgnoreEOL().id === "}")) {
+          if (!state.option.inESNext()) {
+            warning("W104", state.tokens.next, "object short notation");
+          }
+          i = propertyName(true);
+          saveProperty(props, i, state.tokens.next);
+
+          expression(10);
+
+        } else if (peek().id !== ":" && (nextVal === "get" || nextVal === "set")) {
           advance(nextVal);
 
           if (!state.option.inES5()) {
@@ -3240,38 +3250,28 @@ var JSHINT = (function() {
             advance("*");
             g = true;
           }
-          if (state.tokens.next.identifier &&
-              (peekIgnoreEOL().id === "," || peekIgnoreEOL().id === "}")) {
-            if (!state.option.inESNext()) {
-              warning("W104", state.tokens.next, "object short notation");
-            }
-            i = propertyName(true);
+
+          if (state.tokens.next.id === "[") {
+            i = computedPropertyName();
+            state.nameStack.set(i);
+          } else {
+            state.nameStack.set(state.tokens.next);
+            i = propertyName();
             saveProperty(props, i, state.tokens.next);
 
-            expression(10);
+            if (typeof i !== "string") {
+              break;
+            }
+          }
+
+          if (state.tokens.next.value === "(") {
+            if (!state.option.inESNext()) {
+              warning("W104", state.tokens.curr, "concise methods");
+            }
+            doFunction({ type: g ? "generator" : null });
           } else {
-            if (state.tokens.next.id === "[") {
-              i = computedPropertyName();
-              state.nameStack.set(i);
-            } else {
-              state.nameStack.set(state.tokens.next);
-              i = propertyName();
-              saveProperty(props, i, state.tokens.next);
-
-              if (typeof i !== "string") {
-                break;
-              }
-            }
-
-            if (state.tokens.next.value === "(") {
-              if (!state.option.inESNext()) {
-                warning("W104", state.tokens.curr, "concise methods");
-              }
-              doFunction({ type: g ? "generator" : null });
-            } else {
-              advance(":");
-              expression(10);
-            }
+            advance(":");
+            expression(10);
           }
         }
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5696,3 +5696,37 @@ exports.restOperatorWithoutIdentifier = function (test) {
 
   test.done();
 };
+
+exports.getAsIdentifierProp = function (test) {
+  TestRun(test)
+    .test('var get; var obj = { get };', { esnext: true });
+
+  TestRun(test)
+    .test('var set; var obj = { set };', { esnext: true });
+
+  TestRun(test)
+    .test('var get, set; var obj = { get, set };', { esnext: true });
+
+  TestRun(test)
+    .test('var get, set; var obj = { set, get };', { esnext: true });
+
+  TestRun(test)
+    .test('var get; var obj = { a: null, get };', { esnext: true });
+
+  TestRun(test)
+    .test('var get; var obj = { a: null, get, b: null };', { esnext: true });
+
+  TestRun(test)
+    .test('var get; var obj = { get, b: null };', { esnext: true });
+
+  TestRun(test)
+    .test('var get; var obj = { get, get a() {} };', { esnext: true });
+
+  TestRun(test)
+    .test([
+      'var set;',
+      'var obj = { set, get a() {}, set a(_) {} };'
+    ], { esnext: true });
+
+  test.done();
+};


### PR DESCRIPTION
`get` and `set` are both valid identifiers, so they may appear as PropertyDefinitions within a PropertyDefintionList.

(I moved some code around, so adding `?w=1` to the review URL will suppress white space changes and should make reviewing easier.)

Resolves gh-2288.