### PR TITLE
[[FIX]] Remove module import declaration

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1584,23 +1584,6 @@ var JSHINT = (function() {
       res = false;
     }
 
-    // detect a module import declaration
-    if (t.value === "module" && t.type === "(identifier)") {
-      if (peek().type === "(identifier)") {
-        if (!state.inESNext()) {
-          warning("W119", state.tokens.curr, "module");
-        }
-
-        advance("module");
-        var name = identifier();
-        addlabel(name, { type: "unused", token: state.tokens.curr });
-        advance("from");
-        advance("(string)");
-        parseFinalSemicolon();
-        return;
-      }
-    }
-
     if (t.identifier && !res && peek().id === ":") {
       advance();
       advance(":");

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1332,19 +1332,6 @@ exports.testArrayPrototypeExtensions = function (test) {
   test.done();
 };
 
-exports.testModuleKeyword = function (test) {
-  var src = fs.readFileSync(__dirname + "/fixtures/module-keyword.js", "utf8");
-
-  TestRun(test)
-    .addError(4, "Missing semicolon.")
-    .test(src, { esnext: true });
-
-  TestRun(test)
-    .test(src, { esnext: true, asi: true });
-
-  test.done();
-};
-
 // Issue #1446, PR #1688
 exports.testIncorrectJsonDetection = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/mappingstart.js", "utf8");

--- a/tests/unit/fixtures/module-keyword.js
+++ b/tests/unit/fixtures/module-keyword.js
@@ -1,9 +1,0 @@
-/* jshint undef: true */
-
-module ng from "angular";
-module em from "ember"
-
-ng.controller();
-
-var module = {};
-module.exports = "foo";


### PR DESCRIPTION
Fixes #2395 to remove the deprecated `module` import declaration from the parser and the associated test.