### PR TITLE
[[FIX]] Correct exported AssignmentExpressions

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4600,11 +4600,13 @@ var JSHINT = (function() {
 
       identifier = token.value;
 
-      state.funct["(scope)"].addlabel(identifier, {
-        type: exportType,
-        token: token });
+      if (this.block) {
+        state.funct["(scope)"].addlabel(identifier, {
+          type: exportType,
+          token: token });
 
-      state.funct["(scope)"].setExported(identifier, token);
+        state.funct["(scope)"].setExported(identifier, token);
+      }
 
       return this;
     }

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1170,6 +1170,20 @@ exports.testES6ModulesDefaultExportsAffectUnused = function (test) {
   test.done();
 };
 
+exports.testES6ModulesDefaultExportAssignmentExpr = function (test) {
+  // The identifier in the exported AssignmentExpression should not be
+  // interpreted as a declaration.
+  var src = [
+    "let x = 1;",
+    "export default -x;"
+  ];
+
+  TestRun(test)
+    .test(src, { unused: true, esnext: true });
+
+  test.done();
+};
+
 exports.testES6ModulesNameSpaceImportsAffectUnused = function (test) {
   var src = [
     "import * as angular from 'angular';"


### PR DESCRIPTION
When an AssignmentExpression appears following the `default` keyword in
an ExportDeclaration, do not interpret it as a declaration.

Resolves gh-2647