### PR TITLE
[[CHORE]] Allow failures in coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-script: npm run coverage && cat ./coverage/lcov.info | coveralls
+after_success: npm run coverage && cat ./coverage/lcov.info | coveralls
 node_js:
   - "0.10"
   - "0.12"


### PR DESCRIPTION
The Coveralls service occasionally fails to respond within the
continuous integration service's timeout interval. When invoked as part
of the test script, these timeouts trigger build failures.

Move coverage reporting to a task that occurs after build completion[1] so
that these timeouts do not effect build status.

This change also ensures that the project's full set of tests are run in
the continuous integration environment. Previously, only those tests
necessary for generating a code coverage report were executed (omitting
code style and linting checks).

[1] From the TravisCI service's documentation:

> The outcome of any of these commands (except `after_success`,
> `after_failure` or `after_script`) indicates whether or not this build
> has failed or passed.

http://docs.travis-ci.com/user/build-configuration/#Build-Lifecycle