### PR TITLE
[[FIX]] Correctly parse exported generators

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3817,7 +3817,8 @@ var JSHINT = (function() {
     checkProperties(props);
   }
 
-  blockstmt("function", function() {
+  blockstmt("function", function(context) {
+    var inexport = context && context.inexport;
     var generator = false;
     if (state.tokens.next.value === "*") {
       advance("*");
@@ -3835,6 +3836,8 @@ var JSHINT = (function() {
 
     if (i === undefined) {
       warning("W025");
+    } else if (inexport) {
+      exported[i] = true;
     }
 
     // check if a identifier with the same name is already defined
@@ -4662,9 +4665,8 @@ var JSHINT = (function() {
       // ExportDeclaration :: export Declaration
       this.block = true;
       advance("function");
-      exported[state.tokens.next.value] = ok;
       state.tokens.next.exported = true;
-      state.syntax["function"].fud();
+      state.syntax["function"].fud({ inexport:true });
     } else if (state.tokens.next.id === "class") {
       // ExportDeclaration :: export Declaration
       this.block = true;

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -726,6 +726,9 @@ exports.testES6Modules = function (test) {
     .addError(48, "'class' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
     .addError(47, "'export' is only available in ES6 (use esnext option).")
     .addError(46, "'class' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
+    .addError(50, "'export' is only available in ES6 (use esnext option).")
+    .addError(50, "'function*' is only available in ES6 (use esnext option).")
+    .addError(50, "'yield' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
     .test(src, {});
 
   var src2 = [
@@ -759,7 +762,8 @@ exports.testES6ModulesNamedExportsAffectUnused = function (test) {
     "export let letone = 1, lettwo = 2;",
     "export var v1u, v2u;",
     "export let l1u, l2u;",
-    "export const c1u, c2u;"
+    "export const c1u, c2u;",
+    "export function* gen() { yield 1; }"
   ];
 
   TestRun(test)

--- a/tests/unit/fixtures/es6-import-export.js
+++ b/tests/unit/fixtures/es6-import-export.js
@@ -46,3 +46,5 @@ export var c = "c";
 export class Foo {}
 export class List extends Array {}
 export default class Bar {}
+
+export function* gen() { yield 1; }


### PR DESCRIPTION
Before of this patch, JSHint considered the name of expored
generators `*`, because it was the first "thing" after `function`.

Fix #2472