### PR TITLE
[[FIX]] Declare `func` as a property of `state`

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -48,6 +48,7 @@ var state = {
     };
 
     this.option = {};
+    this.funct = null;
     this.ignored = {};
     this.directive = {};
     this.jsonMode = false;


### PR DESCRIPTION
The current `funct` object stores stateful information, so it should be
defined as a property of the global variable reserved for that purpose.
This allows other code to more simply operate based on the current
state because it requires one less reference to be managed across
contexts.