### PR TITLE
[[FIX]] Allow latedef in the initialiser of variable

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3521,25 +3521,6 @@ var JSHINT = (function() {
         warning("E012", state.tokens.curr, state.tokens.curr.value);
       }
 
-      // absorb the assignment before processing the label so that use of the label
-      // can be detected as before declaration
-      if (state.tokens.next.id === "=") {
-        advance("=");
-        if (!prefix && state.tokens.next.id === "undefined") {
-          warning("W080", state.tokens.prev, state.tokens.prev.value);
-        }
-        if (!prefix && peek(0).id === "=" && state.tokens.next.identifier) {
-          warning("W120", state.tokens.next, state.tokens.next.value);
-        }
-        // don't accept `in` in expression if prefix is used for ForIn/Of loop.
-        value = expression(prefix ? 120 : 10);
-        if (lone) {
-          tokens[0].first = value;
-        } else {
-          destructuringPatternMatch(names, value);
-        }
-      }
-
       for (var t in tokens) {
         if (tokens.hasOwnProperty(t)) {
           t = tokens[t];
@@ -3558,6 +3539,25 @@ var JSHINT = (function() {
               state.funct["(scope)"].setExported(t.token.value, t.token);
             }
           }
+        }
+      }
+
+      // absorb the assignment before processing the label so that use of the label
+      // can be detected as before declaration
+      if (state.tokens.next.id === "=") {
+        advance("=");
+        if (!prefix && state.tokens.next.id === "undefined") {
+          warning("W080", state.tokens.prev, state.tokens.prev.value);
+        }
+        if (!prefix && peek(0).id === "=" && state.tokens.next.identifier) {
+          warning("W120", state.tokens.next, state.tokens.next.value);
+        }
+        // don't accept `in` in expression if prefix is used for ForIn/Of loop.
+        value = expression(prefix ? 120 : 10);
+        if (lone) {
+          tokens[0].first = value;
+        } else {
+          destructuringPatternMatch(names, value);
         }
       }
 
@@ -3614,32 +3614,6 @@ var JSHINT = (function() {
 
       this.first = this.first.concat(names);
 
-      // absorb the assignment before processing the label so that use of the label
-      // can be detected as before declaration
-      if (state.tokens.next.id === "=") {
-        state.nameStack.set(state.tokens.curr);
-
-        advance("=");
-        if (!prefix && report && !state.funct["(loopage)"] &&
-          state.tokens.next.id === "undefined") {
-          warning("W080", state.tokens.prev, state.tokens.prev.value);
-        }
-        if (peek(0).id === "=" && state.tokens.next.identifier) {
-          if (!prefix && report &&
-              !state.funct["(params)"] ||
-              state.funct["(params)"].indexOf(state.tokens.next.value) === -1) {
-            warning("W120", state.tokens.next, state.tokens.next.value);
-          }
-        }
-        // don't accept `in` in expression if prefix is used for ForIn/Of loop.
-        value = expression(prefix ? 120 : 10);
-        if (lone) {
-          tokens[0].first = value;
-        } else {
-          destructuringPatternMatch(names, value);
-        }
-      }
-
       for (var t in tokens) {
         if (tokens.hasOwnProperty(t)) {
           t = tokens[t];
@@ -3671,6 +3645,32 @@ var JSHINT = (function() {
             }
             names.push(t.token);
           }
+        }
+      }
+
+      // absorb the assignment before processing the label so that use of the label
+      // can be detected as before declaration
+      if (state.tokens.next.id === "=") {
+        state.nameStack.set(state.tokens.curr);
+
+        advance("=");
+        if (!prefix && report && !state.funct["(loopage)"] &&
+          state.tokens.next.id === "undefined") {
+          warning("W080", state.tokens.prev, state.tokens.prev.value);
+        }
+        if (peek(0).id === "=" && state.tokens.next.identifier) {
+          if (!prefix && report &&
+              !state.funct["(params)"] ||
+              state.funct["(params)"].indexOf(state.tokens.next.value) === -1) {
+            warning("W120", state.tokens.next, state.tokens.next.value);
+          }
+        }
+        // don't accept `in` in expression if prefix is used for ForIn/Of loop.
+        value = expression(prefix ? 120 : 10);
+        if (lone) {
+          tokens[0].first = value;
+        } else {
+          destructuringPatternMatch(names, value);
         }
       }
 

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -747,15 +747,16 @@ var scopeManager = function(state, predefined, exported, declared) {
       use: function(labelName, token) {
 
         // if resolves to current function params, then do not store usage just resolve
-        // this is because function(a) { var a = a; } will resolve to the param, not
+        // this is because function(a) { var a; a = a; } will resolve to the param, not
         // to the unset var
         // first check the param is used
         var paramScope = _currentFunctBody["(parent)"];
         if (paramScope && paramScope["(labels)"][labelName] &&
           paramScope["(labels)"][labelName]["(type)"] === "param") {
 
-          // then check its not used
-          if (!scopeManagerInst.funct.has(labelName, { excludeParams: true })) {
+          // then check its not declared by a block scope variable
+          if (!scopeManagerInst.funct.has(labelName,
+                { excludeParams: true, onlyBlockscoped: true })) {
             paramScope["(labels)"][labelName]["(unused)"] = false;
           }
         }

--- a/tests/unit/fixtures/latedef-esnext.js
+++ b/tests/unit/fixtures/latedef-esnext.js
@@ -53,3 +53,10 @@ function cg() {
     cj();
 }
 cg();
+let da = () => da;
+const db = () => db;
+let dc = {
+    dd() {
+        return dc;
+    }
+};

--- a/tests/unit/fixtures/latedef.js
+++ b/tests/unit/fixtures/latedef.js
@@ -19,3 +19,12 @@ function foo() {
     return 10;
   }
 }
+var a = function() {
+  return a;
+};
+var b = b;
+var c = {
+  d: function() {
+    return d;
+  }
+};

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -736,11 +736,18 @@ exports.undef = function (test) {
 
   // block scope cannot use themselves in the declaration
   TestRun(test)
-    .addError(1, "'a' was used before it was declared, which is illegal for 'let' variables.")
-    .addError(2, "'b' was used before it was declared, which is illegal for 'const' variables.")
+//    .addError(1, "'a' was used before it was declared, which is illegal for 'let' variables.")
+//    .addError(2, "'b' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(5, "'e' is already defined.")
     .test([
       'let a = a;',
-      'const b = b;'
+      'const b = b;',
+      'var c = c;',
+      'function f(e) {',
+      '  var e;',         // the var does not overwrite the param, the param is used
+      '  e = e || 2;',
+      '  return e;',
+      '}'
     ], { esnext: true, undef: true });
 
   // Regression test for GH-668.


### PR DESCRIPTION
Fixes #2628

@jugglinmike as always it wasn't as simple as it seemed as I discovered another minor bug. in master its

```
function(a) {
var a;
return a;
}
```
reports the parameter as unused, when in fact it is used (its not masked by the unnecessary `var a`. I had fixed it for case `function(a) { var a = a; }` but not the above. This now fixes it better. note block scoped vars `function(a) { var b = a; let a;}` will still mark the param as used, but thats okay because its an error to declare block scoped vars with the same name as the parameter.

I started trying to fix `let a = a;` but its probably involved - my start is here - https://github.com/lukeapage/jshint/commit/2b3c5792e0a32167c3c01a12238cdc7e6e01b1f3 I may or may not get time to work on it for a long time.

Feel free to alter this patch as much as you like, you have my permission to use as you wish and get the release out. feel free to finish off my wip if you feel like it.