### PR TITLE
[[FIX]] Don't warn when Array() is used without 'new'.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2496,7 +2496,7 @@ var JSHINT = (function() {
     if (left) {
       if (left.type === "(identifier)") {
         if (left.value.match(/^[A-Z]([A-Z0-9_$]*[a-z][A-Za-z0-9_$]*)?$/)) {
-          if ("Number String Boolean Date Object Error Symbol".indexOf(left.value) === -1) {
+          if ("Array Number String Boolean Date Object Error Symbol".indexOf(left.value) === -1) {
             if (left.value === "Math") {
               warning("W063", left);
             } else if (state.option.newcap) {

--- a/tests/unit/fixtures/newcap.js
+++ b/tests/unit/fixtures/newcap.js
@@ -13,6 +13,7 @@ rat = iAnimal();
 bat = myAnimal();
 
 // Make sure we don't warn on Error, Number, etc.
+Array();
 Error();
 Number();
 String();


### PR DESCRIPTION
Comply with [ECMAScript 5.1
spec](http://www.ecma-international.org/ecma-262/5.1/#sec-15.4.1) to allow `Array` to be called as a
function.

Fixes #1987