### PR TITLE
[[FIX]] Revert regressions commit for __proto__

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4618,7 +4618,7 @@ var JSHINT = (function() {
       name = tkn.value;
     }
 
-    if (props[name] && name !== "__proto__") {
+    if (props[name]) {
       warning("W075", state.tokens.next, msg, name);
     } else {
       props[name] = Object.create(null);
@@ -4654,7 +4654,7 @@ var JSHINT = (function() {
     state.nameStack.set(tkn);
 
     if (props[name]) {
-      if ((props[name].basic || props[name][flagName]) && name !== "__proto__") {
+      if (props[name].basic || props[name][flagName]) {
         warning("W075", state.tokens.next, msg, name);
       }
     } else {

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -589,7 +589,7 @@ var scopeManager = function(state, predefined, exported, declared) {
         } else if (state.option.shadow !== true) {
           // now since we didn't get any block scope variables, test for var/function
           // shadowing
-          if (declaredInCurrentFunctionScope && labelName !== "__proto__") {
+          if (declaredInCurrentFunctionScope) {
 
             // see https://github.com/jshint/jshint/issues/2400
             if (!_currentFunct["(global)"]) {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1778,9 +1778,8 @@ exports.duplicateProto = function (test) {
     "}());"
   ];
 
-  // TODO: Enable this expected warning in the next major release
   TestRun(test, "Duplicate `var`s")
-    //.addError(3, "'__proto__' is already defined.")
+    .addError(3, "'__proto__' is already defined.")
     .test(src, { proto: true });
 
   src = [
@@ -1812,9 +1811,8 @@ exports.duplicateProto = function (test) {
     "};"
   ];
 
-  // TODO: Enable this expected warning in the next major release
   TestRun(test, "Duplicate keys (data)")
-    //.addError(3, "Duplicate key '__proto__'.")
+    .addError(3, "Duplicate key '__proto__'.")
     .test(src, { proto: true });
 
   src = [
@@ -1824,9 +1822,8 @@ exports.duplicateProto = function (test) {
     "};"
   ];
 
-  // TODO: Enable this expected warning in the next major release
   TestRun(test, "Duplicate keys (data and accessor)")
-    //.addError(3, "Duplicate key '__proto__'.")
+    .addError(3, "Duplicate key '__proto__'.")
     .test(src, { proto: true });
 
   src = [


### PR DESCRIPTION
So that jshint now warns on __proto__ as other variables.

So its not forgotten. See #2559