### PR TITLE
[[FIX]] Allow destructuring in catch blocks parameter

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3761,13 +3761,11 @@ var JSHINT = (function() {
 
       if (checkPunctuators(state.tokens.next, ["[", "{"])) {
         var tokens = destructuringExpression();
-        var t;
-        for (t in tokens) {
-          t = tokens[t];
-          if (t.id) {
-            params.push({ id: t.id, token: t });
+        _.each(tokens, function(token) {
+          if (token.id) {
+            params.push({ id: token.id, token: token });
           }
-        }
+        });
       } else if (state.tokens.next.type !== "(identifier)") {
         warning("E030", state.tokens.next, state.tokens.next.value);
       } else {

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3754,18 +3754,25 @@ var JSHINT = (function() {
     var b;
 
     function doCatch() {
-      var e;
+      var params = [];
 
       advance("catch");
       advance("(");
 
-      e = state.tokens.next;
-      if (e.type !== "(identifier)") {
-        warning("E030", state.tokens.next, e.value);
-        e = null;
+      if (checkPunctuators(state.tokens.next, ["[", "{"])) {
+        var tokens = destructuringExpression();
+        var t;
+        for (t in tokens) {
+          t = tokens[t];
+          if (t.id) {
+            params.push({ id: t.id, token: t });
+          }
+        }
+      } else if (state.tokens.next.type !== "(identifier)") {
+        warning("E030", state.tokens.next, state.tokens.next.value);
       } else {
         // only advance if we have an identifier so we can continue parsing in the most common error - that no param is given.
-        advance();
+        params.push({ id: identifier(), token: state.tokens.curr, type: "exception" });
       }
 
       state.funct = functor("(catch)", state.tokens.next, {
@@ -3776,7 +3783,7 @@ var JSHINT = (function() {
         "(catch)"    : true
       });
 
-      state.funct["(scope)"].stackParams(e ? [ { id: e.value, token: e, type: "exception" }] : []);
+      state.funct["(scope)"].stackParams(params);
 
       if (state.tokens.next.value === "if") {
         if (!state.inMoz()) {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -622,6 +622,11 @@ exports.testCatchBlocks = function (test) {
   TestRun(test)
     .test(src, { es3: true, undef: true, devel: true, node: true });
 
+  var code = "try {} catch ({ message }) {}";
+
+  TestRun(test, "destructuring in catch blocks' parameter")
+    .test(code, { esnext: true });
+
   test.done();
 };
 


### PR DESCRIPTION
Example:
```js
try {
  throw new Error("foo");
} catch ({ message }) {
  console.log(message); // foo
}
```

Fixes #2526