### PR TITLE
[[DOCS]] Update notation about `esnext` option

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -541,8 +541,7 @@ exports.bool = {
 
     /**
      * This option tells JSHint that your code uses ECMAScript 6 specific
-     * syntax. Note that these features are not finalized yet and not all
-     * browsers implement them.
+     * syntax. Note that not all browsers implement these features.
      *
      * More info:
      *


### PR DESCRIPTION
ES6 is already finalized on June 17.
Ref: http://www.ecma-international.org/news/Publication%20of%20ECMA-262%206th%20edition.htm