### PR TITLE
[[FIX]] JSHint should warn about duplicate key '__proto__'.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4732,14 +4732,15 @@ var JSHINT = (function() {
       name = tkn.value;
     }
 
-    if (props[name] && _.has(props, name)) {
+    if ((props[name] && _.has(props, name)) || (name === "__proto__" &&
+        Object.getPrototypeOf(props) !== Object.prototype)) { // __proto__ has been modified
       warning("W075", state.tokens.next, msg, name);
-    } else {
-      props[name] = {};
     }
 
-    props[name].basic = true;
-    props[name].basictkn = tkn;
+    props[name] = {
+      basic: true,
+      basictkn: tkn
+    };
   }
 
   /**

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -189,6 +189,13 @@ exports.es5 = function (test) {
   src = fs.readFileSync(__dirname + "/fixtures/es5.funcexpr.js", "utf8");
   TestRun(test).test(src, {  }); // es5
 
+  // JSHint should warn about duplicate key '__proto__'.
+  // (https://github.com/jshint/jshint/issues/2372)
+  src = "var a = { __proto__: null, __proto__: {} };";
+  TestRun(test)
+    .addError(1, "Duplicate key '__proto__'.")
+    .test(src, { proto: true });
+
   test.done();
 };
 


### PR DESCRIPTION
Spec (https://people.mozilla.org/~jorendorff/es6-draft.html#sec-B.3.1):
It is a *Syntax Error* if *PropertyNameList* of *PropertyDefinitionList* contains any duplicate entries for "\__proto\__" and at least two of those entries were obtained from productions of the form
*PropertyDefinition : PropertyName : AssignmentExpression* .

Fixes #2372