### PR TITLE
[[FIX]] Allow semicolon as string value in JSON

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4511,7 +4511,7 @@ var JSHINT = (function() {
           break;
         }
       }
-      if (pn.value === ";") {
+      if (checkPunctuators(pn, [";"])) {
         ret.isBlock = true;
         ret.notJson = true;
       }

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -877,6 +877,17 @@ exports.json.errors = function (test) {
   test.done();
 }
 
+// Regression test for gh-2488
+exports.json.semicolon = function (test) {
+  TestRun(test)
+    .test("{ \"attr\": \";\" }");
+
+  TestRun(test)
+    .test("[\";\"]");
+
+  test.done();
+};
+
 exports.comma = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/comma.js", "utf8");
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -643,7 +643,8 @@ exports.ownProperty = function (test) {
   test.done();
 };
 
-exports.jsonMode = function (test) {
+exports.json = {};
+exports.json.dflt = function (test) {
   var code = [
     '{',
     '  a: 2,',
@@ -675,7 +676,7 @@ exports.jsonMode = function (test) {
   test.done();
 };
 
-exports.deepJSON = function (test) {
+exports.json.deep = function (test) {
   var code = [
     '{',
     '  "key" : {',
@@ -699,7 +700,7 @@ exports.deepJSON = function (test) {
   test.done();
 }
 
-exports.badJSON = function (test) {
+exports.json.errors = function (test) {
   var objTrailingComma = [
     '{ "key" : "value", }',
   ];


### PR DESCRIPTION
Resolves gh-2488

Commit message:

> Previously, any token with the value ";" would trigger JSHint to lint
> the input as though it were JavaScript code. Because the token value may
> also describe a string, this caused JSHint to incorrectly interpret JSON
> input as JavaScript in some cases.
>
> Ensure that only semicolon tokens parsed as punctuators trigger
> JavaScript parsing.
>
> This change necessitated modifying an existing test. That test was
> authored to ensure that JSHint would halt on invalid input and report
> the input as invalid. The modified version of the test continues to
> assert that, but the specific errors have changed because JSHint now
> interprets the input as invalid JSON (not invalid JavaScript).