### PR TITLE
[[FIX]] Don't warn that `let is ES6 or moz` about let blocks and let expressions

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -895,7 +895,7 @@ var JSHINT = (function() {
       state.funct["(scope)"].stack();
       advance("let");
       advance("(");
-      state.tokens.prev.fud();
+      state.tokens.prev.fud({ letExpr: true });
       advance(")");
     }
 
@@ -3528,19 +3528,20 @@ var JSHINT = (function() {
     var inexport = context && context.inexport;
     var isLet = type === "let";
     var isConst = type === "const";
-    var tokens, lone, value, letblock;
+    var isLetExpr = context && context.letExpr;
+    var isLetBlock = isLet && checkPunctuator(state.tokens.next, "(");
+    var tokens, lone, value;
 
-    if (!state.inES6()) {
+    if (!isLetExpr && !isLetBlock && !state.inES6()) {
       warning("W104", state.tokens.curr, type, "6");
     }
 
-    if (isLet && state.tokens.next.value === "(") {
+    if (isLetBlock) {
       if (!state.inMoz()) {
         warning("W118", state.tokens.next, "let block");
       }
       advance("(");
       state.funct["(scope)"].stack();
-      letblock = true;
     } else if (state.funct["(noblockscopedvar)"]) {
       error("E048", state.tokens.curr, isConst ? "Const" : "Let");
     }
@@ -3605,7 +3606,7 @@ var JSHINT = (function() {
       }
       comma();
     }
-    if (letblock) {
+    if (isLetBlock) {
       advance(")");
       block(true, true);
       statement.block = true;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2810,7 +2810,6 @@ exports["let statement (as seen in jetpack) as es5"] = function (test) {
   TestRun(test)
     .addError(1, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(1, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .addError(3, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(3, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
     .test(code, {unused: true, undef: true,
            predef: ["require", "xferable", "options"]}); // es5
@@ -2838,7 +2837,6 @@ exports["let statement (as seen in jetpack) as legacy JS"] = function (test) {
   TestRun(test)
     .addError(1, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(1, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .addError(3, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(3, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
     .test(code, {es3: true, unused: true, undef: true,
            predef: ["require", "xferable", "options"]});
@@ -2890,13 +2888,10 @@ exports["let block and let expression as es5"] = function (test) {
   ];
 
   TestRun(test)
-    .addError(1, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(1, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
-    .addError(3, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(3, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(4, "'let expressions' is only available in Mozilla JavaScript extensions " +
       "(use moz option).")
-    .addError(4, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .test(code, {unused: true, undef: true, predef: ["print"]}); // es5
   test.done();
 };
@@ -2912,13 +2907,10 @@ exports["let block and let expression as legacy JS"] = function (test) {
   ];
 
   TestRun(test)
-    .addError(1, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(1, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
-    .addError(3, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(3, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(4, "'let expressions' is only available in Mozilla JavaScript extensions " +
       "(use moz option).")
-    .addError(4, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
   test.done();
 };


### PR DESCRIPTION
```js
let (a = 1) {
  console.log(a + let (a = 2) a;)
}
```

JSHint shouldn't warn that `'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).`.