### PR TITLE
[[FEAT]] Allow multipler reporters to run

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -204,7 +204,7 @@ function loadIgnores(params) {
     return [];
   }
 
-  var name = (file ? shjs.cat(file) : "");
+  var name = file ? shjs.cat(file) : "";
 
   if (!name) {
     return [];
@@ -640,8 +640,8 @@ var exports = {
         lint(extract(code, opts.extract), results, config, data, filename);
 
         // invoke each reporter
-        for (var index in opts.reporters) {
-          exports.getReporter(opts.reporters[index])(results, data, { verbose: opts.verbose });
+        for (var i = 0; i < opts.reporters.length; i++) {
+          exports.getReporter(opts.reporters[i])(results, data, { verbose: opts.verbose });
         }
 
         cb(results.length === 0);
@@ -681,12 +681,11 @@ var exports = {
 
     if (opts.hasOwnProperty('reporter')) {
       // passed in manually 'old' way without going through entry point of script (interpret)
-      (opts.reporter)(results, data, { verbose: opts.verbose });
-    }
-    else {
+      opts.reporter(results, data, { verbose: opts.verbose });
+    } else {
       // invoke each reporter as set up on
-      for (var index in opts.reporters) {
-        exports.getReporter(opts.reporters[index])(results, data, { verbose: opts.verbose });
+      for (var i = 0; i < opts.reporters.length; i++) {
+        exports.getReporter(opts.reporters[i])(results, data, { verbose: opts.verbose });
       }
     }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -706,10 +706,10 @@ var exports = {
    * @param {string} name of reporter to fetch, pre-defined or custom.
    */
   getReporter: function(reporterName) {
-    var reporter = defReporter; // default
+    var reporter = defReporter; // assume no cli --reporter defined
 
-    if (!reporterName) {
-      return reporter; // return default
+    if (!reporterName || reporterName === 'default') {
+      return reporter; // return defReporter defined in head
     }
 
     switch (reporterName) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -641,7 +641,7 @@ var exports = {
 
         // invoke each reporter
         for (var index in opts.reporters) {
-          (exports.getReporter(opts.reporters[index]))(results, data, { verbose: opts.verbose });
+          exports.getReporter(opts.reporters[index])(results, data, { verbose: opts.verbose });
         }
 
         cb(results.length === 0);
@@ -686,7 +686,7 @@ var exports = {
     else {
       // invoke each reporter as set up on
       for (var index in opts.reporters) {
-        (exports.getReporter(opts.reporters[index]))(results, data, { verbose: opts.verbose });
+        exports.getReporter(opts.reporters[index])(results, data, { verbose: opts.verbose });
       }
     }
 
@@ -712,29 +712,30 @@ var exports = {
     if (!reporterName) {
       return reporter; // return default
     }
-    switch (true) {
+
+    switch (reporterName) {
       // JSLint reporter
-      case reporterName === "jslint":
+      case "jslint":
         reporter = "./reporters/jslint_xml.js";
         break;
 
       // CheckStyle (XML) reporter
-      case reporterName === "checkstyle":
+      case "checkstyle":
         reporter = "./reporters/checkstyle.js";
         break;
 
       // Unix reporter
-      case reporterName === "unix":
+      case "unix":
         reporter = "./reporters/unix.js";
         break;
 
       // Reporter that displays additional JSHint data
-      case reporterName === "non_error":
+      case "non_error":
         reporter = "./reporters/non_error.js";
         break;
 
-      // Custom reporter
-      case reporterName !== undefined:
+      // Custom reporter. not to be confused with 'default' if undefined above
+      default:
         reporter = path.resolve(process.cwd(), reporterName);
         break;
     }

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -360,6 +360,8 @@ exports.group = {
       cli.interpret([
         "node", "jshint", "file.js", "--reporter", "invalid.js"
       ]);
+      // reporter error now thrown from getReporter sub-routine
+      cli.getReporter('invalid.js');
     } catch (err) {
       var msg = out.args[0][0];
       test.equal(msg.slice(0, 25), "Can't load reporter file:");
@@ -393,35 +395,43 @@ exports.group = {
   },
 
   testJSLintReporter: function (test) {
+    test.expect(2);
+
     var rep = require("../src/reporters/jslint_xml.js");
     var run = this.sinon.stub(cli, "run");
 
     cli.interpret([
       "node", "jshint", "file.js", "--reporter", "jslint"
     ]);
-    test.equal(run.args[0][0].reporter, rep.reporter);
+    test.equal(cli.getReporter(cli.run.args[0][0].reporters[0]), rep.reporter);
 
+    // --jslint-reporter depcreated functionality...
     cli.interpret([
       "node", "jshint", "file.js", "--jslint-reporter"
     ]);
-    test.equal(run.args[1][0].reporter, rep.reporter);
+    // deprecated arg is mapped manually. should just remove in next major version
+    test.equal(cli.getReporter('jslint'), rep.reporter);
 
     test.done();
   },
 
   testCheckStyleReporter: function (test) {
+    test.expect(2);
+
     var rep = require("../src/reporters/checkstyle.js");
     var run = this.sinon.stub(cli, "run");
 
     cli.interpret([
       "node", "jshint", "file.js", "--reporter", "checkstyle"
     ]);
-    test.equal(run.args[0][0].reporter, rep.reporter);
+    test.equal(cli.getReporter(run.args[0][0].reporters[0]), rep.reporter);
 
+    // --checkstyle-reporter depcreated functionality...
     cli.interpret([
       "node", "jshint", "file.js", "--checkstyle-reporter"
     ]);
-    test.equal(run.args[1][0].reporter, rep.reporter);
+    // deprecated arg is mapped manually. should just remove in next major version
+    test.equal(cli.getReporter('checkstyle'), rep.reporter);
 
     test.done();
   },
@@ -433,7 +443,7 @@ exports.group = {
     cli.interpret([
       "node", "jshint", "file.js", "--show-non-errors"
     ]);
-    test.equal(run.args[0][0].reporter, rep.reporter);
+    test.equal(cli.getReporter(run.args[0][0].reporters[0]), rep.reporter);
 
     test.done();
   },


### PR DESCRIPTION
Added new helper fuction getReporter that removes logic from interpret.
Now can call jshint example.js --reporter=unix,checkstyle. Fully backwards
compatible.

Fixes #1702