### PR TITLE
[[FIX]] Catch blocks are no longer functions

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3782,14 +3782,6 @@ var JSHINT = (function() {
         advance();
       }
 
-      state.funct = functor("(catch)", state.tokens.next, {
-        "(context)"  : state.funct,
-        "(breakage)" : state.funct["(breakage)"],
-        "(loopage)"  : state.funct["(loopage)"],
-        "(statement)": false,
-        "(catch)"    : true
-      });
-
       state.funct["(scope)"].stackParams(e ? [ { id: e.value, token: e, type: "exception" }] : []);
 
       if (state.tokens.next.value === "if") {
@@ -3802,15 +3794,9 @@ var JSHINT = (function() {
 
       advance(")");
 
-      functions.push(state.funct);
-
       block(false);
 
       state.funct["(scope)"].unstack();
-
-      state.funct["(last)"] = state.tokens.curr.line;
-      state.funct["(lastcharacter)"] = state.tokens.curr.character;
-      state.funct = state.funct["(context)"];
     }
 
     block(true);

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2012,8 +2012,12 @@ exports.maxcomplexity = function (test) {
 exports.fnmetrics = function (test) {
   JSHINT([
     "function foo(a, b) { if (a) return b; }",
-    "function bar() { var a = 0; a += 1; return a; }"
+    "function bar() { var a = 0; a += 1; return a; }",
+    "function hasTryCatch() { try { } catch(e) { }}",
+    "try { throw e; } catch(e) {}"
   ]);
+
+  test.equal(JSHINT.data().functions.length, 3);
 
   test.deepEqual(JSHINT.data().functions[0].metrics, {
     complexity: 2,
@@ -2025,6 +2029,12 @@ exports.fnmetrics = function (test) {
     complexity: 1,
     parameters: 0,
     statements: 3
+  });
+
+  test.deepEqual(JSHINT.data().functions[2].metrics, {
+    complexity: 2,
+    parameters: 0,
+    statements: 1
   });
 
   test.done();


### PR DESCRIPTION
Catch blocks used to be functions in order to handle the exception
parameter, but this is now handled by the scope manager.
Fixes #2510