### PR TITLE
[[FIX]] Enforce Identifier restrictions lazily

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -1782,14 +1782,14 @@ Lexer.prototype = {
         return create("(no subst template)", token.value, null, token);
 
       case Token.Identifier:
-        this.trigger("Identifier", {
+        this.triggerAsync("Identifier", {
           line: this.line,
           char: this.char,
           from: this.form,
           name: token.value,
           raw_name: token.text,
           isProperty: state.tokens.curr.id === "."
-        });
+        }, checks, function() { return true; });
 
         /* falls through */
       case Token.Keyword:

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7216,3 +7216,39 @@ exports["new.target"] = function (test) {
 
   test.done();
 };
+
+// gh2656: "[Regression] 2.9.0 warns about proto deprecated even if proto:true"
+exports.lazyIdentifierChecks = function (test) {
+  var src = [
+    "var o = [",
+    "  function() {",
+    "    // jshint proto: true",
+    "    o.__proto__ = null;",
+    "  }",
+    "];",
+    "o.__proto__ = null;"
+  ];
+
+  TestRun(test)
+    .addError(7, "The '__proto__' property is deprecated.")
+    .test(src);
+
+  src = [
+    "var o = {",
+    "  p: function() {",
+    "    // jshint proto: true, iterator: true",
+    "    o.__proto__ = null;",
+    "    o.__iterator__ = null;",
+    "  }",
+    "};",
+    "o.__proto__ = null;",
+    "o.__iterator__ = null;"
+  ];
+
+  TestRun(test)
+    .addError(8, "The '__proto__' property is deprecated.")
+    .addError(9, "The '__iterator__' property is deprecated.")
+    .test(src);
+
+  test.done();
+};


### PR DESCRIPTION
Because the lexer may create tokens before in-line linting directives
are applied (e.g. during invocation of the `peek` function), contextual
restrictions cannot be applied at the time of tokenization.

Defer application of Identifier restrictions until in-line linting
directives have been applied.

Resolves gh-2656