### PR TITLE
Fix labeled break and continue semantics

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4111,20 +4111,19 @@ var JSHINT = (function() {
   stmt("break", function() {
     var v = state.tokens.next.value;
 
-    if (state.funct["(breakage)"] === 0)
-      warning("W052", state.tokens.next, this.value);
-
     if (!state.option.asi)
       nolinebreak(this);
 
-    if (state.tokens.next.id !== ";" && !state.tokens.next.reach) {
-      if (state.tokens.curr.line === startLine(state.tokens.next)) {
-        if (!state.funct["(scope)"].funct.hasBreakLabel(v)) {
-          warning("W090", state.tokens.next, v);
-        }
-        this.first = state.tokens.next;
-        advance();
+    if (state.tokens.next.id !== ";" && !state.tokens.next.reach &&
+        state.tokens.curr.line === startLine(state.tokens.next)) {
+      if (!state.funct["(scope)"].funct.hasBreakLabel(v)) {
+        warning("W090", state.tokens.next, v);
       }
+      this.first = state.tokens.next;
+      advance();
+    } else {
+      if (state.funct["(breakage)"] === 0)
+        warning("W052", state.tokens.next, this.value);
     }
 
     reachable(this);
@@ -4138,6 +4137,8 @@ var JSHINT = (function() {
 
     if (state.funct["(breakage)"] === 0)
       warning("W052", state.tokens.next, this.value);
+    if (!state.funct["(loopage)"])
+      warning("W052", state.tokens.next, this.value);
 
     if (!state.option.asi)
       nolinebreak(this);
@@ -4150,8 +4151,6 @@ var JSHINT = (function() {
         this.first = state.tokens.next;
         advance();
       }
-    } else if (!state.funct["(loopage)"]) {
-      warning("W052", state.tokens.next, this.value);
     }
 
     reachable(this);

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1555,6 +1555,68 @@ exports.labelDoesNotExistInGlobalScope = function (test) {
   test.done();
 };
 
+exports.labeledBreakWithoutLoop = function (test) {
+  var src = [
+    "foo: {",
+    "  break foo;",
+    "}"
+  ];
+
+  TestRun(test)
+    .test(src);
+
+  test.done();
+};
+
+// ECMAScript 5.1 § 12.7: labeled continue must refer to an enclosing
+// IterationStatement, as opposed to labeled break which is only required to
+// refer to an enclosing Statement.
+exports.labeledContinueWithoutLoop = function (test) {
+  var src = [
+    "foo: switch (i) {",
+    "  case 1:",
+    "    continue foo;",
+    "}"
+  ];
+
+  TestRun(test)
+    .addError(3, "Unexpected 'continue'.")
+    .test(src);
+
+  test.done();
+};
+
+exports.unlabeledBreakWithoutLoop = function(test) {
+  var src = [
+    "if (1 == 1) {",
+    "  break;",
+    "}",
+  ];
+
+  TestRun(test)
+    .addError(2, "Unexpected 'break'.")
+    .test(src);
+
+  test.done();
+}
+
+exports.unlabeledContinueWithoutLoop = function(test) {
+  var src = [
+    "switch (i) {",
+    "  case 1:",
+    "    continue;", // breakage but not loopage
+    "}",
+    "continue;"
+  ];
+
+  TestRun(test)
+    .addError(3, "Unexpected 'continue'.")
+    .addError(5, "Unexpected 'continue'.")
+    .test(src);
+
+  test.done();
+}
+
 exports.labelsContinue = function (test) {
   var src = [
     "exists: while(true) {",


### PR DESCRIPTION
A labeled break may refer to any statement, it is not required to be inside a loop or switch. Whereas a labeled continue must refer to a loop, you cannot continue a switch.

In ECMAScript terminology, the identifier following "continue" must appear in the label set of an enclosing *IterationStatement* (do, while, for). The identifier following "break" must appear in the label set of an enclosing *Statement* (which includes a simple *Block*). http://www.ecma-international.org/ecma-262/5.1/#sec-12.7

Added tests.

I am using labeled breaks in code automatically generated by PEG.js, in my pending PEG.js pull request: https://github.com/pegjs/pegjs/pull/348 . Its automated test suite is failing due to jshint. If I had goto, I could have generated even faster code, but you make do with what you've got, right? ;)