### PR TITLE
Replace ampersand with "and"

### DIFF
--- a/examples/.jshintrc
+++ b/examples/.jshintrc
@@ -19,7 +19,7 @@
     "noempty"       : true,     // true: Prohibit use of empty blocks
     "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
     "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
-    "plusplus"      : false,    // true: Prohibit use of `++` & `--`
+    "plusplus"      : false,    // true: Prohibit use of `++` and `--`
     "quotmark"      : false,    // Quotation mark consistency:
                                 //   false    : do nothing (default)
                                 //   true     : ensure whatever is used is consistent


### PR DESCRIPTION
For increased consistency within the example, and to remove any
possible confusion with the bitwise AND operator, spell out "and"
instead of "&".