### PR TITLE
[[DOCS]] Link to inline configuration from globals option

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -776,6 +776,9 @@ exports.val = {
    * See also the "environment" options: a set of options to be used as short
    * hand for enabling global variables defined in common JavaScript
    * environments.
+   *
+   * To configure `globals` within an individual file, see [Inline
+   * Configuration](http://jshint.com/docs/#inline-configuration).
    */
   globals      : false,
 


### PR DESCRIPTION
For users reading the JSHint Options documentation, there is no indication on this page about how to use globals as inline configuration.

It's easy and explained clearly if you arrived at the documentation on main Docs page, but not if you arrived at Options first (eg a search for "jshint options").  Hence, a simple link to direct people to that section of the Docs page.