### PR TITLE
[[FIX]] Allow `__proto__` when using ES6

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -210,7 +210,8 @@ var warnings = {
   W131: "Invalid parameter after rest parameter.",
   W132: "`var` declarations are forbidden. Use `let` or `const` instead.",
   W133: "Invalid for-{a} loop left-hand-side: {b}.",
-  W134: "The '{a}' option is only available when linting ECMAScript {b} code."
+  W134: "The '{a}' option is only available when linting ECMAScript {b} code.",
+  W135: "{a} may not be supported by non-browser environments."
 };
 
 var info = {

--- a/src/style.js
+++ b/src/style.js
@@ -5,15 +5,18 @@ exports.register = function(linter) {
   // deprecated and then re-introduced for ES6.
 
   linter.on("Identifier", function style_scanProto(data) {
-    if (linter.getOption("proto")) {
+    var esnext = linter.getOption("esnext");
+
+    if (linter.getOption("proto") || (esnext && (linter.getOption("browser") ||
+        linter.getOption("node") || linter.getOption("rhino")))) {
       return;
     }
 
     if (data.name === "__proto__") {
-      linter.warn("W103", {
+      linter.warn(esnext ? "W135" : "W119", {
         line: data.line,
         char: data.char,
-        data: [ data.name ]
+        data: [ esnext ? "The '__proto__' property" : "__proto__" ]
       });
     }
   });

--- a/src/style.js
+++ b/src/style.js
@@ -7,8 +7,7 @@ exports.register = function(linter) {
   linter.on("Identifier", function style_scanProto(data) {
     var esnext = linter.getOption("esnext");
 
-    if (linter.getOption("proto") || (esnext && (linter.getOption("browser") ||
-        linter.getOption("node") || linter.getOption("rhino")))) {
+    if (linter.getOption("proto") || (esnext && linter.getOption("browser"))) {
       return;
     }
 

--- a/tests/regression/thirdparty.js
+++ b/tests/regression/thirdparty.js
@@ -116,7 +116,7 @@ exports.prototype_1_7 = function (test) {
     .addError(5224, "'values' is already defined.")
     .addError(5495, "Function declarations should not be placed in blocks. Use a function " +
       "expression or move the statement to the top of the outer function.")
-    .addError(5545, "The '__proto__' property is deprecated.")
+    .addError(5545, "'__proto__' is only available in ES6 (use esnext option).")
     .test(src, {
       sub      : true,
       lastsemic: true,

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -171,7 +171,7 @@ exports.notypeof = function (test) {
     .test(src, { notypeof: true, esnext: true });
 
   test.done();
-}
+};
 
 exports['combination of latedef and undef'] = function (test) {
   var src = fixture('latedefundef.js');
@@ -267,13 +267,13 @@ exports.testProtoAndIterator = function (test) {
   // JSHint should not allow the `__proto__` and
   // `__iterator__` properties by default
   TestRun(test)
-    .addError(7, "The '__proto__' property is deprecated.")
-    .addError(8, "The '__proto__' property is deprecated.")
-    .addError(10, "The '__proto__' property is deprecated.")
+    .addError(7, "'__proto__' is only available in ES6 (use esnext option).")
+    .addError(8, "'__proto__' is only available in ES6 (use esnext option).")
+    .addError(10, "'__proto__' is only available in ES6 (use esnext option).")
     .addError(27, "'__iterator__' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
-    .addError(33, "The '__proto__' property is deprecated.")
-    .addError(37, "The '__proto__' property is deprecated.")
-    .test(source, {es3: true});
+    .addError(33, "'__proto__' is only available in ES6 (use esnext option).")
+    .addError(37, "'__proto__' is only available in ES6 (use esnext option).")
+    .test(source, { es3: true });
 
   TestRun(test)
     .addError(1, "The '__proto__' key may produce unexpected results.")
@@ -284,6 +284,23 @@ exports.testProtoAndIterator = function (test) {
   // options are on
   TestRun("source").test(source, { es3: true, proto: true, iterator: true });
   TestRun("json").test(json, { es3: true, proto: true, iterator: true });
+
+  // Should not allow the `__proto__` property if esnext is on but browser is off.
+  TestRun(test)
+    .addError(7, "The '__proto__' property may not be supported by non-browser environments.")
+    .addError(8, "The '__proto__' property may not be supported by non-browser environments.")
+    .addError(10, "The '__proto__' property may not be supported by non-browser environments.")
+    .addError(33, "The '__proto__' property may not be supported by non-browser environments.")
+    .addError(37, "The '__proto__' property may not be supported by non-browser environments.")
+    .test(source, { es3: true, esnext: true, iterator: true });
+
+  // Should allow the `__proto__` property if both esnext and one of browser, node or rhino are on
+  TestRun(test)
+    .test(source, { es3: true, esnext: true, browser: true, iterator: true });
+  TestRun(test)
+    .test(source, { es3: true, esnext: true, node: true, iterator: true });
+  TestRun(test)
+    .test(source, { es3: true, esnext: true, rhino: true, iterator: true });
 
   test.done();
 };

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -292,15 +292,11 @@ exports.testProtoAndIterator = function (test) {
     .addError(10, "The '__proto__' property may not be supported by non-browser environments.")
     .addError(33, "The '__proto__' property may not be supported by non-browser environments.")
     .addError(37, "The '__proto__' property may not be supported by non-browser environments.")
-    .test(source, { es3: true, esnext: true, iterator: true });
+    .test(source, { esnext: true, iterator: true });
 
-  // Should allow the `__proto__` property if both esnext and one of browser, node or rhino are on
+  // Should allow the `__proto__` property if both esnext and browser are on
   TestRun(test)
-    .test(source, { es3: true, esnext: true, browser: true, iterator: true });
-  TestRun(test)
-    .test(source, { es3: true, esnext: true, node: true, iterator: true });
-  TestRun(test)
-    .test(source, { es3: true, esnext: true, rhino: true, iterator: true });
+    .test(source, { esnext: true, browser: true, iterator: true });
 
   test.done();
 };


### PR DESCRIPTION
In ECMAScript 6 `__proto__` is no longer deprecated (but non-browser environments may not
support it).

- If proto option is on, JSHint behaves as before.
- If esnext option is off , JSHint warns: `'__proto__' is available in ES6 (use esnext option).`. (W119)
- If esnext is is on but browser, node, and rhino options are off, JSHint warns: `The '__proto__ property may not be supported by non-browser environments.` (New W135 warning).

Fixes #2371