### PR TITLE
[[FIX]] Dont crash when testing x == keyword if eqnull is on

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2031,7 +2031,8 @@ var JSHINT = (function() {
   bitwise("^", "bitxor", 80);
   bitwise("&", "bitand", 90);
   relation("==", function(left, right) {
-    var eqnull = state.option.eqnull && (left.value === "null" || right.value === "null");
+    var eqnull = state.option.eqnull &&
+      ((left && left.value) === "null" || (right && right.value) === "null");
 
     switch (true) {
       case !eqnull && state.option.eqeqeq:
@@ -2064,7 +2065,7 @@ var JSHINT = (function() {
   });
   relation("!=", function(left, right) {
     var eqnull = state.option.eqnull &&
-        (left.value === "null" || right.value === "null");
+        ((left && left.value) === "null" || (right && right.value) === "null");
 
     if (!eqnull && state.option.eqeqeq) {
       this.from = this.character;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -926,36 +926,79 @@ exports.comma = function (test) {
 
 exports["gh-2587"] = function (test) {
 
-  var ops = ["==", "!="];
-  var options = [{}, {eqeqeq: true}, {eqnull: true}, {eqeqeq: true, eqnull: true}];
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .addError(1, "Expected '===' and instead saw '=='.")
+    .test([
+    "true == if"
+  ], {eqeqeq: true, eqnull: true});
 
-  ops.forEach(function(op) {
-    options.forEach(function(option) {
-      var testRun = TestRun(test)
-        .addError(1, "Expected an identifier and instead saw 'if'.")
-        .addError(1, "Unrecoverable syntax error. (100% scanned).");
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .addError(1, "Expected '!==' and instead saw '!='.")
+    .test([
+    "true != if"
+  ], {eqeqeq: true, eqnull: true});
 
-      if (option.eqeqeq) {
-        testRun.addError(1, "Expected '" + op + "=' and instead saw '" + op + "'.");
-      } else {
-        testRun.addError(1, "Use '" + op + "=' to compare with 'true'.");
-      }
-      testRun.test([
-          "true " + op + " if"
-        ], option);
-    });
-  });
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .addError(1, "Use '===' to compare with 'true'.")
+    .test([
+    "true == if"
+  ], {});
 
-  var otherOps = ["===", "!==", ">", "<", ">=", "<="];
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .addError(1, "Use '!==' to compare with 'true'.")
+    .test([
+    "true != if"
+  ], {});
 
-  otherOps.forEach(function(op) {
-    TestRun(test)
-      .addError(1, "Expected an identifier and instead saw 'if'.")
-      .addError(1, "Unrecoverable syntax error. (100% scanned).")
-      .test([
-        "true " + op + " if"
-      ], {});
-  });
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test([
+    "true === if"
+  ], {});
+
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test([
+    "true !== if"
+  ], {});
+
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test([
+    "true > if"
+  ], {});
+
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test([
+    "true < if"
+  ], {});
+
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test([
+    "true >= if"
+  ], {});
+
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'if'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test([
+    "true <= if"
+  ], {});
 
   test.done();
 };

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -924,6 +924,42 @@ exports.comma = function (test) {
   test.done();
 };
 
+exports["gh-2587"] = function (test) {
+
+  var ops = ["==", "!="];
+  var options = [{}, {eqeqeq: true}, {eqnull: true}, {eqeqeq: true, eqnull: true}];
+
+  ops.forEach(function(op) {
+    options.forEach(function(option) {
+      var testRun = TestRun(test)
+        .addError(1, "Expected an identifier and instead saw 'if'.")
+        .addError(1, "Unrecoverable syntax error. (100% scanned).");
+
+      if (option.eqeqeq) {
+        testRun.addError(1, "Expected '" + op + "=' and instead saw '" + op + "'.");
+      } else {
+        testRun.addError(1, "Use '" + op + "=' to compare with 'true'.");
+      }
+      testRun.test([
+          "true " + op + " if"
+        ], option);
+    });
+  });
+
+  var otherOps = ["===", "!==", ">", "<", ">=", "<="];
+
+  otherOps.forEach(function(op) {
+    TestRun(test)
+      .addError(1, "Expected an identifier and instead saw 'if'.")
+      .addError(1, "Unrecoverable syntax error. (100% scanned).")
+      .test([
+        "true " + op + " if"
+      ], {});
+  });
+
+  test.done();
+};
+
 exports.withStatement = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/with.js", "utf8");
   var run;


### PR DESCRIPTION
If eqnull was on jshint previously crashed if the right hand side of an
assignment was not an expression.
Fixes #2587