### PR TITLE
Change Imports to be const and change multiple warnings on block scope redeclaration to one warning

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4300,7 +4300,7 @@ var JSHINT = (function() {
       // ImportClause :: ImportedDefaultBinding
       this.name = identifier();
       state.funct["(scope)"].addlabel(this.name, {
-        type: "var",
+        type: "const",
         token: state.tokens.curr });
 
       if (state.tokens.next.value === ",") {
@@ -4325,7 +4325,7 @@ var JSHINT = (function() {
       if (state.tokens.next.identifier) {
         this.name = identifier();
         state.funct["(scope)"].addlabel(this.name, {
-          type: "var",
+          type: "const",
           token: state.tokens.curr });
       }
     } else {
@@ -4349,7 +4349,7 @@ var JSHINT = (function() {
         }
 
         state.funct["(scope)"].addlabel(importName, {
-          type: "var",
+          type: "const",
           token: state.tokens.curr });
 
         if (state.tokens.next.value === ",") {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -741,12 +741,7 @@ exports.testES6Modules = function (test) {
     [58, "'set' has already been declared."],
     [59, "'_' has already been declared."],
     [60, "'ember2' has already been declared."],
-    [65, "'newImport' was used before it was declared, which is illegal for 'const' variables."],
-    [57, "'$' was used before it was declared, which is illegal for 'const' variables."],
-    [58, "'emGet' was used before it was declared, which is illegal for 'const' variables."],
-    [58, "'set' was used before it was declared, which is illegal for 'const' variables."],
-    [59, "'_' was used before it was declared, which is illegal for 'const' variables."],
-    [60, "'ember2' was used before it was declared, which is illegal for 'const' variables."]
+    [65, "'newImport' was used before it was declared, which is illegal for 'const' variables."]
   ];
 
   var testRun = TestRun(test);

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -730,10 +730,30 @@ exports.testUndefinedAssignment = function (test) {
 exports.testES6Modules = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-import-export.js", "utf8");
 
-  TestRun(test)
-    .test(src, {esnext: true});
+  var importConstErrors = [
+    [51, "Attempting to override '$' which is a constant."],
+    [52, "Attempting to override 'emGet' which is a constant."],
+    [53, "Attempting to override 'one' which is a constant."],
+    [54, "Attempting to override '_' which is a constant."],
+    [55, "Attempting to override 'ember2' which is a constant."],
+    [57, "'$' has already been declared."],
+    [58, "'emGet' has already been declared."],
+    [58, "'set' has already been declared."],
+    [59, "'_' has already been declared."],
+    [60, "'ember2' has already been declared."],
+    [65, "'newImport' was used before it was declared, which is illegal for 'const' variables."],
+    [57, "'$' was used before it was declared, which is illegal for 'const' variables."],
+    [58, "'emGet' was used before it was declared, which is illegal for 'const' variables."],
+    [58, "'set' was used before it was declared, which is illegal for 'const' variables."],
+    [59, "'_' was used before it was declared, which is illegal for 'const' variables."],
+    [60, "'ember2' was used before it was declared, which is illegal for 'const' variables."]
+  ];
 
-  TestRun(test)
+  var testRun = TestRun(test);
+  importConstErrors.forEach(function(error) { testRun.addError.apply(testRun, error); });
+  testRun.test(src, {esnext: true});
+
+  testRun = TestRun(test)
     .addError(3, "'import' is only available in ES6 (use esnext option).")
     .addError(4, "'import' is only available in ES6 (use esnext option).")
     .addError(5, "'import' is only available in ES6 (use esnext option).")
@@ -757,7 +777,13 @@ exports.testES6Modules = function (test) {
     .addError(48, "'class' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
     .addError(47, "'export' is only available in ES6 (use esnext option).")
     .addError(46, "'class' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).")
-    .test(src, {});
+    .addError(57, "'import' is only available in ES6 (use esnext option).")
+    .addError(58, "'import' is only available in ES6 (use esnext option).")
+    .addError(59, "'import' is only available in ES6 (use esnext option).")
+    .addError(60, "'import' is only available in ES6 (use esnext option).")
+    .addError(65, "'import' is only available in ES6 (use esnext option).")
+  importConstErrors.forEach(function(error) { testRun.addError.apply(testRun, error); });
+  testRun.test(src, {});
 
   var src2 = [
     "var a = {",

--- a/tests/unit/fixtures/es6-import-export.js
+++ b/tests/unit/fixtures/es6-import-export.js
@@ -46,3 +46,20 @@ export var c = "c";
 export class Foo {}
 export class List extends Array {}
 export default class Bar {}
+
+// imports are const's and cannot be re-assigned
+$ = null;
+emGet = null;
+one = null;
+_ = null;
+ember2 = null;
+// they also cannot be imported twice
+import $ from "jquery";
+import { get as emGet, set } from "ember";
+import { default as _ } from "underscore";
+import * as ember2 from "ember";
+// or used before definition
+if (newImport) {
+  $();
+}
+import newImport from 'newImport';

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -114,9 +114,7 @@ exports.shadowEs6 = function (test) {
     [301, "'zf' has already been declared."],
     [344, "'zzi' has already been declared."],
     [345, "'zzj' has already been declared."],
-    [349, "'zzl' was used before it was declared, which is illegal for 'const' variables."],
     [349, "'zzl' has already been declared."],
-    [350, "'zzm' was used before it was declared, which is illegal for 'let' variables."],
     [350, "'zzm' has already been declared."]
   ];
 
@@ -233,6 +231,13 @@ exports.latedef = function (test) {
   TestRun(test)
     .addError(10, "'vr' was used before it was defined.")
     .test(src, { es3: true, latedef: "nofunc" });
+
+  // when latedef is true, jshint must not warn if variable is defined.
+  TestRun(test)
+    .test([
+      "if(true) { var a; }",
+      "if (a) { a(); }",
+      "var a;"], { es3: true, latedef: true});
 
   // When latedef_func is true, JSHint must not tolerate the use before definition for functions
   TestRun(test)


### PR DESCRIPTION
As per the es6 spec, treat the variables declared via import as
constants, meaning they cannot be re-assigned and cannot be declared
twice.
Fixes #2428 

Also fixed the following which I noticed. included in the same PR because there would be a merge conflict in the tests..

[[FIX]] Dont warn twice in block var redeclaration
When a block scoped variable is declared twice in the same scope it is a
syntax error. If the variable is used between those declarations jshint
should not warn about use before declared and error on re-declaration, so
remove the use before declared warning in this case.