### PR TITLE
[[FIX]] Accept new RegExp flags introduced by ES6

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -40,6 +40,11 @@ var Context = {
   Template: 2
 };
 
+var validRegexFlags = {
+  es5: /[gim]/,
+  es6: /[gimuy]/
+};
+
 // Object that handles postponed lexing verifications that checks the parsed
 // environment state.
 
@@ -119,6 +124,7 @@ function Lexer(source) {
   this.inComment = false;
   this.context = [];
   this.templateStarts = [];
+  this.regexpFlags = validRegexFlags[state.inESNext() ? 'es6' : 'es5'];
 
   for (var i = 0; i < state.option.indent; i += 1) {
     state.tab += " ";
@@ -1379,7 +1385,7 @@ Lexer.prototype = {
 
     while (index < length) {
       char = this.peek(index);
-      if (!/[gim]/.test(char)) {
+      if (!this.regexpFlags.test(char)) {
         break;
       }
       flags.push(char);
@@ -1390,7 +1396,7 @@ Lexer.prototype = {
     // Check regular expression for correctness.
 
     try {
-      new RegExp(body, flags.join(""));
+      new RegExp(body);
     } catch (err) {
       malformed = true;
       this.trigger("error", {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -510,6 +510,22 @@ exports.regexp = function (test) {
   TestRun(test).test("var a = 1; var b = a-- / 10;", {esnext: true});
   TestRun(test).test("var a = 1; var b = a-- / 10;", {moz: true});
 
+  TestRun(test)
+    .addError(1, "Missing semicolon.")
+    .addError(1, "Expected an assignment or function call and instead saw an expression.")
+    .test("var a = /.*/u;");
+
+  TestRun(test)
+    .test("var a = /.*/u;", { esnext: true });
+
+  TestRun(test)
+    .addError(1, "Missing semicolon.")
+    .addError(1, "Expected an assignment or function call and instead saw an expression.")
+    .test("var a = /.*/y;");
+
+  TestRun(test)
+    .test("var a = /.*/y;", { esnext: true });
+
   test.done();
 };
 


### PR DESCRIPTION
This resolves gh-2361.

Commit message:

> ECMAScript 6 introduces two additional flags for regular expressions:
> "u" and "y". Extend the lexer to accept these when linting ES6 code.
>
> Existing code attempts to compile regular expression literals as a
> mechanism to ensure validity. Update this code to ignore regular
> expression flags in order to ensure consistent behavior when JSHint is
> executed in ES5 and ES6 environments.