### PR TITLE
[[FIX]] Warn about using `var` inside `for (...)` when `varstmt: true`

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3608,7 +3608,7 @@ var JSHINT = (function() {
         lone = true;
       }
 
-      if (!prefix && report && state.option.varstmt) {
+      if (!(prefix && implied) && report && state.option.varstmt) {
         warning("W132", this);
       }
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2969,7 +2969,8 @@ exports.varstmt = function (test) {
     "var fn = function() {",
     "  var x;",
     "  var y = 5;",
-    "};"
+    "};",
+    "for (var a in x);"
   ];
 
   TestRun(test)
@@ -2978,6 +2979,7 @@ exports.varstmt = function (test) {
     .addError(3, "`var` declarations are forbidden. Use `let` or `const` instead.")
     .addError(4, "`var` declarations are forbidden. Use `let` or `const` instead.")
     .addError(5, "`var` declarations are forbidden. Use `let` or `const` instead.")
+    .addError(7, "`var` declarations are forbidden. Use `let` or `const` instead.")
     .test(code, { varstmt: true });
 
   test.done();


### PR DESCRIPTION
Fixes #2627