### PR TITLE
[[FIX]] Regular args can come after args with default

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2784,10 +2784,12 @@ var JSHINT = (function() {
         }
       }
 
-      // it is a syntax error to have a regular argument after a default argument
+      // It is valid to have a regular argument after a default argument
+      // since undefined can be used for missing parameters. Still warn as it is
+      // a possible code smell.
       if (pastDefault) {
         if (state.tokens.next.id !== "=") {
-          error("E051", state.tokens.current);
+          error("W138", state.tokens.current);
         }
       }
       if (state.tokens.next.id === "=") {

--- a/src/messages.js
+++ b/src/messages.js
@@ -62,11 +62,11 @@ var errors = {
   E044: null,
   E045: "Invalid for each loop.",
   E046: "A yield statement shall be within a generator function (with syntax: `function*`)",
-  E047: null, // Vacant
+  E047: null,
   E048: "{a} declaration not directly within block.",
   E049: "A {a} cannot be named '{b}'.",
   E050: "Mozilla requires the yield expression to be parenthesized here.",
-  E051: "Regular parameters cannot come after default parameters.",
+  E051: null,
   E052: "Unclosed template literal.",
   E053: "Export declaration must be in global scope.",
   E054: "Class properties must be methods. Expected '(' but instead saw '{a}'.",
@@ -217,7 +217,8 @@ var warnings = {
   W134: "The '{a}' option is only available when linting ECMAScript {b} code.",
   W135: "{a} may not be supported by non-browser environments.",
   W136: "'{a}' must be in function scope.",
-  W137: "Empty destructuring."
+  W137: "Empty destructuring.",
+  W138: "Regular parameters should not come after default parameters."
 };
 
 var info = {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1438,7 +1438,7 @@ exports.testDefaultArguments = function (test) {
     .addError(14, "'bar' is not defined.")
     .addError(14, "'num3' was used before it was declared, which is illegal for 'param' variables.")
     .addError(15, "'num4' was used before it was declared, which is illegal for 'param' variables.")
-    .addError(11, "Regular parameters should not come after default parameters.")
+    .addError(18, "Regular parameters should not come after default parameters.")
     .addError(27, "'c' is not defined.")
     .addError(33, "'d' was used before it was defined.")
     .addError(36, "'e' was used before it was declared, which is illegal for 'param' variables.")
@@ -1447,7 +1447,7 @@ exports.testDefaultArguments = function (test) {
   TestRun(test)
     .addError(14, "'num3' was used before it was declared, which is illegal for 'param' variables.")
     .addError(15, "'num4' was used before it was declared, which is illegal for 'param' variables.")
-    .addError(11, "Regular parameters should not come after default parameters.")
+    .addError(18, "Regular parameters should not come after default parameters.")
     .addError(36, "'e' was used before it was declared, which is illegal for 'param' variables.")
     .test(src, { moz: true });
 
@@ -1461,7 +1461,7 @@ exports.testDefaultArguments = function (test) {
     .addError(15, "'default parameters' is only available in ES6 (use esnext option).")
     .addError(15, "'num4' was used before it was declared, which is illegal for 'param' variables.")
     .addError(18, "'default parameters' is only available in ES6 (use esnext option).")
-    .addError(11, "Regular parameters should not come after default parameters.")
+    .addError(18, "Regular parameters should not come after default parameters.")
     .addError(26, "'default parameters' is only available in ES6 (use esnext option).")
     .addError(31, "'default parameters' is only available in ES6 (use esnext option).")
     .addError(33, "'default parameters' is only available in ES6 (use esnext option).")

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1438,7 +1438,7 @@ exports.testDefaultArguments = function (test) {
     .addError(14, "'bar' is not defined.")
     .addError(14, "'num3' was used before it was declared, which is illegal for 'param' variables.")
     .addError(15, "'num4' was used before it was declared, which is illegal for 'param' variables.")
-    .addError(18, "Regular parameters cannot come after default parameters.")
+    .addError(11, "Regular parameters should not come after default parameters.")
     .addError(27, "'c' is not defined.")
     .addError(33, "'d' was used before it was defined.")
     .addError(36, "'e' was used before it was declared, which is illegal for 'param' variables.")
@@ -1447,7 +1447,7 @@ exports.testDefaultArguments = function (test) {
   TestRun(test)
     .addError(14, "'num3' was used before it was declared, which is illegal for 'param' variables.")
     .addError(15, "'num4' was used before it was declared, which is illegal for 'param' variables.")
-    .addError(18, "Regular parameters cannot come after default parameters.")
+    .addError(11, "Regular parameters should not come after default parameters.")
     .addError(36, "'e' was used before it was declared, which is illegal for 'param' variables.")
     .test(src, { moz: true });
 
@@ -1461,7 +1461,7 @@ exports.testDefaultArguments = function (test) {
     .addError(15, "'default parameters' is only available in ES6 (use esnext option).")
     .addError(15, "'num4' was used before it was declared, which is illegal for 'param' variables.")
     .addError(18, "'default parameters' is only available in ES6 (use esnext option).")
-    .addError(18, "Regular parameters cannot come after default parameters.")
+    .addError(11, "Regular parameters should not come after default parameters.")
     .addError(26, "'default parameters' is only available in ES6 (use esnext option).")
     .addError(31, "'default parameters' is only available in ES6 (use esnext option).")
     .addError(33, "'default parameters' is only available in ES6 (use esnext option).")


### PR DESCRIPTION
Fixes #1779 

Not a breaking change since it used to be an error, which could not be overridden, this makes it a warning which can be overridden.

Other option is to remove the warning completely.