### PR TITLE
[[DOCS]] Mark the 'curly' option as deprecated

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -47,6 +47,11 @@ exports.bool = {
      *     while (day)
      *       shuffle();
      *       sleep();
+     *
+     * @deprecated JSHint is limiting its scope to issues of code correctness.
+     *             If you would like to enforce rules relating to code style,
+     *             check out [the JSCS
+     *             project](https://github.com/jscs-dev/node-jscs).
      */
     curly       : true,
 


### PR DESCRIPTION
Commit 4e8921666a5fd54c5f58ebc66f3c61d6c60f7d85 marked many options
like 'camelcase', 'indent' and 'quotmark' as deprecated in favor of
the respective JSCS rules.

JSCS' requireCurlyBraces is the equivalent of JSHint's curly, as stated
at http://jscs.info/rule/requireCurlyBraces, but more customizable.

In order not to split efforts between projects, JSHint should not
enforce code style.