### PR TITLE
[[FIX]] Make `strict: func` have precedence over env options.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -198,6 +198,9 @@ var JSHINT = (function() {
     }
 
     if (state.option.module) {
+      if (state.option.strict === true) {
+        state.option.strict = "global";
+      }
       /**
        * TODO: Extend this restriction to *all* ES6-specific options.
        */
@@ -228,6 +231,9 @@ var JSHINT = (function() {
 
     if (state.option.phantom) {
       combine(predefined, vars.phantom);
+      if (state.option.strict === true) {
+        state.option.strict = "global";
+      }
     }
 
     if (state.option.prototypejs) {
@@ -237,6 +243,9 @@ var JSHINT = (function() {
     if (state.option.node) {
       combine(predefined, vars.node);
       combine(predefined, vars.typed);
+      if (state.option.strict === true) {
+        state.option.strict = "global";
+      }
     }
 
     if (state.option.devel) {
@@ -256,6 +265,9 @@ var JSHINT = (function() {
       combine(predefined, vars.browser);
       combine(predefined, vars.typed);
       combine(predefined, vars.browserify);
+      if (state.option.strict === true) {
+        state.option.strict = "global";
+      }
     }
 
     if (state.option.nonstandard) {
@@ -607,12 +619,12 @@ var JSHINT = (function() {
         if (key === "strict") {
           switch (val) {
           case "true":
-          case "func":
             state.option.strict = true;
             break;
           case "false":
             state.option.strict = false;
             break;
+          case "func":
           case "global":
           case "implied":
             state.option.strict = val;
@@ -5143,10 +5155,7 @@ var JSHINT = (function() {
 
         if (state.directive["use strict"]) {
           if (state.option.strict !== "global") {
-            if (!(state.option.module || state.option.node || state.option.phantom ||
-              state.option.browserify)) {
-              warning("W097", state.tokens.prev);
-            }
+            warning("W097", state.tokens.prev);
           }
         }
 

--- a/src/options.js
+++ b/src/options.js
@@ -881,7 +881,9 @@ exports.val = {
    * - "global"  - there must be a `"use strict";` directive at global level
    * - "implied" - lint the code as if there is the `"use strict";` directive
    * - false     - disable warnings about strict mode
-   * - true      - same as `"func"`
+   * - true      - same as `"func"`, but environment options have precedence over
+   *               this (e.g. `node`, `module`, `browserify` and `phantomjs` can
+   *               set `strict: global`)
    */
   strict      : true,
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1579,16 +1579,21 @@ exports.strict = function (test) {
   run.addError(1, 'Unnecessary directive "use strict".')
     .test(code3, { strict: "implied" });
 
-  [ true, false, "global", "implied" ].forEach(function(val) {
+  [ true, false, "global", "func", "implied" ].forEach(function(val) {
     JSHINT("/*jshint strict: " + val + " */");
     test.strictEqual(JSHINT.data().options.strict, val);
   });
-  JSHINT("/*jshint strict: func */");
-  test.strictEqual(JSHINT.data().options.strict, true);
 
   TestRun(test)
     .addError(1, "Bad option value.")
     .test("/*jshint strict: foo */");
+
+  TestRun(test, "environments have precedence over 'strict: true'")
+    .test(code3, { strict: true, node: true });
+
+  TestRun(test, "environments don't have precedence over 'strict: func'")
+    .addError(1, 'Use the function form of "use strict".')
+    .test(code3, { strict: "func", node: true });
 
   test.done();
 };


### PR DESCRIPTION
>Now it is possible to ovverride node, phantom, module and browserify's `strict: global` using
`strict: func`, so that JSHint warns if `"use strict";` isn't in a function.
Example:
```js
/* jshint node: true, strict: func */
"use strict"; // Warning: Use the function form of "use strict".
```

>Env options still have precedence over `strict: true`.