### PR TITLE
[[Fix]] Make const have block scope

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4887,6 +4887,40 @@ var JSHINT = (function() {
     }
   }
 
+  var warnUnused = function(name, tkn, type, unused_opt) {
+    var line = tkn.line;
+    var chr  = tkn.from;
+    var raw_name = tkn.raw_text || name;
+
+    if (unused_opt === undefined) {
+      unused_opt = state.option.unused;
+    }
+
+    if (unused_opt === true) {
+      unused_opt = "last-param";
+    }
+
+    var warnable_types = {
+      "vars": ["var"],
+      "last-param": ["var", "param"],
+      "strict": ["var", "param", "last-param"]
+    };
+
+    if (unused_opt) {
+      if (warnable_types[unused_opt] && warnable_types[unused_opt].indexOf(type) !== -1) {
+        if (!tkn.exported) {
+          warningAt("W098", line, chr, raw_name);
+        }
+      }
+    }
+
+    unuseds.push({
+      name: name,
+      line: line,
+      character: chr
+    });
+  };
+
   var blockScope = function() {
     var _current = {};
     var _variables = [_current];
@@ -4902,16 +4936,8 @@ var JSHINT = (function() {
             if (tkn.exported) {
               continue;
             }
-            var line = tkn.line;
-            var chr  = tkn.character;
-            warningAt("W098", line, chr, t);
 
-            // todo - use warnunused?
-            unuseds.push({
-              name: t,
-              line: line,
-              character: chr
-            });
+            warnUnused(t, tkn, "var");
           }
         }
       }
@@ -5258,40 +5284,6 @@ var JSHINT = (function() {
           delete implied[name];
         else
           implied[name] = newImplied;
-      };
-
-      var warnUnused = function(name, tkn, type, unused_opt) {
-        var line = tkn.line;
-        var chr  = tkn.from;
-        var raw_name = tkn.raw_text || name;
-
-        if (unused_opt === undefined) {
-          unused_opt = state.option.unused;
-        }
-
-        if (unused_opt === true) {
-          unused_opt = "last-param";
-        }
-
-        var warnable_types = {
-          "vars": ["var"],
-          "last-param": ["var", "param"],
-          "strict": ["var", "param", "last-param"]
-        };
-
-        if (unused_opt) {
-          if (warnable_types[unused_opt] && warnable_types[unused_opt].indexOf(type) !== -1) {
-            if (!tkn.exported) {
-              warningAt("W098", line, chr, raw_name);
-            }
-          }
-        }
-
-        unuseds.push({
-          name: name,
-          line: line,
-          character: chr
-        });
       };
 
       var checkUnused = function(func, key) {

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3470,7 +3470,7 @@ var JSHINT = (function() {
           if (t.id && (!isBlockScoped || !funct["(noblockscopedvar)"])) {
             addlabel(t.id, { type: isConst ? "const" : "unused",
               token: t.token,
-              isblockscoped: isBlockScoped }); //todo check in here for else block scoped const specofic
+              isblockscoped: isBlockScoped });
             names.push(t.token);
           }
         }

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1093,7 +1093,7 @@ var JSHINT = (function() {
           warning("W017", this);
         }
 
-        // detect modification of a const
+        // detect increment/decrement of a const
         // in the case of a.b, right will be the "." punctuator
         if (this.right && this.right.identifier) {
           if (funct["(blockscope)"].labeltype(this.right.value) === "const") {
@@ -1420,7 +1420,6 @@ var JSHINT = (function() {
     }, 20);
   }
 
-
   function suffix(s) {
     var x = symbol(s, 150);
 
@@ -1434,7 +1433,7 @@ var JSHINT = (function() {
         warning("W017", this);
       }
 
-      // detect modification of a const.
+      // detect increment/decrement of a const
       // in the case of a.b, left will be the "." punctuator
       if (left && left.identifier) {
         if (funct["(blockscope)"].labeltype(left.value) === "const") {
@@ -3470,7 +3469,8 @@ var JSHINT = (function() {
             }
           }
           if (t.id && !funct["(noblockscopedvar)"]) {
-            addlabel(t.id, { type: isConst ? "const" : "unused",
+            addlabel(t.id, {
+              type: isConst ? "const" : "unused",
               token: t.token,
               isblockscoped: true });
             names.push(t.token);

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1092,6 +1092,12 @@ var JSHINT = (function() {
             this.right.id !== "." && this.right.id !== "[") {
           warning("W017", this);
         }
+        if (this.right && this.right.identifier) {
+          var label = funct["(blockscope)"].getlabel(this.right.value);
+          if (label && label[this.right.value]["(type)"] === "const") {
+            error("E013", this, this.right.value);
+          }
+        }
       }
 
       return this;
@@ -1422,6 +1428,12 @@ var JSHINT = (function() {
         warning("W016", this, this.id);
       } else if ((!left.identifier || isReserved(left)) && left.id !== "." && left.id !== "[") {
         warning("W017", this);
+      }
+      if (left && left.identifier) {
+        var label = funct["(blockscope)"].getlabel(left.value);
+        if (label && label[left.value]["(type)"] === "const") {
+          error("E013", this, left.value);
+        }
       }
 
       this.left = left;

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1426,7 +1426,6 @@ var JSHINT = (function() {
     x.led = function(left) {
       // this = suffix e.g. "++" punctuator
       // left = symbol operated e.g. "a" identifier or "a.b" punctuator
-
       if (state.option.plusplus) {
         warning("W016", this, this.id);
       } else if ((!left.identifier || isReserved(left)) && left.id !== "." && left.id !== "[") {
@@ -1923,6 +1922,8 @@ var JSHINT = (function() {
 
     nud: function() {
       var v = this.value;
+      // s will be either the function object 'funct' that the identifier points at
+      //   or it will be a boolean if it is a predefined variable
       var s = scope[v];
       var f;
       var block;
@@ -1952,7 +1953,7 @@ var JSHINT = (function() {
         funct = f;
       }
 
-      // The name is in scope and defined in the current function.
+      // The name is in scope and defined in the current function or it exists in the blockscope.
       if (funct === s || block) {
         // Change 'unused' to 'var', and reject labels.
         // the name is in a block scope.
@@ -2031,9 +2032,6 @@ var JSHINT = (function() {
             case "unused":
               s[v] = "closure";
               funct[v] = s["(global)"] ? "global" : "outer";
-              break;
-            case "const":
-              s[v]["(type)"] = false;
               break;
             case "closure":
               funct[v] = s["(global)"] ? "global" : "outer";
@@ -3778,7 +3776,9 @@ var JSHINT = (function() {
       warning("W025");
     }
 
-    if (funct[i] === "const") {
+    // check if a identifier with the same name is already defined
+    // in the blockscope as a const
+    if (funct["(blockscope)"].labeltype(i) === "const") {
       warning("E011", null, i);
     }
     addlabel(i, { type: "unction", token: state.tokens.curr });

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -427,7 +427,6 @@ var JSHINT = (function() {
   // name: string
   // opts: { type: string, token: token, isblockscoped: bool }
   function addlabel(name, opts) {
-    opts = opts || {};
 
     var type  = opts.type;
     var token = opts.token;

--- a/src/messages.js
+++ b/src/messages.js
@@ -63,7 +63,7 @@ var errors = {
   E045: "Invalid for each loop.",
   E046: "A yield statement shall be within a generator function (with syntax: `function*`)",
   E047: null, // Vacant
-  E048: "Block scoped variable declaration not directly within block.",
+  E048: "{a} declaration not directly within block.",
   E049: "A {a} cannot be named '{b}'.",
   E050: "Mozilla requires the yield expression to be parenthesized here.",
   E051: "Regular parameters cannot come after default parameters.",

--- a/src/messages.js
+++ b/src/messages.js
@@ -63,7 +63,7 @@ var errors = {
   E045: "Invalid for each loop.",
   E046: "A yield statement shall be within a generator function (with syntax: `function*`)",
   E047: null, // Vacant
-  E048: "Let declaration not directly within block.",
+  E048: "Block scoped variable declaration not directly within block.",
   E049: "A {a} cannot be named '{b}'.",
   E050: "Mozilla requires the yield expression to be parenthesized here.",
   E051: "Regular parameters cannot come after default parameters.",

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -742,6 +742,62 @@ exports.testES6ModulesNamedExportsAffectUnused = function (test) {
   test.done();
 };
 
+exports.testConstRedeclaration = function (test) {
+
+  // consts cannot be redeclared, but they can shadow
+  var src = [
+    "const a = 1;",
+    "const a = 2;",
+    "if (a) {",
+    "  const a = 3;",
+    "}",
+    "for(const a in a) {",
+    "  const a = 4;",
+    "}"
+  ];
+
+  TestRun(test)
+      .addError(2, "const 'a' has already been declared.")
+      .test(src, {
+        esnext: true
+      });
+
+  test.done();
+};
+
+exports.testConstModification = function (test) {
+
+  // consts cannot be modified
+  var src = [
+    "const a = 1;",
+    "const b = { a: 2 };",
+    "a = 2;",
+    "b = 2;",
+    "b.a = 3;",
+    "a++;",
+    "b.a++;",
+    "--a;",
+    "--b.a;",
+    "a += 1;",
+    "a.b += 1;",
+    "const c = () => 1;",
+    "c();",
+    "const d = [1, 2, 3];",
+    "d[0] = 2;",
+  ];
+
+  TestRun(test)
+      .addError(3, "Attempting to override 'a' which is a constant.")
+      .addError(4, "Attempting to override 'b' which is a constant.")
+      .addError(6, "Attempting to override 'a' which is a constant.")
+      .addError(8, "Attempting to override 'a' which is a constant.")
+      .addError(10, "Attempting to override 'a' which is a constant.")
+      .test(src, {
+        esnext: true
+      });
+
+  test.done();
+};
 
 exports["class declaration export (default)"] = function (test) {
   var source = fs.readFileSync(__dirname + "/fixtures/class-declaration.js", "utf8");

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -753,11 +753,17 @@ exports.testConstRedeclaration = function (test) {
     "}",
     "for(const a in a) {",
     "  const a = 4;",
-    "}"
+    "}",
+    "function a() {",
+    "}",
+    "function b() {",
+    "}",
+    "const b = 1;"
   ];
 
   TestRun(test)
       .addError(2, "const 'a' has already been declared.")
+      .addError(9, "const 'a' has already been declared.")
       .test(src, {
         esnext: true
       });
@@ -767,31 +773,73 @@ exports.testConstRedeclaration = function (test) {
 
 exports.testConstModification = function (test) {
 
-  // consts cannot be modified
   var src = [
     "const a = 1;",
     "const b = { a: 2 };",
+    // const errors
     "a = 2;",
     "b = 2;",
-    "b.a = 3;",
     "a++;",
-    "b.a++;",
     "--a;",
-    "--b.a;",
     "a += 1;",
+    "let y = a = 3;",
+    // valid const access
+    "b.a++;",
+    "--b.a;",
+    "b.a = 3;",
     "a.b += 1;",
     "const c = () => 1;",
     "c();",
     "const d = [1, 2, 3];",
     "d[0] = 2;",
+    "let x = -a;",
+    "x = +a;",
+    "x = a + 1;",
+    "x = a * 2;",
+    "x = a / 2;",
+    "x = a % 2;",
+    "x = a & 1;",
+    "x = a ^ 1;",
+    "x = a === true;",
+    "x = a == 1;",
+    "x = a !== true;",
+    "x = a != 1;",
+    "x = a > 1;",
+    "x = a >= 1;",
+    "x = a < 1;",
+    "x = a <= 1;",
+    "x = 1 + a;",
+    "x = 2 * a;",
+    "x = 2 / a;",
+    "x = 2 % a;",
+    "x = 1 & a;",
+    "x = 1 ^ a;",
+    "x = true === a;",
+    "x = 1 == a;",
+    "x = true !== a;",
+    "x = 1 != a;",
+    "x = 1 > a;",
+    "x = 1 >= a;",
+    "x = 1 < a;",
+    "x = 1 <= a;",
+    "x = typeof a;",
+    "x = a.a;",
+    "x = a[0];",
+    "delete a.a;",
+    "delete a[0];",
+    "new a();",
+    "new a;",
   ];
 
   TestRun(test)
       .addError(3, "Attempting to override 'a' which is a constant.")
       .addError(4, "Attempting to override 'b' which is a constant.")
+      .addError(5, "Attempting to override 'a' which is a constant.")
       .addError(6, "Attempting to override 'a' which is a constant.")
+      .addError(7, "Attempting to override 'a' which is a constant.")
       .addError(8, "Attempting to override 'a' which is a constant.")
-      .addError(10, "Attempting to override 'a' which is a constant.")
+      .addError(8, "You might be leaking a variable (a) here.")
+      .addError(53, "Missing '()' invoking a constructor.")
       .test(src, {
         esnext: true
       });

--- a/tests/unit/fixtures/const.js
+++ b/tests/unit/fixtures/const.js
@@ -37,10 +37,9 @@ immutable7.pop();
 // Comma separated is ok.
 const immutable8 = "testing", immutable9 = true;
 
-// In current implementations, const doesn't have block scope.
+// immutable9 has block scope.
 for (var i = 0; i < 1; i += 1) {
-  // :(
-  // const immutable9 = false;
+  const immutable9 = false;
 }
 
 // In scope

--- a/tests/unit/fixtures/unused.js
+++ b/tests/unit/fixtures/unused.js
@@ -52,3 +52,13 @@ c.delete(hoistedDelete);
 // passed to methods that look like unresolvable-reference-accepting operators.
 function hoistedDelete() {}
 function hoistedTypeof() {}
+
+const constUsed = "this is used";
+while(constUsed) {
+    const constUsed = "unused";
+}
+let letUsed = "this is used";
+if (letUsed) {
+    let letUsed = "unused",
+        anotherUnused;
+}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1416,16 +1416,7 @@ exports.esnext = function (test) {
     'const foo = 9;',
     'var myConst = function (test) { };',
     'foo = "hello world";',
-    'var a = { get x() {} };',
-    'if (a) {',
-    '  const bar = 3;',
-    '  bar++;',
-    '  bar+=1;',
-    '  --bar;',
-    '} else {',
-    '  const bar = 2;',
-    '  const bar = 3;',
-    '}'
+    'var a = { get x() {} };'
   ];
 
   TestRun(test)
@@ -1439,19 +1430,11 @@ exports.esnext = function (test) {
   TestRun(test)
     .addError(3, "const 'myConst' has already been declared.")
     .addError(4, "Attempting to override 'foo' which is a constant.")
-    .addError(8, "Attempting to override 'bar' which is a constant.")
-    .addError(9, "Attempting to override 'bar' which is a constant.")
-    .addError(10, "Attempting to override 'bar' which is a constant.")
-    .addError(13, "const 'bar' has already been declared.")
     .test(code, { esnext: true });
 
   TestRun(test)
     .addError(3, "const 'myConst' has already been declared.")
     .addError(4, "Attempting to override 'foo' which is a constant.")
-    .addError(8, "Attempting to override 'bar' which is a constant.")
-    .addError(9, "Attempting to override 'bar' which is a constant.")
-    .addError(10, "Attempting to override 'bar' which is a constant.")
-    .addError(13, "const 'bar' has already been declared.")
     .test(code, { moz: true });
 
   test.done();

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1419,6 +1419,9 @@ exports.esnext = function (test) {
     'var a = { get x() {} };',
     'if (a) {',
     '  const bar = 3;',
+    '  bar++;',
+    '  bar+=1;',
+    '  --bar;',
     '} else {',
     '  const bar = 2;',
     '  const bar = 3;',
@@ -1436,13 +1439,19 @@ exports.esnext = function (test) {
   TestRun(test)
     .addError(3, "const 'myConst' has already been declared.")
     .addError(4, "Attempting to override 'foo' which is a constant.")
-    .addError(10, "const 'bar' has already been declared.")
+    .addError(8, "Attempting to override 'bar' which is a constant.")
+    .addError(9, "Attempting to override 'bar' which is a constant.")
+    .addError(10, "Attempting to override 'bar' which is a constant.")
+    .addError(13, "const 'bar' has already been declared.")
     .test(code, { esnext: true });
 
   TestRun(test)
     .addError(3, "const 'myConst' has already been declared.")
     .addError(4, "Attempting to override 'foo' which is a constant.")
-    .addError(10, "const 'bar' has already been declared.")
+    .addError(8, "Attempting to override 'bar' which is a constant.")
+    .addError(9, "Attempting to override 'bar' which is a constant.")
+    .addError(10, "Attempting to override 'bar' which is a constant.")
+    .addError(13, "const 'bar' has already been declared.")
     .test(code, { moz: true });
 
   test.done();

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -641,7 +641,10 @@ exports.unused = function (test) {
     [20, "'bar' is defined but never used."],
     [22, "'i' is defined but never used."],
     [36, "'cc' is defined but never used."],
-    [39, "'dd' is defined but never used."]
+    [39, "'dd' is defined but never used."],
+    [58, "'constUsed' is defined but never used."],
+    [62, "'letUsed' is defined but never used."],
+    [63, "'anotherUnused' is defined but never used."]
   ];
 
   var last_param_errors = [
@@ -683,7 +686,7 @@ exports.unused = function (test) {
   vars_run.test(src, { esnext: true, unused: "vars"});
 
   var unused = JSHINT.data().unused;
-  test.equal(12, unused.length);
+  test.equal(15, unused.length);
   test.ok(unused.some(function (err) { return err.line === 1 && err.character == 5 && err.name === "a"; }));
   test.ok(unused.some(function (err) { return err.line === 6 && err.character == 18 && err.name === "f"; }));
   test.ok(unused.some(function (err) { return err.line === 7 && err.character == 9 && err.name === "c"; }));
@@ -1413,7 +1416,13 @@ exports.esnext = function (test) {
     'const foo = 9;',
     'var myConst = function (test) { };',
     'foo = "hello world";',
-    'var a = { get x() {} };'
+    'var a = { get x() {} };',
+    'if (a) {',
+    '  const bar = 3;',
+    '} else {',
+    '  const bar = 2;',
+    '  const bar = 3;',
+    '}'
   ];
 
   TestRun(test)
@@ -1427,11 +1436,13 @@ exports.esnext = function (test) {
   TestRun(test)
     .addError(3, "const 'myConst' has already been declared.")
     .addError(4, "Attempting to override 'foo' which is a constant.")
+    .addError(10, "const 'bar' has already been declared.")
     .test(code, { esnext: true });
 
   TestRun(test)
     .addError(3, "const 'myConst' has already been declared.")
     .addError(4, "Attempting to override 'foo' which is a constant.")
+    .addError(10, "const 'bar' has already been declared.")
     .test(code, { moz: true });
 
   test.done();

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3795,16 +3795,41 @@ exports["no let not directly within a block"] = function (test) {
   ];
 
   TestRun(test)
-    .addError(1, "Let declaration not directly within block.")
-    .addError(4, "Let declaration not directly within block.")
-    .addError(7, "Let declaration not directly within block.")
-    .addError(8, "Let declaration not directly within block.")
-    .addError(9, "Let declaration not directly within block.")
-    .addError(10, "Let declaration not directly within block.")
-    .addError(11, "Let declaration not directly within block.")
-    .addError(11, "Let declaration not directly within block.")
-    .addError(11, "Let declaration not directly within block.")
+    .addError(1, "Block scoped variable declaration not directly within block.")
+    .addError(4, "Block scoped variable declaration not directly within block.")
+    .addError(7, "Block scoped variable declaration not directly within block.")
+    .addError(8, "Block scoped variable declaration not directly within block.")
+    .addError(9, "Block scoped variable declaration not directly within block.")
+    .addError(10, "Block scoped variable declaration not directly within block.")
+    .addError(11, "Block scoped variable declaration not directly within block.")
+    .addError(11, "Block scoped variable declaration not directly within block.")
+    .addError(11, "Block scoped variable declaration not directly within block.")
     .test(code, {moz: true, predef: ["print"]});
+
+  test.done();
+};
+
+exports["no const not directly within a block"] = function (test) {
+  var code = [
+    "if (true) const x = 1;",
+    "function foo() {",
+    "   if (true)",
+    "       const x = 1;",
+    "}",
+    "for (let x = 0; x < 42; ++x) const a = 1;",
+    "while (true) const a = 1;",
+    "if (false) const a = 1; else if (true) const a = 1; else const a = 2;"
+  ];
+
+  TestRun(test)
+    .addError(1, "Block scoped variable declaration not directly within block.")
+    .addError(4, "Block scoped variable declaration not directly within block.")
+    .addError(6, "Block scoped variable declaration not directly within block.")
+    .addError(7, "Block scoped variable declaration not directly within block.")
+    .addError(8, "Block scoped variable declaration not directly within block.")
+    .addError(8, "Block scoped variable declaration not directly within block.")
+    .addError(8, "Block scoped variable declaration not directly within block.")
+    .test(code, {predef: ["print"], esnext: true});
 
   test.done();
 };

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3802,15 +3802,15 @@ exports["no let not directly within a block"] = function (test) {
   ];
 
   TestRun(test)
-    .addError(1, "Block scoped variable declaration not directly within block.")
-    .addError(4, "Block scoped variable declaration not directly within block.")
-    .addError(7, "Block scoped variable declaration not directly within block.")
-    .addError(8, "Block scoped variable declaration not directly within block.")
-    .addError(9, "Block scoped variable declaration not directly within block.")
-    .addError(10, "Block scoped variable declaration not directly within block.")
-    .addError(11, "Block scoped variable declaration not directly within block.")
-    .addError(11, "Block scoped variable declaration not directly within block.")
-    .addError(11, "Block scoped variable declaration not directly within block.")
+    .addError(1, "Let declaration not directly within block.")
+    .addError(4, "Let declaration not directly within block.")
+    .addError(7, "Let declaration not directly within block.")
+    .addError(8, "Let declaration not directly within block.")
+    .addError(9, "Let declaration not directly within block.")
+    .addError(10, "Let declaration not directly within block.")
+    .addError(11, "Let declaration not directly within block.")
+    .addError(11, "Let declaration not directly within block.")
+    .addError(11, "Let declaration not directly within block.")
     .test(code, {moz: true, predef: ["print"]});
 
   test.done();
@@ -3829,13 +3829,13 @@ exports["no const not directly within a block"] = function (test) {
   ];
 
   TestRun(test)
-    .addError(1, "Block scoped variable declaration not directly within block.")
-    .addError(4, "Block scoped variable declaration not directly within block.")
-    .addError(6, "Block scoped variable declaration not directly within block.")
-    .addError(7, "Block scoped variable declaration not directly within block.")
-    .addError(8, "Block scoped variable declaration not directly within block.")
-    .addError(8, "Block scoped variable declaration not directly within block.")
-    .addError(8, "Block scoped variable declaration not directly within block.")
+    .addError(1, "Const declaration not directly within block.")
+    .addError(4, "Const declaration not directly within block.")
+    .addError(6, "Const declaration not directly within block.")
+    .addError(7, "Const declaration not directly within block.")
+    .addError(8, "Const declaration not directly within block.")
+    .addError(8, "Const declaration not directly within block.")
+    .addError(8, "Const declaration not directly within block.")
     .test(code, {predef: ["print"], esnext: true});
 
   test.done();


### PR DESCRIPTION
I've re-combined the copy and pasted code for var/const/let and in the process made const block scoped as per the spec.

It was a bit of a nightmare and the code was a bit of a nightmare.

I'd like to see if there are any bits to tidy and add some more tests, but I wanted to start getting feedback first - no point polishing if you are unhappy with the general approach.

More things to do:

* I've removed the hacked-in way to allow unused variable tracking of consts and replaced it with a new system (again just for consts) - would it be nice if this was the same for all variables?
* I added a todo about the warnunsed method not being used - it was already like this, but I'll see if it makes sense to fix or take out
* more tests