### PR TITLE
Make the generated data files always use LF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+data/non-ascii-identifier-part-only.js  eol=lf
+data/non-ascii-identifier-start.js      eol=lf


### PR DESCRIPTION
This way, when `autocrlf` is set to `true`, we won't end up with modified files.