### PR TITLE
[[FIX]] Improve support for `__proto__` identifier

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4616,7 +4616,7 @@ var JSHINT = (function() {
       name = tkn.value;
     }
 
-    if (props[name]) {
+    if (props[name] && name !== "__proto__") {
       warning("W075", state.tokens.next, msg, name);
     } else {
       props[name] = Object.create(null);
@@ -4652,7 +4652,7 @@ var JSHINT = (function() {
     state.nameStack.set(tkn);
 
     if (props[name]) {
-      if (props[name].basic || props[name][flagName]) {
+      if ((props[name].basic || props[name][flagName]) && name !== "__proto__") {
         warning("W075", state.tokens.next, msg, name);
       }
     } else {

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3061,7 +3061,7 @@ var JSHINT = (function() {
     // Check for lonely setters if in the ES5 mode.
     if (state.inES5()) {
       for (var name in props) {
-        if (_.has(props, name) && props[name].setterToken && !props[name].getterToken) {
+        if (props[name] && props[name].setterToken && !props[name].getterToken) {
           warning("W078", props[name].setterToken);
         }
       }
@@ -3086,7 +3086,7 @@ var JSHINT = (function() {
   (function(x) {
     x.nud = function() {
       var b, f, i, p, t, isGeneratorMethod = false, nextVal;
-      var props = {}; // All properties, including accessors
+      var props = Object.create(null); // All properties, including accessors
 
       b = state.tokens.curr.line !== startLine(state.tokens.next);
       if (b) {
@@ -3581,8 +3581,8 @@ var JSHINT = (function() {
     var isStatic;
     var isGenerator;
     var getset;
-    var props = {};
-    var staticProps = {};
+    var props = Object.create(null);
+    var staticProps = Object.create(null);
     var computed;
     for (var i = 0; state.tokens.next.id !== "}"; ++i) {
       name = state.tokens.next;
@@ -4616,10 +4616,10 @@ var JSHINT = (function() {
       name = tkn.value;
     }
 
-    if (props[name] && _.has(props, name)) {
+    if (props[name]) {
       warning("W075", state.tokens.next, msg, name);
     } else {
-      props[name] = {};
+      props[name] = Object.create(null);
     }
 
     props[name].basic = true;
@@ -4651,12 +4651,12 @@ var JSHINT = (function() {
     state.tokens.curr.accessorType = accessorType;
     state.nameStack.set(tkn);
 
-    if (props[name] && _.has(props, name)) {
+    if (props[name]) {
       if (props[name].basic || props[name][flagName]) {
         warning("W075", state.tokens.next, msg, name);
       }
     } else {
-      props[name] = {};
+      props[name] = Object.create(null);
     }
 
     props[name][flagName] = tkn;

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -49,7 +49,7 @@ var scopeManager = function(state, predefined, exported, declared) {
     if (token) {
       token["(function)"] = _currentFunct;
     }
-    if (!_.has(_current["(usages)"], labelName)) {
+    if (!_current["(usages)"][labelName]) {
       _current["(usages)"][labelName] = {
         "(modified)": [],
         "(reassigned)": [],
@@ -117,7 +117,7 @@ var scopeManager = function(state, predefined, exported, declared) {
     }
     var curentLabels = _current["(labels)"];
     for (var labelName in curentLabels) {
-      if (_.has(curentLabels, labelName)) {
+      if (curentLabels[labelName]) {
         if (curentLabels[labelName]["(type)"] !== "exception" &&
           curentLabels[labelName]["(unused)"]) {
           _warnUnused(labelName, curentLabels[labelName]["(token)"], "var");
@@ -162,7 +162,7 @@ var scopeManager = function(state, predefined, exported, declared) {
   function _getLabel(labelName) {
     for (var i = _scopeStack.length - 1 ; i >= 0; --i) {
       var scopeLabels = _scopeStack[i]["(labels)"];
-      if (_.has(scopeLabels, labelName)) {
+      if (scopeLabels[labelName]) {
         return scopeLabels;
       }
     }
@@ -172,7 +172,7 @@ var scopeManager = function(state, predefined, exported, declared) {
     // used so far in this whole function and any sub functions
     for (var i = _scopeStack.length - 1; i >= 0; i--) {
       var current = _scopeStack[i];
-      if (_.has(current["(usages)"], labelName)) {
+      if (current["(usages)"][labelName]) {
         return current["(usages)"][labelName];
       }
       if (current === _currentFunct) {
@@ -199,11 +199,11 @@ var scopeManager = function(state, predefined, exported, declared) {
       if (!isNewFunction && _scopeStack[i + 1] === _currentFunct) {
         outsideCurrentFunction = false;
       }
-      if (outsideCurrentFunction && _.has(stackItem["(labels)"], labelName)) {
+      if (outsideCurrentFunction && stackItem["(labels)"][labelName]) {
         warning("W123", token, labelName);
         //break;
       }
-      if (_.has(stackItem["(breakLabels)"], labelName)) {
+      if (stackItem["(breakLabels)"][labelName]) {
         warning("W123", token, labelName);
       }
     }
@@ -261,7 +261,7 @@ var scopeManager = function(state, predefined, exported, declared) {
         var usedLabelName = usedLabelNameList[i];
 
         var usage = currentUsages[usedLabelName];
-        var usedLabel = _.has(currentLabels, usedLabelName) && currentLabels[usedLabelName];
+        var usedLabel = currentLabels[usedLabelName];
         if (usedLabel) {
 
           if (usedLabel["(useOutsideOfScope)"] && !state.option.funcscope) {
@@ -301,7 +301,7 @@ var scopeManager = function(state, predefined, exported, declared) {
 
         if (subScope) {
           // not exiting the global scope, so copy the usage down in case its an out of scope usage
-          if (!_.has(subScope["(usages)"], usedLabelName)) {
+          if (!subScope["(usages)"][usedLabelName]) {
             subScope["(usages)"][usedLabelName] = usage;
             if (isUnstackingFunction) {
               subScope["(usages)"][usedLabelName]["(onlyUsedSubFunction)"] = true;
@@ -503,15 +503,15 @@ var scopeManager = function(state, predefined, exported, declared) {
       // if is block scoped (let or const)
       if (isblockscoped) {
 
-        var declaredInCurrentScope = _.has(_current["(labels)"], labelName);
+        var declaredInCurrentScope = _current["(labels)"][labelName];
         // for block scoped variables, params are seen in the current scope as the root function
         // scope, so check these too.
         if (!declaredInCurrentScope && _current === _currentFunct && !_current["(global)"]) {
-          declaredInCurrentScope = _.has(_currentFunct["(parent)"]["(labels)"], labelName);
+          declaredInCurrentScope = !!_currentFunct["(parent)"]["(labels)"][labelName];
         }
 
         // if its not already defined (which is an error, so ignore) and is used in TDZ
-        if (!declaredInCurrentScope && _.has(_current["(usages)"], labelName)) {
+        if (!declaredInCurrentScope && _current["(usages)"][labelName]) {
           var usage = _current["(usages)"][labelName];
           // if its in a sub function it is not necessarily an error, just latedef
           if (usage["(onlyUsedSubFunction)"]) {
@@ -585,7 +585,7 @@ var scopeManager = function(state, predefined, exported, declared) {
         var currentScopeIndex = _scopeStack.length - (options && options.excludeCurrent ? 2 : 1);
         for (var i = currentScopeIndex; i >= 0; i--) {
           var current = _scopeStack[i];
-          if (_.has(current["(labels)"], labelName) &&
+          if (current["(labels)"][labelName] &&
             (!onlyBlockscoped || current["(labels)"][labelName]["(blockscoped)"])) {
             return current["(labels)"][labelName]["(type)"];
           }
@@ -605,7 +605,7 @@ var scopeManager = function(state, predefined, exported, declared) {
         for (var i = _scopeStack.length - 1; i >= 0; i--) {
           var current = _scopeStack[i];
 
-          if (_.has(current["(breakLabels)"], labelName)) {
+          if (current["(breakLabels)"][labelName]) {
             return true;
           }
           if (current["(isParams)"] === "function") {
@@ -653,7 +653,7 @@ var scopeManager = function(state, predefined, exported, declared) {
         // to the unset var
         // first check the param is used
         var paramScope = _currentFunct["(parent)"];
-        if (paramScope && _.has(paramScope["(labels)"], labelName) &&
+        if (paramScope && paramScope["(labels)"][labelName] &&
           paramScope["(labels)"][labelName]["(type)"] === "param") {
 
           // then check its not used

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -552,7 +552,7 @@ var scopeManager = function(state, predefined, exported, declared) {
         } else if (state.option.shadow !== true) {
           // now since we didn't get any block scope variables, test for var/function
           // shadowing
-          if (declaredInCurrentFunctionScope) {
+          if (declaredInCurrentFunctionScope && labelName !== "__proto__") {
 
             // see https://github.com/jshint/jshint/issues/2400
             if (!_currentFunct["(global)"]) {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -51,6 +51,37 @@ exports.testUnusedDefinedGlobals = function (test) {
   test.done();
 };
 
+exports.testImplieds = function (test) {
+  var src = [
+    "f = 0;",
+    "(function() {",
+    "  g = 0;",
+    "}());",
+    "h = 0;"
+  ];
+  var report;
+
+  TestRun(test).test(src);
+  report = JSHINT.data();
+
+  test.deepEqual(
+    report.implieds,
+    [
+      { name: "f", line: [1] },
+      { name: "g", line: [3] },
+      { name: "h", line: [5] }
+    ]
+  );
+
+  TestRun(test)
+    .test("__proto__ = 0;", { proto: true });
+  report = JSHINT.data();
+
+  test.deepEqual(report.implieds, [ { name: "__proto__", line: [1] } ]);
+
+  test.done();
+};
+
 exports.testExportedDefinedGlobals = function (test) {
   var src = ["/*global foo, bar */",
     "export { bar, foo };"];

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -73,6 +73,10 @@ exports.testGlobalVarDeclarations = function (test) {
   var report = JSHINT.data();
   test.deepEqual(report.globals, ['a']);
 
+  TestRun(test).test("var __proto__;", { proto: true });
+  report = JSHINT.data();
+  test.deepEqual(report.globals, ["__proto__"]);
+
   test.done();
 };
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1734,3 +1734,74 @@ exports["gh-1920"] = function (test) {
 
   test.done();
 };
+
+exports.duplicateProto = function (test) {
+  var src = [
+    "(function() {",
+    "  var __proto__;",
+    "  var __proto__;",
+    "}());"
+  ];
+
+  TestRun(test, "Duplicate `var`s")
+    .addError(3, "'__proto__' is already defined.")
+    .test(src, { proto: true });
+
+  src = [
+    "(function() {",
+    "  let __proto__;",
+    "  let __proto__;",
+    "}());"
+  ];
+
+  TestRun(test, "Duplicate `let`s")
+    .addError(3, "'__proto__' has already been declared.")
+    .test(src, { proto: true, esnext: true });
+
+  src = [
+    "(function() {",
+    "  const __proto__ = null;",
+    "  const __proto__ = null;",
+    "}());"
+  ];
+
+  TestRun(test, "Duplicate `const`s")
+    .addError(3, "'__proto__' has already been declared.")
+    .test(src, { proto: true, esnext: true });
+
+  src = [
+    "void {",
+    "  __proto__: null,",
+    "  __proto__: null",
+    "};"
+  ];
+
+  TestRun(test, "Duplicate keys (data)")
+    .addError(3, "Duplicate key '__proto__'.")
+    .test(src, { proto: true });
+
+  src = [
+    "void {",
+    "  __proto__: null,",
+    "  get __proto__() {}",
+    "};"
+  ];
+
+  TestRun(test, "Duplicate keys (data and accessor)")
+    .addError(3, "Duplicate key '__proto__'.")
+    .test(src, { proto: true });
+
+  src = [
+    "__proto__: while (true) {",
+    "  __proto__: while (true) {",
+    "    break;",
+    "  }",
+    "}"
+  ];
+
+  TestRun(test, "Duplicate labels")
+    .addError(2, "'__proto__' has already been declared.")
+    .test(src, { proto: true });
+
+  test.done();
+};

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1743,8 +1743,9 @@ exports.duplicateProto = function (test) {
     "}());"
   ];
 
+  // TODO: Enable this expected warning in the next major release
   TestRun(test, "Duplicate `var`s")
-    .addError(3, "'__proto__' is already defined.")
+    //.addError(3, "'__proto__' is already defined.")
     .test(src, { proto: true });
 
   src = [
@@ -1776,8 +1777,9 @@ exports.duplicateProto = function (test) {
     "};"
   ];
 
+  // TODO: Enable this expected warning in the next major release
   TestRun(test, "Duplicate keys (data)")
-    .addError(3, "Duplicate key '__proto__'.")
+    //.addError(3, "Duplicate key '__proto__'.")
     .test(src, { proto: true });
 
   src = [
@@ -1787,8 +1789,9 @@ exports.duplicateProto = function (test) {
     "};"
   ];
 
+  // TODO: Enable this expected warning in the next major release
   TestRun(test, "Duplicate keys (data and accessor)")
-    .addError(3, "Duplicate key '__proto__'.")
+    //.addError(3, "Duplicate key '__proto__'.")
     .test(src, { proto: true });
 
   src = [


### PR DESCRIPTION
Information about identifiers used are stored internally as properties
of objects whose key values are the identifier value. Because of
non-standard implementations of the `__proto__` property, input source
code that uses it as an identifier can have inconsistent side effects
across environments.

When using an object as a lookup table, the built-in
`Object.hasOwnProperty` is generally preferable for detecting property
membership. Unfortunately, due to the non-standard implementations
described above, this check has environment-specific results.

An alternate approach to membership detection is coercing direct
property references to a boolean value. This is not appropriate in cases
where the entries may themselves be "falsey" values, but in the
identifier lookup tables, entries are consistently object literals.

This second approach yields the same results across all legacy
environments and is also compatable with the standardized specification
for the `__proto__` attribute (provided the table is initialized to have
no prototype).

`var o = {};`

                                           | Compliant | Node.js v0.10.40 | IE9   | PhantomJS v1.9
------------------------------------------ | --------- | ---------------- | ----- | --------------
**Before `__proto__` assignment**          |           |                  |       |
!!o.__proto__                              | true      | true             | false | true
'__proto__' in o                           | true      | true             | false | true
Object.hasOwnProperty.call(o, '__proto__') | false     | false            | false | true
Object.keys(o).length                      | 0         | 0                | 0     | 0
**After `__proto__` assignment**           |           |                  |       |
!!o.__proto__                              | true      | true             | true  | true
'__proto__' in o                           | true      | true             | true  | true
Object.hasOwnProperty.call(o, '__proto__') | false     | false            | true  | true
Object.keys(o).length                      | 0         | 0                | 1     | 0

`var o = Object.create(null);`

                                           | Compliant | Node.js v0.10.40 | IE9   | PhantomJS v1.9
------------------------------------------ | --------- | ---------------- | ----- | --------------
**Before `__proto__` assignment**          |           |                  |       |
!!o.__proto__                              | false     | false            | false | false
'__proto__' in o                           | false     | true             | false | true
Object.hasOwnProperty.call(o, '__proto__') | false     | false            | false | true
Object.keys(o).length                      | 0         | 0                | 0     | 0
**After `__proto__` assignment**           |           |                  |       |
!!o.__proto__                              | true      | true             | true  | true
'__proto__' in o                           | true      | true             | true  | true
Object.hasOwnProperty.call(o, '__proto__') | true      | false            | true  | true
Object.keys(o).length                      | 1         | 0                | 1     | 0

Compliant enviroments: latest SpiderMonkey (and Firefox), latest V8 (and
Chrome), Node.js v0.12.7, Iojs v.2.3.4

Update all lookup tables to be created without a prototype, and update
all membership tests to simply coerce direct attribute references.