### PR TITLE
Support `--prereq` CLI options

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,13 @@ var defReporter       = require("./reporters/default").reporter;
 var OPTIONS = {
   "config": ["c", "Custom configuration file", "string", false ],
   "reporter": ["reporter", "Custom reporter (<PATH>|jslint|checkstyle|unix)", "string", undefined ],
+  "prereq": [
+    "prereq",
+    "Comma-separate list of prerequisite (paths). E.g. files which include" +
+    "definitions of global variabls used throughout your project",
+    "string",
+    null
+  ],
   "exclude": ["exclude",
     "Exclude files matching the given filename pattern (same as .jshintignore)", "string", null],
   "exclude-path": ["exclude-path", "Pass in a custom jshintignore file path", "string", null],
@@ -596,6 +603,12 @@ var exports = {
     var results = [];
     var data = [];
 
+    function mergeCLIPrereq(config) {
+      if (opts.prereq) {
+        config.prereq = (config.prereq || []).concat(opts.prereq.split(/\s*,\s*/));
+      }
+    }
+
     if (opts.useStdin) {
       cli.withStdin(function(code) {
         var config = opts.config;
@@ -616,6 +629,8 @@ var exports = {
 
         config = config || {};
 
+        mergeCLIPrereq(config);
+
         lint(extract(code, opts.extract), results, config, data, filename);
         (opts.reporter || defReporter)(results, data, { verbose: opts.verbose });
         cb(results.length === 0);
@@ -634,6 +649,8 @@ var exports = {
         cli.error("Can't open " + file);
         exports.exit(1);
       }
+
+      mergeCLIPrereq(config);
 
       lint(extract(code, opts.extract), results, config, data, file);
 
@@ -743,6 +760,7 @@ var exports = {
       verbose:    options.verbose,
       extract:    options.extract,
       filename:   options.filename,
+      prereq:     options.prereq,
       useStdin:   { "-": true, "/dev/stdin": true }[args[args.length - 1]]
     }, done));
   }

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -192,11 +192,75 @@ exports.group = {
       .withArgs("-e", sinon.match(/config.json$/)).returns(true);
 
     cli.exit.withArgs(0).returns(true)
-      .withArgs(1).throws("ProcessExit");
+      .withArgs(2).throws("ProcessExit");
 
     cli.interpret([
       "node", "jshint", "file.js", "--config", "config.json"
     ]);
+
+    shjs.cat.restore();
+    shjs.test.restore();
+
+    test.done();
+  },
+
+  // CLI prereqs
+  testPrereqCLIOption: function (test) {
+    this.sinon.stub(shjs, "cat")
+      .withArgs(sinon.match(/file\.js$/)).returns("a();")
+      .withArgs(sinon.match(/prereq.js$/)).returns("var a = 1;")
+      .withArgs(sinon.match(/config.json$/)).returns("{\"undef\":true}");
+
+    this.sinon.stub(shjs, "test")
+      .withArgs("-e", sinon.match(/file\.js$/)).returns(true)
+      .withArgs("-e", sinon.match(/prereq.js$/)).returns(true)
+      .withArgs("-e", sinon.match(/config.json$/)).returns(true);
+
+    cli.exit.restore();
+    this.sinon.stub(cli, "exit")
+      .withArgs(0).returns(true)
+      .withArgs(2).throws("ProcessExit");
+
+    cli.interpret([
+      "node", "jshint", "file.js",
+      "--config", "config.json",
+      "--prereq", "prereq.js  , prereq2.js"
+    ]);
+
+    shjs.cat.restore();
+    shjs.test.restore();
+
+    test.done();
+  },
+
+  // CLI prereqs should get merged with config prereqs
+  testPrereqBothConfigAndCLIOption: function (test) {
+    this.sinon.stub(shjs, "cat")
+      .withArgs(sinon.match(/file\.js$/)).returns("a(); b();")
+      .withArgs(sinon.match(/prereq.js$/)).returns("var a = 1;")
+      .withArgs(sinon.match(/prereq2.js$/)).returns("var b = 2;")
+      .withArgs(sinon.match(/config.json$/))
+        .returns("{\"undef\":true,\"prereq\":[\"prereq.js\"]}");
+
+    this.sinon.stub(shjs, "test")
+      .withArgs("-e", sinon.match(/file\.js$/)).returns(true)
+      .withArgs("-e", sinon.match(/prereq.js$/)).returns(true)
+      .withArgs("-e", sinon.match(/prereq2.js$/)).returns(true)
+      .withArgs("-e", sinon.match(/config.json$/)).returns(true);
+
+    cli.exit.restore();
+    this.sinon.stub(cli, "exit")
+      .withArgs(0).returns(true)
+      .withArgs(2).throws("ProcessExit");
+
+    cli.interpret([
+      "node", "jshint", "file.js",
+      "--config", "config.json",
+      "--prereq", "prereq2.js,prereq3.js"
+    ]);
+
+    shjs.cat.restore();
+    shjs.test.restore();
 
     test.done();
   },


### PR DESCRIPTION
cherry picked original PR - https://github.com/jshint/jshint/pull/1909
Resolved comments 
 - from @mikesherov - whitespace formatting - it now seems this is the default so it matches the file
 - from @mikesherov - using null instead of "" - change made
 - from @jugglinmike - I don't think its a valid comment, I've replied on the original PR
I've reviewed but I'm not familiar with the cli code so will wait for someone else to say okay before merging.

Since [the docs][1] mention it, and it's already supported via [config][2],
I thought I'd just pop the CLI support in.

This PR make `jshint` allow specifying the `--prereq` option on the command
line, accepting a comma-separated list of paths.

Test-related notes:

- Fixes the existing `testPrereq` test to check the right exit code. In its
  current incarnation, it could never fail (even when `lint` didn't pass)
- Added 2 tests for specifying the `--prereq` options from the command line.

Implementation notes:

I did the simplest thing possible (just merging the CLI `prereq` options in
with the config ones in the `run` method in `cli.js`). It's a little bit
awkward because there are 2 paths to `lint`:

1. `opts.useStdin`
2. `!opts.useStdin`

And each loads the config in a slightly different way. So the `mergeCLIPrereq`
function has to be in 2 code paths. So, slightly awkward, but not too terrible.

Fixes #1685.

[1]: http://jshint.com/docs/cli
[2]: https://github.com/jshint/jshint/blob/master/src/cli.js#L451-458

Conflicts:

	src/cli.js
	tests/cli.js