### PR TITLE
[[FIX]] Parse semicolons in class bodies

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3711,6 +3711,16 @@ var JSHINT = (function() {
       isStatic = false;
       isGenerator = false;
       getset = null;
+
+      // The ES6 grammar for ClassElement includes the `;` token, but it is
+      // defined only as a placeholder to facilitate future language
+      // extensions. In ES6 code, it serves no purpose.
+      if (name.id === ";") {
+        warning("W032");
+        advance(";");
+        continue;
+      }
+
       if (name.id === "*") {
         isGenerator = true;
         advance("*");

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4670,6 +4670,30 @@ exports.classExpressionThis = function (test) {
   test.done();
 };
 
+exports.classElementEmpty = function (test) {
+  var code = [
+    "class A {",
+    "  ;",
+    "  method() {}",
+    "  ;",
+    "  *methodB() { yield; }",
+    "  ;;",
+    "  methodC() {}",
+    "  ;",
+    "}",
+  ];
+
+  TestRun(test)
+    .addError(2, "Unnecessary semicolon.")
+    .addError(4, "Unnecessary semicolon.")
+    .addError(6, "Unnecessary semicolon.")
+    .addError(6, "Unnecessary semicolon.")
+    .addError(8, "Unnecessary semicolon.")
+    .test(code, { esnext: true });
+
+  test.done();
+};
+
 exports["test for GH-1018"] = function (test) {
   var code = [
     "if (a = 42) {}",


### PR DESCRIPTION
Although the semicolon token may appear in class bodies in valid ES6
code, it serves no purpose. Extend the parser to accept this token, but
emit the same warning used for unnecessary semicolons appearing
elsewhere. This warning may be disabled by the end user if desired.