### PR TITLE
Add `mocha` to `mocha` environment

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -670,6 +670,8 @@ exports.yui = {
 };
 
 exports.mocha = {
+  // Global (for config etc.)
+  mocha       : false,
   // BDD
   describe    : false,
   xdescribe   : false,


### PR DESCRIPTION
Mocha exposes the global name `mocha` too for configuration etc. This adds that to the `mocha` environment.