### PR TITLE
[[FIX]] Don't warn that an exported function is used before it is defined

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3856,15 +3856,15 @@ var JSHINT = (function() {
     }
     var i = optionalidentifier();
 
+    state.funct["(scope)"].addlabel(i, {
+      type: "function",
+      token: state.tokens.curr });
+
     if (i === undefined) {
       warning("W025");
     } else if (inexport) {
       state.funct["(scope)"].setExported(i, state.tokens.prev);
     }
-
-    state.funct["(scope)"].addlabel(i, {
-      type: "function",
-      token: state.tokens.curr });
 
     doFunction({
       name: i,

--- a/tests/unit/fixtures/latedef-esnext.js
+++ b/tests/unit/fixtures/latedef-esnext.js
@@ -65,3 +65,4 @@ export function de() {}
 export class df {}
 export var dg;
 export let dh;
+export const di = {};

--- a/tests/unit/fixtures/latedef-esnext.js
+++ b/tests/unit/fixtures/latedef-esnext.js
@@ -60,3 +60,8 @@ let dc = {
         return dc;
     }
 };
+
+export function de() {}
+export class df {}
+export var dg;
+export let dh;

--- a/tests/unit/fixtures/latedef-esnext.js
+++ b/tests/unit/fixtures/latedef-esnext.js
@@ -61,6 +61,7 @@ let dc = {
     }
 };
 
+// Regression test for gh-2658
 export function de() {}
 export class df {}
 export var dg;


### PR DESCRIPTION
Fixes #2658