### PR TITLE
[[FIX]] Add `File` to browser global variables

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -84,6 +84,8 @@ exports.browser = {
   Event                : false,
   event                : false,
   fetch                : false,
+  File                 : false,
+  FileList             : false,
   FileReader           : false,
   FormData             : false,
   focus                : false,


### PR DESCRIPTION
File was left out of browser global variables

Fixes #2690