### PR TITLE
[[FIX]] Relax restriction on `module` option

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -199,13 +199,6 @@ var JSHINT = (function() {
 
     if (state.option.module) {
       /**
-       * TODO: Extend this restriction to *all* "environmental" options.
-       */
-      if (!hasParsedCode(state.funct)) {
-        error("E055", state.tokens.next, "module");
-      }
-
-      /**
        * TODO: Extend this restriction to *all* ES6-specific options.
        */
       if (!state.inESNext()) {
@@ -628,6 +621,15 @@ var JSHINT = (function() {
             error("E002", nt);
           }
           return;
+        }
+
+        if (key === "module") {
+          /**
+           * TODO: Extend this restriction to *all* "environmental" options.
+           */
+          if (!hasParsedCode(state.funct)) {
+            error("E055", state.tokens.next, "module");
+          }
         }
 
         var match = /^([+-])(W\d{3})$/g.exec(key);

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2930,5 +2930,13 @@ exports.module.declarationRestrictions = function( test ) {
       "/* jshint module: true */"
     ], { esnext: true });
 
+  TestRun(test, "Not re-applied with every directive (gh-2560)")
+    .test([
+      "/* jshint module:true */",
+      "function bar() {",
+      "  /* jshint validthis:true */",
+      "}"
+    ], { esnext: true });
+
   test.done();
 };


### PR DESCRIPTION
While the `module` option is intended to be set before executable code,
this restriction should only be enforced when it is first enabled (and
not with the application of every in-line directive).

Resolves gh-2560