### PR TITLE
[[CHORE]]: bump conventional-changelog and conventional-github-releaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@
 * Support generators in class body ([ee348c3](https://github.com/jshint/jshint/commit/ee348c3))
 
 
+### BREAKING CHANGES
+
+* In projects which do not enable ES3 mode, it is now an error by default to use elision array elements,
+also known as empty array elements (such as `[1, , 3, , 5]`)
+
+
 
 <a name="2.5.11"></a>
 ## [2.5.11](https://github.com/jshint/jshint/compare/2.5.10...2.5.11) (2014-12-18)

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
 
   "devDependencies": {
     "browserify":                     "9.x",
-    "conventional-changelog":         "0.3.x",
-    "conventional-github-releaser":   "0.3.x",
+    "conventional-changelog":         "0.4.x",
+    "conventional-github-releaser":   "0.4.x",
     "coveralls":                      "2.11.x",
     "istanbul":                       "0.3.x",
     "jscs":                           "1.11.x",


### PR DESCRIPTION
The footer can contain breaking changes. These updated tools fix this.