### PR TITLE
[[FIX]] Param destructuring should not effect max params

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2973,10 +2973,10 @@ var JSHINT = (function() {
 
     if (paramsInfo) {
       state.funct["(params)"] = paramsInfo.params;
-      state.funct["(metrics)"].verifyMaxParametersPerFunction(paramsInfo.arity);
-      state.funct["(arity)"] = paramsInfo.arity;
+      state.funct["(metrics)"].arity = paramsInfo.arity;
+      state.funct["(metrics)"].verifyMaxParametersPerFunction();
     } else {
-      state.funct["(arity)"] = 0;
+      state.funct["(metrics)"].arity = 0;
     }
 
     if (isArrow) {
@@ -3021,6 +3021,7 @@ var JSHINT = (function() {
       statementCount: 0,
       nestedBlockDepth: -1,
       ComplexityCount: 1,
+      arity: 0,
 
       verifyMaxStatementsPerFunction: function() {
         if (state.option.maxstatements &&
@@ -3029,9 +3030,10 @@ var JSHINT = (function() {
         }
       },
 
-      verifyMaxParametersPerFunction: function(count) {
-        if (_.isNumber(state.option.maxparams) && count > state.option.maxparams) {
-          warning("W072", functionStartToken, count);
+      verifyMaxParametersPerFunction: function() {
+        if (_.isNumber(state.option.maxparams) &&
+          this.arity > state.option.maxparams) {
+          warning("W072", functionStartToken, this.arity);
         }
       },
 
@@ -5280,7 +5282,7 @@ var JSHINT = (function() {
 
       fu.metrics = {
         complexity: f["(metrics)"].ComplexityCount,
-        parameters: f["(arity)"],
+        parameters: f["(metrics)"].arity,
         statements: f["(metrics)"].statementCount
       };
 

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2974,6 +2974,9 @@ var JSHINT = (function() {
     if (paramsInfo) {
       state.funct["(params)"] = paramsInfo.params;
       state.funct["(metrics)"].verifyMaxParametersPerFunction(paramsInfo.count);
+      state.funct["(paramCount)"] = paramsInfo.count;
+    } else {
+      state.funct["(paramCount)"] = 0;
     }
 
     if (isArrow) {
@@ -5277,7 +5280,7 @@ var JSHINT = (function() {
 
       fu.metrics = {
         complexity: f["(metrics)"].ComplexityCount,
-        parameters: (f["(params)"] || []).length,
+        parameters: f["(paramCount)"],
         statements: f["(metrics)"].statementCount
       };
 

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2729,7 +2729,7 @@ var JSHINT = (function() {
    *                                  single-argument shorthand.
    * @param {bool} [options.parsedOpening] Whether the opening parenthesis has
    *                                       already been parsed.
-   * @returns {{ count: number, params: Array.<string>}}
+   * @returns {{ arity: number, params: Array.<string>}}
    */
   function functionparams(options) {
     var next;
@@ -2739,12 +2739,12 @@ var JSHINT = (function() {
     var t;
     var pastDefault = false;
     var pastRest = false;
-    var count = 0;
+    var arity = 0;
     var loneArg = options && options.loneArg;
 
     if (loneArg && loneArg.identifier === true) {
       state.funct["(scope)"].addParam(loneArg.value, loneArg);
-      return { count: 1, params: [ loneArg.value ] };
+      return { arity: 1, params: [ loneArg.value ] };
     }
 
     next = state.tokens.next;
@@ -2763,7 +2763,7 @@ var JSHINT = (function() {
     }
 
     for (;;) {
-      count++;
+      arity++;
       // are added to the param scope
       var currentParams = [];
 
@@ -2813,7 +2813,7 @@ var JSHINT = (function() {
         comma();
       } else {
         advance(")", next);
-        return { count: count, params: paramsIds };
+        return { arity: arity, params: paramsIds };
       }
     }
   }
@@ -2973,10 +2973,10 @@ var JSHINT = (function() {
 
     if (paramsInfo) {
       state.funct["(params)"] = paramsInfo.params;
-      state.funct["(metrics)"].verifyMaxParametersPerFunction(paramsInfo.count);
-      state.funct["(paramCount)"] = paramsInfo.count;
+      state.funct["(metrics)"].verifyMaxParametersPerFunction(paramsInfo.arity);
+      state.funct["(arity)"] = paramsInfo.arity;
     } else {
-      state.funct["(paramCount)"] = 0;
+      state.funct["(arity)"] = 0;
     }
 
     if (isArrow) {
@@ -5280,7 +5280,7 @@ var JSHINT = (function() {
 
       fu.metrics = {
         complexity: f["(metrics)"].ComplexityCount,
-        parameters: f["(paramCount)"],
+        parameters: f["(arity)"],
         statements: f["(metrics)"].statementCount
       };
 

--- a/tests/unit/fixtures/max-parameters-per-function.js
+++ b/tests/unit/fixtures/max-parameters-per-function.js
@@ -3,3 +3,15 @@ function functionWithNoParameters() {
 
 function functionWith3Parameters(param1, param2, param3) {
 }
+
+var a = () => {};
+var b = (a) => {};
+var c = a => {};
+var d = (a, b, c) => {};
+var e = ({a, b, c}) => {};
+
+function f([a, b, c] = [], [d, e] = []) {
+}
+
+function g({a}, {b}, {c}) {
+}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2063,6 +2063,18 @@ exports.maxparams = function (test) {
   TestRun(test)
     .test(src, { esnext: true });
 
+  var functions = JSHINT.data().functions;
+  test.equal(functions.length, 9);
+  test.equal(functions[0].metrics.parameters, 0);
+  test.equal(functions[1].metrics.parameters, 3);
+  test.equal(functions[2].metrics.parameters, 0);
+  test.equal(functions[3].metrics.parameters, 1);
+  test.equal(functions[4].metrics.parameters, 1);
+  test.equal(functions[5].metrics.parameters, 3);
+  test.equal(functions[6].metrics.parameters, 1);
+  test.equal(functions[7].metrics.parameters, 2);
+  test.equal(functions[8].metrics.parameters, 3);
+
   test.done();
 };
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2043,17 +2043,25 @@ exports.maxparams = function (test) {
 
   TestRun(test)
     .addError(4, "This function has too many parameters. (3)")
-    .test(src, { es3: true, maxparams: 2 });
+    .addError(10, "This function has too many parameters. (3)")
+    .addError(16, "This function has too many parameters. (3)")
+    .test(src, { esnext: true, maxparams: 2 });
 
   TestRun(test)
-    .test(src, { es3: true, maxparams: 3 });
+    .test(src, { esnext: true, maxparams: 3 });
 
   TestRun(test)
     .addError(4, "This function has too many parameters. (3)")
-    .test(src, {es3: true, maxparams: 0 });
+    .addError(8, "This function has too many parameters. (1)")
+    .addError(9, "This function has too many parameters. (1)")
+    .addError(10, "This function has too many parameters. (3)")
+    .addError(11, "This function has too many parameters. (1)")
+    .addError(13, "This function has too many parameters. (2)")
+    .addError(16, "This function has too many parameters. (3)")
+    .test(src, {esnext: true, maxparams: 0 });
 
   TestRun(test)
-    .test(src, { es3: true });
+    .test(src, { esnext: true });
 
   test.done();
 };


### PR DESCRIPTION
Fixes destructuring so that multiple destructured params do not count
towards the maxparams limit. This is because destructuring is the solution
to having alot of numbered params, since you would replace a hard to
figure out list of params with an object, then use destructuring to pull
out from that object.
Fixes #2183