### PR TITLE
[[Fix]] Update Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "minimatch":           "2.0.x",
     "shelljs":             "0.3.x",
     "strip-json-comments": "1.0.x",
-    "lodash":              "3.6.x"
+    "lodash":              "3.7.x"
   },
 
   "devDependencies": {


### PR DESCRIPTION
Ideally, I'd like to add tests for this, but that is blocked by the open pull request at gh-2128. In the mean time, it's more important to get the latest version working on the home page.

Commit message:

> When the 3.6.0 release of Lodash is included in a script using
> Browserify, the resulting file cannot be executed in a browser web
> worker context. This is how the jshint.com homepage includes JSHint,
> meaning that the website cannot be updated to demonstrate the latest
> release.
>
> The 3.7.0 release of Lodash addresses this problem [1].
>
> Update to Lodash version 3.7.0 so the next release can be published on
> the JSHint homepage.
>
> [1] https://github.com/lodash/lodash/commit/e28e04a99030ef968a2ab1f9b3d9ed7ea01b7797