### PR TITLE
[[FIX]] Disallow incompatible option values

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -210,6 +210,10 @@ var JSHINT = (function() {
       combine(predefined, vars.ecmaIdentifiers[6]);
     }
 
+    if (state.option.strict === "global" && "globalstrict" in state.option) {
+      error("E059", state.tokens.next, "strict", "globalstrict");
+    }
+
     if (state.option.module) {
       if (state.option.strict === true) {
         state.option.strict = "global";

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -210,6 +210,10 @@ var JSHINT = (function() {
       combine(predefined, vars.ecmaIdentifiers[6]);
     }
 
+    /**
+     * Use `in` to check for the presence of any explicitly-specified value for
+     * `globalstrict` because both `true` and `false` should trigger an error.
+     */
     if (state.option.strict === "global" && "globalstrict" in state.option) {
       error("E059", state.tokens.next, "strict", "globalstrict");
     }

--- a/src/messages.js
+++ b/src/messages.js
@@ -73,7 +73,8 @@ var errors = {
   E055: "The '{a}' option cannot be set after any executable code.",
   E056: "'{a}' was used before it was declared, which is illegal for '{b}' variables.",
   E057: "Invalid meta property: '{a}.{b}'.",
-  E058: "Missing semicolon."
+  E058: "Missing semicolon.",
+  E059: "Incompatible values for the '{a}' and '{b}' linting options."
 };
 
 var warnings = {

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1679,6 +1679,26 @@ exports.globalstrict = function (test) {
   // Don't enforce "use strict"; if strict has been explicitly set to false
   TestRun(test).test(code[1], { es3: true, globalstrict: true, strict: false });
 
+  TestRun(test, "co-occurence with 'strict: global'")
+    .addError(0, "Incompatible values for the 'strict' and 'globalstrict' linting options.")
+    .test(code, { strict: "global", globalstrict: false });
+
+  TestRun(test, "co-occurence with 'strict: global'")
+    .addError(0, "Incompatible values for the 'strict' and 'globalstrict' linting options.")
+    .test(code, { strict: "global", globalstrict: true });
+
+  TestRun(test, "co-occurence with internally-set 'strict: gobal' (module code)")
+    .test(code, { strict: true, globalstrict: false, esnext: true, module: true });
+
+  TestRun(test, "co-occurence with internally-set 'strict: gobal' (Node.js code)")
+    .test(code, { strict: true, globalstrict: false, node: true });
+
+  TestRun(test, "co-occurence with internally-set 'strict: gobal' (Phantom.js code)")
+    .test(code, { strict: true, globalstrict: false, phantom: true });
+
+  TestRun(test, "co-occurence with internally-set 'strict: gobal' (Browserify code)")
+    .test(code, { strict: true, globalstrict: false, browserify: true });
+
   // Check that we can detect missing "use strict"; statement for code that is
   // not inside a function
   code = [


### PR DESCRIPTION
This was requested by @rwaldron during the discussion of gh-2663.

Commit message:

> The recently-implemented "global" value for the "strict" option is
> incompatible with the "globalstrict" value, so their combined use should
> be disallowed.
>
> Introduce a generic error message for incompatible option values, and
> utilize it to restrict the combined usage of "strict: global" and
> "globalstrict".