### PR TITLE
[[FEAT]] Add option 'brkret' to suppress warning about unreachable break...

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1529,9 +1529,13 @@ var JSHINT = (function() {
           }
           break;
         }
-        if (!state.option.brkret) {
-          warning("W027", t, t.value, controlToken.value);
+
+        if (t.value === "break" && controlToken.value === "return") {
+          if (state.option.brkret === true) {
+            return;
+          }
         }
+        warning("W027", t, t.value, controlToken.value);
         break;
       }
     }

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1529,8 +1529,9 @@ var JSHINT = (function() {
           }
           break;
         }
-
-        warning("W027", t, t.value, controlToken.value);
+        if (!state.option.brkret) {
+          warning("W027", t, t.value, controlToken.value);
+        }
         break;
       }
     }

--- a/src/options.js
+++ b/src/options.js
@@ -354,6 +354,12 @@ exports.bool = {
     boss        : true,
 
     /**
+     * This option suppresses warnings about the use of break after return
+     * in switch statements. Usefull especialy with automaticaly generated code
+     */
+    brkret      : true,
+
+    /**
      * This option suppresses warnings about the use of `eval`. The use of
      * `eval` is discouraged because it can make your code vulnerable to
      * various injection attacks and it makes it hard for JavaScript

--- a/tests/unit/fixtures/brkret1.js
+++ b/tests/unit/fixtures/brkret1.js
@@ -1,0 +1,9 @@
+var x = 5;
+switch (x) {
+  case 1:
+    return;
+  case 2:
+    break;
+  default:
+    break;
+}

--- a/tests/unit/fixtures/brkret2.js
+++ b/tests/unit/fixtures/brkret2.js
@@ -1,0 +1,11 @@
+var x = 5;
+switch (x) {
+  case 1:
+    return;
+  case 2:
+    return;
+    break;
+  default:
+    return;
+    break;
+}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2391,3 +2391,21 @@ exports.errorI003 = function(test) {
 
   test.done();
 };
+
+exports.brkret = function (test) {
+  var src1  = fs.readFileSync(__dirname + '/fixtures/brkret1.js', 'utf8'),
+    src2 = fs.readFileSync(__dirname + '/fixtures/brkret2.js', 'utf8');
+
+  // By default, throw warning when there is break after return in switch statement
+  TestRun(test)
+    .addError(7, "Unreachable 'break' after 'return'.")
+    .addError(10, "Unreachable 'break' after 'return'.")
+    .test(src2);
+
+  TestRun(test).test(src1);
+
+  TestRun(test).test(src1, {brkret: true});
+  TestRun(test).test(src2, {brkret: true});
+
+  test.done();
+}


### PR DESCRIPTION
[[FEAT]] Add option 'brkret' to suppress warning about unreachable break after return statement

This options suppresses warnings about unreachable break after return. It is useful especially
with auto generated code.

This issue was already closed but with workaround 

Closes #757