### PR TITLE
[[FIX]] Reset generator flag for each method definition

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3216,7 +3216,7 @@ var JSHINT = (function() {
 
   (function(x) {
     x.nud = function() {
-      var b, f, i, p, t, g, nextVal;
+      var b, f, i, p, t, isGeneratorMethod = false, nextVal;
       var props = {}; // All properties, including accessors
 
       b = state.tokens.curr.line !== startLine(state.tokens.next);
@@ -3281,7 +3281,9 @@ var JSHINT = (function() {
               warning("W104", state.tokens.next, "generator functions");
             }
             advance("*");
-            g = true;
+            isGeneratorMethod = true;
+          } else {
+            isGeneratorMethod = false;
           }
 
           if (state.tokens.next.id === "[") {
@@ -3301,7 +3303,7 @@ var JSHINT = (function() {
             if (!state.inESNext()) {
               warning("W104", state.tokens.curr, "concise methods");
             }
-            doFunction({ type: g ? "generator" : null });
+            doFunction({ type: isGeneratorMethod ? "generator" : null });
           } else {
             advance(":");
             expression(10);

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -6584,3 +6584,23 @@ exports.functionKeyword = function (test) {
 
   test.done();
 };
+
+exports.nonGeneratorAfterGenerator = function (test) {
+  var run;
+  var code = [
+    'var obj = {',
+    '  *gen() {',
+    '    yield 1;',
+    '  },',
+    // non_gen shouldn't be parsed as a generator method here, and parser
+    // shouldn't report an error about a generator without a yield expression.
+    '  non_gen() {',
+    '  }',
+    '};'
+  ];
+
+  run = TestRun(test);
+  run.test(code, { esnext: true });
+
+  test.done();
+};


### PR DESCRIPTION
This patch fixes the handling of non-generator method after generator method.
For examle:

    var a = {
      *gen() {
        yield 1;
      },
      non_gen() {
      }
    };

Here, non_gen was treated as a generator function, since generator flag `g`
wasn't reset to false when `*` wasn't found before method name.

Fixes #2388