### PR TITLE
[[FIX]] Allow binary and octal numbers, and templates when using inline esnext

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -791,7 +791,7 @@ Lexer.prototype = {
           isAllowedDigit = isOctalDigit;
           base = 8;
 
-          if (!state.option.esnext) {
+          if (!state.inES6(true)) {
             this.trigger("warning", {
               code: "W119",
               line: this.line,
@@ -809,7 +809,7 @@ Lexer.prototype = {
           isAllowedDigit = isBinaryDigit;
           base = 2;
 
-          if (!state.option.esnext) {
+          if (!state.inES6(true)) {
             this.trigger("warning", {
               code: "W119",
               line: this.line,
@@ -1056,7 +1056,7 @@ Lexer.prototype = {
     var startChar = this.char;
     var depth = this.templateStarts.length;
 
-    if (!state.option.esnext) {
+    if (!state.inES6(true)) {
       // Only lex template strings in ESNext mode.
       return null;
     } else if (this.peek() === "`") {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1187,10 +1187,12 @@ exports.testES6ModulesNameSpaceImportsAffectUnused = function (test) {
 
 exports.testES6TemplateLiterals = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/es6-template-literal.js", "utf8");
-  TestRun(test)
+  var run = TestRun(test)
     .addError(14, "Octal literals are not allowed in strict mode.")
-    .addError(21, "Unclosed template literal.")
-    .test(src, { esnext: true });
+    .addError(21, "Unclosed template literal.");
+  run.test(src, { esnext: true });
+  run.test("/* jshint esnext: true */" + src);
+
   test.done();
 };
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -427,6 +427,12 @@ exports.numbers = function (test) {
       "var f = 0b1012;",
     ], {esnext: true});
 
+  TestRun(test)
+    .test([
+      "// jshint esnext: true",
+      "var a = 0b0 + 0o0;"
+    ]);
+
   test.done();
 };
 


### PR DESCRIPTION
This commit fixes a regression introduced in gh-2519