### PR TITLE
[[FEAT]] config file extension: expand tilde

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "htmlparser2":         "3.8.x",
     "minimatch":           "2.0.x",
     "shelljs":             "0.3.x",
+    "expand-home-dir":     "0.0.2",
     "strip-json-comments": "1.0.x",
     "lodash":              "3.7.x"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ var exit              = require("exit");
 var stripJsonComments = require("strip-json-comments");
 var JSHINT            = require("./jshint.js").JSHINT;
 var defReporter       = require("./reporters/default").reporter;
+var expandHomeDir     = require("expand-home-dir");
 
 var OPTIONS = {
   "config": ["c", "Custom configuration file", "string", false ],
@@ -532,7 +533,8 @@ var exports = {
       config.dirname = path.dirname(fp);
 
       if (config['extends']) {
-        var baseConfig = exports.loadConfig(path.resolve(config.dirname, config['extends']));
+        var basePath = expandTilde(config['extends']);
+        var baseConfig = exports.loadConfig(path.resolve(config.dirname, basePath));
         config = _.merge({}, baseConfig, config, function(a, b) {
           if (_.isArray(a)) {
             return a.concat(b);
@@ -545,6 +547,11 @@ var exports = {
     } catch (err) {
       cli.error("Can't parse config file: " + fp + "\nError:" + err);
       exports.exit(1);
+    }
+
+    function expandTilde(path) {
+      if (path.substr(0, 2) === '~/') return expandHomeDir('~') + path.substr(1);
+      else return path;
     }
   },
 


### PR DESCRIPTION
This patch allows me to use "~/" in configuration's "extends" option.
For example:

{
  "extends": "~/.jshintrc",
  ...
}