### PR TITLE
[[FIX]] Throw W119 instead of "Unexpected '`'" when using templates in ES5 mode

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -1056,10 +1056,15 @@ Lexer.prototype = {
     var startChar = this.char;
     var depth = this.templateStarts.length;
 
-    if (!state.inES6(true)) {
-      // Only lex template strings in ESNext mode.
-      return null;
-    } else if (this.peek() === "`") {
+    if (this.peek() === "`") {
+      if (!state.inES6(true)) {
+        this.trigger("warning", {
+          code: "W119",
+          line: this.line,
+          character: this.char,
+          data: ["template literal syntax", "6"]
+        });
+      }
       // Template must start with a backtick.
       tokenType = Token.TemplateHead;
       this.templateStarts.push({ line: this.line, char: this.char });

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1826,9 +1826,7 @@ exports.quotesAndTemplateLiterals = function (test) {
 
   // Without esnext
   TestRun(test)
-    .addError(2, "Unexpected '`'.")
-    .addError(2, "Unexpected early end of program.")
-    .addError(2, "Unrecoverable syntax error. (100% scanned).")
+    .addError(2, "'template literal syntax' is only available in ES6 (use 'esversion: 6').")
     .test(src);
 
   // With esnext


### PR DESCRIPTION
Commit message:
> Previously, linting this code:
```
var a = ``;
```
JSHint threw three errors:
- Unexpected '`'
- Unexpected early end of program
- Unrecoverable syntax error.

> Now it throws "'template literal syntax' is only available in ES6 (use 'esversion: 6')."

So JSHint doesn't stop if it encounters a template literal and esversion is less than 6