### PR TITLE
Update dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,22 +38,22 @@
     "console-browserify":  "1.1.x",
     "exit":                "0.1.x",
     "htmlparser2":         "3.8.x",
+    "lodash":              "3.8.x",
     "minimatch":           "2.0.x",
-    "shelljs":             "0.3.x",
-    "strip-json-comments": "1.0.x",
-    "lodash":              "3.7.x"
+    "shelljs":             "0.4.x",
+    "strip-json-comments": "1.0.x"
   },
 
   "devDependencies": {
-    "browserify":    "9.x",
+    "browserify":    "10.x",
     "coveralls":     "2.11.x",
     "istanbul":      "0.3.x",
     "jscs":          "1.11.x",
-    "jshint":        "2.6.x",
+    "jshint":        "2.7.x",
     "mock-stdin":    "0.3.x",
     "nodeunit":      "0.9.x",
     "regenerate":    "1.2.x",
-    "sinon":         "1.12.x",
+    "sinon":         "1.14.x",
     "unicode-6.3.0": "0.1.x"
   },
 


### PR DESCRIPTION
Note that the new JSCS version fails for indented comments. From a quick look, I couldn't find a fix; any feedback is welcomed.