### PR TITLE
Fix 2292

### DIFF
--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -860,6 +860,11 @@ exports.testConstModification = function (test) {
     "delete a[0];",
     "new a();",
     "new a;",
+    "function e() {",
+    "  f++;",
+    "}",
+    "const f = 1;",
+    "e();"
   ];
 
   TestRun(test)
@@ -871,6 +876,7 @@ exports.testConstModification = function (test) {
       .addError(8, "Attempting to override 'a' which is a constant.")
       .addError(8, "You might be leaking a variable (a) here.")
       .addError(53, "Missing '()' invoking a constructor.")
+      // .addError(55, "Attempting to override 'f' which is a constant.") todo gh-2368
       .test(src, {
         esnext: true
       });

--- a/tests/unit/fixtures/latedef-esnext.js
+++ b/tests/unit/fixtures/latedef-esnext.js
@@ -1,0 +1,51 @@
+let a = 1;
+let b = () => a;
+let d = () => c;
+let c = 1;
+let f = () => e;
+const e = 1;
+function ag() {
+    function ah() {
+        ai = 2;
+    }
+    let ai;
+    function aj() {
+        function ak() {
+            ai = 3;
+        }
+        let ai;
+        ak();
+    }
+    ah();
+    aj();
+}
+ag();
+function bg() {
+    function bh() {
+        bi = 2;
+    }
+    let bi;
+    function bj() {
+        function bk() {
+            bi = 3;
+        }
+        bk();
+    }
+    bh();
+    bj();
+}
+bg();
+function cg() {
+    let ci;
+    function cj() {
+        function ck() {
+            ci = 3;
+        }
+        let ci;
+        ck();
+    }
+    ci = 2;
+    ch();
+    cj();
+}
+cg();

--- a/tests/unit/fixtures/unused.js
+++ b/tests/unit/fixtures/unused.js
@@ -69,3 +69,10 @@ x = y => {};
 x = (y) => {};
 x = (y, z) => y;
 x = (y, z) => z;
+
+function throwAwayFuncA() { if (testLateDef) {} }
+let testLateDef = true;
+function throwAwayFuncB() { if (testLateDefConst) {} }
+const testLateDefConst = true;
+throwAwayFuncA();
+throwAwayFuncB();

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -100,11 +100,15 @@ exports.shadowInline = function (test) {
  */
 exports.latedef = function (test) {
   var src  = fs.readFileSync(__dirname + '/fixtures/latedef.js', 'utf8'),
-    src1 = fs.readFileSync(__dirname + '/fixtures/redef.js', 'utf8');
+    src1 = fs.readFileSync(__dirname + '/fixtures/redef.js', 'utf8'),
+    esnextSrc = fs.readFileSync(__dirname + '/fixtures/latedef-esnext.js', 'utf8');
 
   // By default, tolerate the use of variable before its definition
   TestRun(test)
     .test(src, {es3: true});
+
+  TestRun(test)
+      .test(esnextSrc, {esnext: true});
 
   // However, JSHint must complain if variable is actually missing
   TestRun(test)
@@ -127,8 +131,18 @@ exports.latedef = function (test) {
     .addError(2, "'fn' was used before it was defined.")
     .addError(6, "'fn1' was used before it was defined.")
     .addError(10, "'vr' was used before it was defined.")
+    .addError(18, "'bar' was used before it was defined.") // todo - one or the other? what creates error below?
     .addError(18, "Inner functions should be listed at the top of the outer function.")
     .test(src, { es3: true, latedef: true });
+
+  TestRun(test)
+      .addError(4, "'c' was used before it was defined.")
+      .addError(6, "'e' was used before it was defined.")
+      .addError(11, "'ai' was used before it was defined.")
+      // .addError(16, "'ai' was used before it was defined.") TODO
+      .addError(27, "'bi' was used before it was defined.")
+      // .addError(44, "'ci' was used before it was defined.") TODO
+      .test(esnextSrc, {esnext: true, latedef: true});
 
   test.done();
 };


### PR DESCRIPTION
the problem was that in the simple implied map

```
i = 1; // i goes into implied
let i; // this should error 
```

```
var a = () => { i = 1; /* i goes into implied */ };
let i; // this should not error
```

there was no way to differentiate between the two situations.

So I took a leaf out of the blockscope manager and created one for implied that manages the different scopes.

But then as I've been doing this I've become unsure about the approach of the (blockscope) manager and implied manager - that logic is already present for var's in order to detect var's out of scope

```
function() {
    for(var i = 0; i < 8; i++) {
        var j = 1;
    }
    for(j = 0; j < 8; j++) {
    }
}
```

because even though j is function scope, jshint detects that j was not declared in the outer scope.

and it seems to me the logic should be combined. whats more I prefer the explicitness of the implied manager and blockscope manager (I think the logic outside of it is difficult to follow, with little overall explanation).

so @caitp @jugglinmike .. what do you think.. do you think the approach here is okay? which way should it be going?

Would you be happy if I continued refactoring and put implieds, blockscope and scope all into one "manager" with better names to test and poke on different scenarios ?