### PR TITLE
[[FIX]] Don't throw W080 when the initializer starts with `undefined`

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3441,6 +3441,8 @@ var JSHINT = (function() {
         }
       }
     };
+
+    var id, value;
     if (checkPunctuator(firstToken, "[")) {
       if (!openingParsed) {
         advance("[");
@@ -3461,10 +3463,11 @@ var JSHINT = (function() {
           } else {
             advance("=");
           }
-          if (state.tokens.next.id === "undefined") {
-            warning("W080", state.tokens.prev, state.tokens.prev.value);
+          id = state.tokens.prev;
+          value = expression(10);
+          if (value && value.type === "undefined") {
+            warning("W080", id, id.value);
           }
-          expression(10);
         }
         if (!checkPunctuator(state.tokens.next, "]")) {
           advance(",");
@@ -3483,10 +3486,11 @@ var JSHINT = (function() {
         assignmentProperty();
         if (checkPunctuator(state.tokens.next, "=")) {
           advance("=");
-          if (state.tokens.next.id === "undefined") {
-            warning("W080", state.tokens.prev, state.tokens.prev.value);
+          id = state.tokens.prev;
+          value = expression(10);
+          if (value && value.type === "undefined") {
+            warning("W080", id, id.value);
           }
-          expression(10);
         }
         if (!checkPunctuator(state.tokens.next, "}")) {
           advance(",");
@@ -3581,14 +3585,15 @@ var JSHINT = (function() {
 
       if (state.tokens.next.id === "=") {
         advance("=");
-        if (!prefix && state.tokens.next.id === "undefined") {
-          warning("W080", state.tokens.prev, state.tokens.prev.value);
-        }
         if (!prefix && peek(0).id === "=" && state.tokens.next.identifier) {
           warning("W120", state.tokens.next, state.tokens.next.value);
         }
+        var id = state.tokens.prev;
         // don't accept `in` in expression if prefix is used for ForIn/Of loop.
         value = expression(prefix ? 120 : 10);
+        if (!prefix && value && value.type === "undefined") {
+          warning("W080", id, id.value);
+        }
         if (lone) {
           tokens[0].first = value;
         } else {
@@ -3687,10 +3692,6 @@ var JSHINT = (function() {
         state.nameStack.set(state.tokens.curr);
 
         advance("=");
-        if (!prefix && report && !state.funct["(loopage)"] &&
-          state.tokens.next.id === "undefined") {
-          warning("W080", state.tokens.prev, state.tokens.prev.value);
-        }
         if (peek(0).id === "=" && state.tokens.next.identifier) {
           if (!prefix && report &&
               !state.funct["(params)"] ||
@@ -3698,8 +3699,12 @@ var JSHINT = (function() {
             warning("W120", state.tokens.next, state.tokens.next.value);
           }
         }
+        var id = state.tokens.prev;
         // don't accept `in` in expression if prefix is used for ForIn/Of loop.
         value = expression(prefix ? 120 : 10);
+        if (value && !prefix && report && !state.funct["(loopage)"] && value.type === "undefined") {
+          warning("W080", id, id.value);
+        }
         if (lone) {
           tokens[0].first = value;
         } else {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -775,6 +775,10 @@ exports.testUndefinedAssignment = function (test) {
     "var l = undefined === 0;",
     "const m = undefined === 0;",
     "let n = undefined === 0;",
+    "let [ o = undefined === 0 ] = [];",
+    "[ o = undefined === 0] = [];",
+    "let { p = undefined === 0, x: q = undefined === 0 } = {};",
+    "({ p = undefined === 0, x: q = undefined === 0 } = {});"
   ];
 
   TestRun(test)

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -771,6 +771,10 @@ exports.testUndefinedAssignment = function (test) {
     "var i = undefined;",
     "const j = undefined;",
     "let k = undefined;",
+    "// jshint +W080",
+    "var l = undefined === 0;",
+    "const m = undefined === 0;",
+    "let n = undefined === 0;",
   ];
 
   TestRun(test)


### PR DESCRIPTION
> Example:
   ```js
var a = undefined === 0; // a is 'false', not 'undefined'
```

> Fixes gh-2699