### PR TITLE
[[FEAT]] Support .jshintrc "extends" with no specific path.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -527,25 +527,59 @@ var exports = {
       exports.exit(1);
     }
 
+    var config;
     try {
-      var config = JSON.parse(stripJsonComments(shjs.cat(fp)));
-      config.dirname = path.dirname(fp);
-
-      if (config['extends']) {
-        var baseConfig = exports.loadConfig(path.resolve(config.dirname, config['extends']));
-        config = _.merge({}, baseConfig, config, function(a, b) {
-          if (_.isArray(a)) {
-            return a.concat(b);
-          }
-        });
-        delete config['extends'];
-      }
-
-      return config;
-    } catch (err) {
-      cli.error("Can't parse config file: " + fp + "\nError:" + err);
+      config = JSON.parse(stripJsonComments(shjs.cat(fp)));
+    } catch (e) {
+      cli.error("Can't parse config file: " + fp + "\nError:" + e);
       exports.exit(1);
     }
+
+    config.dirname = path.dirname(fp);
+
+    var extendsOption = config["extends"];
+    delete config["extends"];
+    if (!extendsOption) {
+      return config;
+    }
+
+    // Get the base config path
+    var basePath;
+    switch (typeof extendsOption) {
+      case "string":
+        basePath = path.resolve(config.dirname, extendsOption);
+        break;
+
+      case "boolean":
+        // Look for a config file to extend in parent directory/ies
+        var root = path.resolve('/');
+        var dir = config.dirname;
+        do {
+          dir = path.resolve(dir, "..");
+          if (dir === root) {
+            // We got to the root directory but no config file to extend was found
+            //TODO Should I notify the user ?
+            return config;
+          }
+
+          basePath = path.resolve(dir, ".jshintrc");
+        } while (!shjs.test("-e", basePath));
+        break;
+
+      default:
+        //TODO Should I notify the user ?
+        return config;
+    }
+
+    // Load the base config & extend it
+    var baseConfig = exports.loadConfig(basePath);
+    config = _.merge({}, baseConfig, config, function(a, b) {
+      if (_.isArray(a)) {
+        return a.concat(b);
+      }
+    });
+
+    return config;
   },
 
   /**


### PR DESCRIPTION
Extending the abilities of the .jshintrc file option `"extends"`.
The new behavior resembles the `root` option of .editorconfig files.

When the boolean value `true` is used:
JSHint will walk up the directory tree and look for a .jshintrc file.

If no .jshintrc file is found (root directory reached):
Nothing will happen, and the original .jshintrc file will be used as is.

If a .jshintrc file is found:
JSHint will behave as if the file's path was explicitly passed as the `"extends"` option.
This includes recursive behavior for this feature.
