### PR TITLE
[[CHORE]] Revert - allow failures in coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-after_success: npm run coverage && cat ./coverage/lcov.info | coveralls
+script: npm run coverage && cat ./coverage/lcov.info | coveralls
 node_js:
   - "0.10"
   - "0.12"


### PR DESCRIPTION
This reverts commit 8f82d0d640e73d0f0271202b14e15047b1b2fe6e.
This is because coveralls stops commenting when not run as a script??

This PR is a test!