### PR TITLE
[[FIX]] `latedef` shouldn't warn when marking a var as exported

### DIFF
--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -65,16 +65,6 @@ var scopeManager = function(state, predefined, exported, declared) {
     }
   }
 
-  function _addUsage(labelName, token) {
-
-    _setupUsages(labelName);
-
-    if (token) {
-      token["(function)"] = _currentFunctBody;
-      _current["(usages)"][labelName]["(tokens)"].push(token);
-    }
-  }
-
   var _getUnusedOption = function(unused_opt) {
     if (unused_opt === undefined) {
       unused_opt = state.option.unused;
@@ -772,7 +762,12 @@ var scopeManager = function(state, predefined, exported, declared) {
           token.ignoreUndef = true;
         }
 
-        _addUsage(labelName, token);
+        _setupUsages(labelName);
+
+        if (token) {
+          token["(function)"] = _currentFunctBody;
+          _current["(usages)"][labelName]["(tokens)"].push(token);
+        }
       },
 
       reassign: function(labelName, token) {

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -565,6 +565,19 @@ var scopeManager = function(state, predefined, exported, declared) {
       } else if (_.has(globalLabels, labelName)) {
         globalLabels[labelName]["(unused)"] = false;
       } else {
+        for (var i = 1; i < _scopeStack.length; i++) {
+          var scope = _scopeStack[i];
+          // if `scope.(type)` is not defined, it is a block scope
+          if (!scope["(type)"]) {
+            if (_.has(scope["(labels)"], labelName) &&
+                !scope["(labels)"][labelName]["(blockscoped)"]) {
+              scope["(labels)"][labelName]["(unused)"] = false;
+              return;
+            }
+          } else {
+            break;
+          }
+        }
         exported[labelName] = true;
       }
     },

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -568,11 +568,12 @@ var scopeManager = function(state, predefined, exported, declared) {
      * for the exported options, indicating a variable is used outside the file
      */
     addExported: function(labelName) {
+      var globalLabels = _scopeStack[0]["(labels)"];
       if (_.has(declared, labelName)) {
         // remove the declared token, so we know it is used
         delete declared[labelName];
-      } else if (_current["(type)"] === "global" && _.has(_current["(labels)"], labelName)) {
-        _current["(labels)"][labelName]["(unused)"] = false;
+      } else if (_.has(globalLabels, labelName)) {
+        globalLabels[labelName]["(unused)"] = false;
       } else {
         exported[labelName] = true;
       }

--- a/tests/unit/fixtures/exported.js
+++ b/tests/unit/fixtures/exported.js
@@ -16,3 +16,14 @@ var unusedExpression = function () {};
 (function () {
   function cannotBeExported() {}
 }());
+
+var a, b;
+if (true) {
+  /* exported a */
+}
+if (true) {
+  for(var i = 0; i < 1; i++) {
+    // dont peek
+  }
+  /* exported b */
+}

--- a/tests/unit/fixtures/exported.js
+++ b/tests/unit/fixtures/exported.js
@@ -27,3 +27,8 @@ if (true) {
   }
   /* exported b */
 }
+
+if (true) {
+  var c;
+}
+/* exported c */

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -259,6 +259,9 @@ exports.latedef = function (test) {
       .addError(48, "'ci' was used before it was defined.")
       .test(esnextSrc, {esnext: true, latedef: true});
 
+  TestRun(test, "shouldn't warn when marking a var as exported")
+    .test("var a;", { exported: ["a"], latedef: true });
+
   test.done();
 };
 
@@ -271,6 +274,9 @@ exports.latedefInline = function (test) {
     .addError(22, "'a' was used before it was defined.")
     .addError(26, "Bad option value.")
     .test(src);
+
+  TestRun(test, "shouldn't warn when marking a var as exported")
+    .test("/*exported a*/var a;", { latedef: true });
 
   test.done();
 };

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -1129,6 +1129,9 @@ exports.exported = function (test) {
     .addError(1, "'unused' is defined but never used.")
     .test("var unused = 1; var used = 2;", {exported: ["used"], unused: true});
 
+  TestRun(test, "exported vars aren't used before definition")
+    .test("var a;", {exported:["a"], latedef: true});
+
   test.done();
 };
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -1124,8 +1124,9 @@ exports.exported = function (test) {
   run.test(src, {unused: true }); // es5
   run.test(src, {esnext: true, unused: true });
   run.test(src, {moz: true, unused: true });
+  run.test(src, {unused: true, latedef: true});
 
-  run = TestRun(test)
+  TestRun(test)
     .addError(1, "'unused' is defined but never used.")
     .test("var unused = 1; var used = 2;", {exported: ["used"], unused: true});
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -1133,6 +1133,27 @@ exports.exported = function (test) {
   TestRun(test, "exported vars aren't used before definition")
     .test("var a;", {exported:["a"], latedef: true});
 
+  var code = [
+    "/* exported a, b */",
+    "if (true) {",
+    "  /* exported c, d */",
+    "  let a, c, e, g;",
+    "  const [b, d, f, h] = [];",
+    "  /* exported e, f */",
+    "}",
+    "/* exported g, h */"
+  ];
+  TestRun(test, "blockscoped variables")
+    .addError(4, "'a' is defined but never used.")
+    .addError(4, "'c' is defined but never used.")
+    .addError(4, "'e' is defined but never used.")
+    .addError(4, "'g' is defined but never used.")
+    .addError(5, "'b' is defined but never used.")
+    .addError(5, "'d' is defined but never used.")
+    .addError(5, "'f' is defined but never used.")
+    .addError(5, "'h' is defined but never used.")
+    .test(code, {esversion: 6, unused: true});
+
   test.done();
 };
 


### PR DESCRIPTION
Fixes #2662