### PR TITLE
[[FIX]] Report an error when a necessary semicolon is missing

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1491,12 +1491,18 @@ var JSHINT = (function() {
     if (state.tokens.next.id !== ";") {
       // don't complain about unclosed templates / strings
       if (state.tokens.next.isUnclosed) return advance();
-      if (!state.option.asi) {
+
+      var sameLine = startLine(state.tokens.next) === state.tokens.curr.line &&
+                     state.tokens.next.id !== "(end)";
+      var blockEnd = checkPunctuators(state.tokens.next, "}");
+
+      if (sameLine && !blockEnd) {
+        errorAt("E057", state.tokens.curr.line, state.tokens.curr.character);
+      } else if (!state.option.asi) {
         // If this is the last statement in a block that ends on
         // the same line *and* option lastsemic is on, ignore the warning.
         // Otherwise, complain about missing semicolon.
-        if (!state.option.lastsemic || state.tokens.next.id !== "}" ||
-          startLine(state.tokens.next) !== state.tokens.curr.line) {
+        if ((blockEnd && !state.option.lastsemic) || !sameLine) {
           warningAt("W033", state.tokens.curr.line, state.tokens.curr.character);
         }
       }

--- a/src/messages.js
+++ b/src/messages.js
@@ -71,7 +71,8 @@ var errors = {
   E053: "Export declaration must be in global scope.",
   E054: "Class properties must be methods. Expected '(' but instead saw '{a}'.",
   E055: "The '{a}' option cannot be set after any executable code.",
-  E056: "'{a}' was used before it was declared, which is illegal for '{b}' variables."
+  E056: "'{a}' was used before it was declared, which is illegal for '{b}' variables.",
+  E057: "Missing semicolon."
 };
 
 var warnings = {

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -635,7 +635,36 @@ exports.safeasi = function (test) {
     .addError(10, "Bad line breaking before '/'.")
     .addError(10, "Expected an identifier and instead saw '.'.")
     .addError(10, "Expected an assignment or function call and instead saw an expression.")
+    .addError(10, "Missing semicolon.")
     .test(src, { asi: true });
+
+  test.done();
+};
+
+exports["missing semicolons not influenced by asi"] = function (test) {
+  // These tests are taken from
+  // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-11.9.2
+
+  var code = [
+    "void 0;", // Not JSON
+    "{ 1 2 } 3"
+  ];
+
+  JSHINT(code, { expr: true, asi: true });
+
+  var error = JSHINT.errors[0]
+  test.equal(error.code, "E057");
+  test.equal(error.line, 2);
+  test.equal(error.character, 4);
+  test.equal(JSHINT.errors.length, 1);
+
+  code = [
+    "void 0;",
+    "{ 1",
+    "2 } 3"
+  ];
+
+  TestRun(test).test(code, { expr: true, asi: true });
 
   test.done();
 };

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -650,13 +650,9 @@ exports["missing semicolons not influenced by asi"] = function (test) {
     "{ 1 2 } 3"
   ];
 
-  JSHINT(code, { expr: true, asi: true });
-
-  var error = JSHINT.errors[0]
-  test.equal(error.code, "E057");
-  test.equal(error.line, 2);
-  test.equal(error.character, 4);
-  test.equal(JSHINT.errors.length, 1);
+  TestRun(test)
+    .addError(2, "Missing semicolon.", { character: 4, code: "E057" })
+    .test(code, { expr: true, asi: true });
 
   code = [
     "void 0;",

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5853,13 +5853,15 @@ exports["test for crash with invalid condition"] = function (test) {
     .addError(4, "Expected an identifier and instead saw ','.")
     .addError(4, "Expected ')' to match '(' from line 4 and instead saw 'b'.")
     .addError(4, "Expected an identifier and instead saw ')'.")
+    .addError(4, "Missing semicolon.")
     .addError(6, "Expected an identifier and instead saw ','.")
     .addError(7, "Unexpected ')'.")
     .addError(7, "Expected an identifier and instead saw ')'.")
     .addError(7, "Expected ')' to match '(' from line 7 and instead saw ';'.")
     .addError(8, "Expected an identifier and instead saw ','.")
     .addError(8, "Expected ')' to match '(' from line 8 and instead saw 'b'.")
-    .addError(8, "Expected an identifier and instead saw ')'.");
+    .addError(8, "Expected an identifier and instead saw ')'.")
+    .addError(8, "Missing semicolon.");
 
   run.test(code, {asi: true, expr: true});
   test.done();
@@ -5966,6 +5968,7 @@ exports["test for line breaks with 'yield'"] = function (test) {
     .addError(8, "Comma warnings can be turned off with 'laxcomma'.")
     .addError(7, "Bad line breaking before ','.")
     .addError(10, "Expected an identifier and instead saw '?'.")
+    .addError(10, "Missing semicolon.")
     .addError(10, "Expected an assignment or function call and instead saw an expression.")
     .addError(10, "Label 'i' on j statement.")
     .addError(10, "Expected an assignment or function call and instead saw an expression.")
@@ -5981,7 +5984,6 @@ exports["test for line breaks with 'yield'"] = function (test) {
     .addError(7, "Line breaking error 'yield'.")
     .addError(9, "Line breaking error 'yield'.")
     .addError(9, "Missing semicolon.")
-    .addError(10, "Missing semicolon.")
     .addError(11, "Line breaking error 'yield'.")
     .addError(13, "Line breaking error 'yield'.")
     .addError(13, "Missing semicolon.");


### PR DESCRIPTION
The `asi` option also disabled warning about missing necessary semicolons (e.g. semicolons between
two tokens on the same line). Now, they are reported as errors and can't be disabled.

Fixes #1327