### PR TITLE
[[FIX]] The `__iterator__` property is deprecated.

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -19,7 +19,8 @@ exports.register = function(linter) {
   });
 
   // Check for properties named __iterator__. This is a special property
-  // available only in browsers with JavaScript 1.7 implementation.
+  // available only in browsers with JavaScript 1.7 implementation, but
+  // it is deprecated for ES6
 
   linter.on("Identifier", function style_scanIterator(data) {
     if (linter.getOption("iterator")) {
@@ -27,7 +28,7 @@ exports.register = function(linter) {
     }
 
     if (data.name === "__iterator__") {
-      linter.warn("W104", {
+      linter.warn("W103", {
         line: data.line,
         char: data.char,
         data: [ data.name ]

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -270,7 +270,7 @@ exports.testProtoAndIterator = function (test) {
     .addError(7, "The '__proto__' property is deprecated.")
     .addError(8, "The '__proto__' property is deprecated.")
     .addError(10, "The '__proto__' property is deprecated.")
-    .addError(27, "'__iterator__' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(27, "The '__iterator__' property is deprecated.")
     .addError(33, "The '__proto__' property is deprecated.")
     .addError(37, "The '__proto__' property is deprecated.")
     .test(source, {es3: true});


### PR DESCRIPTION
It should be used `Symbol.iterator`.
Now JSHint throws W103 instead of W104.

(https://developer.mozilla.org/it/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods)