### PR TITLE
[[FIX]] Honor `ignore` directive more consistently

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -801,6 +801,14 @@ var JSHINT = (function() {
 
       if (state.tokens.next.isSpecial) {
         doOption();
+
+      // The `ignore` directive normally prevents tokens from being lexed, but
+      // the directive is only applied when the code is visited by the Pratt
+      // parser. `peek` operations may cause tokens to be lexed in advance of
+      // parsing (see the `lookahead` array); such tokens must be explicitly
+      // skipped here.
+      } else if (state.ignoreLinterErrors) {
+        continue;
       } else {
         if (state.tokens.next.id !== "(endline)") {
           break;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5903,7 +5903,9 @@ exports["allow expression with a comma in switch case condition"] = function (te
   test.done();
 };
 
-exports["/*jshint ignore */ should be a good option and only accept start, end or line as values"] = function (test) {
+exports.ignoreDirective = {};
+
+exports.ignoreDirective["should be a good option and only accept start, end or line as values"] = function (test) {
   var code = [
     "/*jshint ignore:start*/",
     "/*jshint ignore:end*/",
@@ -5918,7 +5920,7 @@ exports["/*jshint ignore */ should be a good option and only accept start, end o
   test.done();
 };
 
-exports["/*jshint ignore */ should allow the linter to skip blocked-out lines to continue finding errors in the rest of the code"] = function (test) {
+exports.ignoreDirective["should allow the linter to skip blocked-out lines to continue finding errors in the rest of the code"] = function (test) {
   var code = fs.readFileSync(__dirname + "/fixtures/gh826.js", "utf8");
 
   TestRun(test)
@@ -5928,7 +5930,7 @@ exports["/*jshint ignore */ should allow the linter to skip blocked-out lines to
   test.done();
 };
 
-exports["/*jshint ignore */ should ignore lines that appear to end with multiline comment endings (GH-1691)"] = function(test) {
+exports.ignoreDirective["should ignore lines that appear to end with multiline comment endings (GH-1691)"] = function(test) {
   var code = [
     "/*jshint ignore: start*/",
     "var a = {",
@@ -5945,7 +5947,7 @@ exports["/*jshint ignore */ should ignore lines that appear to end with multilin
   test.done();
 };
 
-exports["/*jshint ignore */ should ignore lines that end with a multi-line comment (GH-1396)"] = function(test) {
+exports.ignoreDirective["should ignore lines that end with a multi-line comment (GH-1396)"] = function(test) {
   var code = [
     "/*jshint ignore:start */",
     "var a; /* following comment */",
@@ -5958,7 +5960,7 @@ exports["/*jshint ignore */ should ignore lines that end with a multi-line comme
   test.done();
 };
 
-exports["/*jshint ignore */ should ignore multi-line comments"] = function(test) {
+exports.ignoreDirective["should ignore multi-line comments"] = function(test) {
   var code = [
     "/*jshint ignore:start */",
     "/*",
@@ -5974,7 +5976,7 @@ exports["/*jshint ignore */ should ignore multi-line comments"] = function(test)
   test.done();
 };
 
-exports["/*jshint ignore */ should be detected even with leading and/or trailing whitespace"] = function (test) {
+exports.ignoreDirective["should be detected even with leading and/or trailing whitespace"] = function (test) {
   var code = [
     "  /*jshint ignore:start */",     // leading whitespace
     "   if (true) { alert('sup') }", // should be ignored
@@ -5987,6 +5989,33 @@ exports["/*jshint ignore */ should be detected even with leading and/or trailing
 
   TestRun(test)
     .addError(4, "Missing semicolon.")
+    .test(code);
+
+  test.done();
+};
+
+// gh-2411 /* jshint ignore:start */ stopped working.
+exports.ignoreDirective["should apply to lines lexed during lookahead operations"] = function (test) {
+  var code = [
+    "void [function () {",
+    "  /* jshint ignore:start */",
+    "  ?",
+    "  /* jshint ignore:end */",
+    "}];"
+  ];
+
+  TestRun(test)
+    .test(code);
+
+  code = [
+    "(function () {",
+    "  /* jshint ignore:start */",
+    "  ?",
+    "  /* jshint ignore:end */",
+    "}());"
+  ];
+
+  TestRun(test)
     .test(code);
 
   test.done();


### PR DESCRIPTION
Ensure that the `ignore` directive applies even to tokens lexed during
lookahead operations.

Resolves gh-2411