### PR TITLE
Remove globals

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -171,6 +171,11 @@ var JSHINT = (function() {
   function combine(dest, src) {
     Object.keys(src).forEach(function(name) {
       if (_.has(JSHINT.blacklist, name)) return;
+      var match = name.match(/^\-(.*)/);
+      if (match) {
+        JSHINT.blacklist[match[1]] = src[name];
+        return;
+      }
       dest[name] = src[name];
     });
   }

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -50,6 +50,26 @@ exports.testUnusedDefinedGlobals = function (test) {
   test.done();
 };
 
+exports.testRemoveCustomGlobals = function (test) {
+  var src = fs.readFileSync(__dirname + "/fixtures/removeglobals.js", "utf8");
+
+  TestRun(test)
+    .addError(1, "'JSON' is not defined.")
+    .test(src, { undef: true }, { "-JSON": true, "myglobal": true });
+
+  test.done();
+};
+
+exports.testRemovePresetGlobals = function (test) {
+  var src = "event();";
+
+  TestRun(test)
+    .addError(1, "'event' is not defined.")
+    .test(src, { undef: true, browser: true }, { "-event": true });
+
+  test.done();
+};
+
 exports.globalDeclarations = function (test) {
   var src = "exports = module.exports = function (test) {};";
 


### PR DESCRIPTION
The `predef` option allowed us to blacklist globals otherwise considered valid. Since this option is being deprecated, this PR restores this functionality by allowing the specification of blacklisted as well as whitelisted globals.

Whitelisted globals continue to act as normal while blacklisted globals are indicated as they were in the `predef` array, with a leading hyphen sigil.