### PR TITLE
Enforce TDZ within initializer of lexical declaration (refactored)

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3576,7 +3576,9 @@ var JSHINT = (function() {
         }
       }
 
-      state.funct["(scope)"].definition.reset();
+      if (!prefix) {
+        state.funct["(scope)"].definition.reset();
+      }
 
       statement.first = statement.first.concat(names);
 
@@ -4275,6 +4277,10 @@ var JSHINT = (function() {
       //     for ( LeftHandSideExpression of AssignmentExpression ) Statement
       expression(bindingPower);
       advance(")", t);
+
+      if (letscope) {
+        state.funct["(scope)"].definition.reset();
+      }
 
       if (nextop.value === "in" && state.option.forin) {
         state.forinifcheckneeded = true;

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3553,6 +3553,7 @@ var JSHINT = (function() {
             if (lone && inexport) {
               state.funct["(scope)"].setExported(t.token.value, t.token);
             }
+            state.funct["(scope)"].definition.add(t.id, type);
           }
         }
       }
@@ -3574,6 +3575,8 @@ var JSHINT = (function() {
           destructuringPatternMatch(names, value);
         }
       }
+
+      state.funct["(scope)"].definition.reset();
 
       statement.first = statement.first.concat(names);
 

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3549,11 +3549,6 @@ var JSHINT = (function() {
               type: type,
               token: t.token });
             names.push(t.token);
-
-            if (lone && inexport) {
-              state.funct["(scope)"].setExported(t.token.value, t.token);
-            }
-            state.funct["(scope)"].definition.add(t.id, type);
           }
         }
       }
@@ -3577,7 +3572,16 @@ var JSHINT = (function() {
       }
 
       if (!prefix) {
-        state.funct["(scope)"].definition.reset();
+        for (t in tokens) {
+          if (tokens.hasOwnProperty(t)) {
+            t = tokens[t];
+            state.funct["(scope)"].initialize(t.id);
+
+            if (lone && inexport) {
+              state.funct["(scope)"].setExported(t.token.value, t.token);
+            }
+          }
+        }
       }
 
       statement.first = statement.first.concat(names);
@@ -3719,7 +3723,6 @@ var JSHINT = (function() {
         type: "class",
         token: state.tokens.curr });
 
-      state.funct["(scope)"].definition.add(this.name, "class");
     } else if (state.tokens.next.identifier && state.tokens.next.value !== "extends") {
       // BindingIdentifier(opt)
       this.name = identifier();
@@ -3731,7 +3734,7 @@ var JSHINT = (function() {
     classtail(this);
 
     if (isStatement) {
-      state.funct["(scope)"].definition.reset();
+      state.funct["(scope)"].initialize(this.name);
     }
 
     return this;
@@ -4278,10 +4281,6 @@ var JSHINT = (function() {
       expression(bindingPower);
       advance(")", t);
 
-      if (letscope) {
-        state.funct["(scope)"].definition.reset();
-      }
-
       if (nextop.value === "in" && state.option.forin) {
         state.forinifcheckneeded = true;
 
@@ -4582,6 +4581,7 @@ var JSHINT = (function() {
       // Import bindings are immutable (see ES6 8.1.1.5.5)
       state.funct["(scope)"].addlabel(this.name, {
         type: "const",
+        initialized: true,
         token: state.tokens.curr });
 
       if (state.tokens.next.value === ",") {
@@ -4608,6 +4608,7 @@ var JSHINT = (function() {
         // Import bindings are immutable (see ES6 8.1.1.5.5)
         state.funct["(scope)"].addlabel(this.name, {
           type: "const",
+          initialized: true,
           token: state.tokens.curr });
       }
     } else {
@@ -4633,6 +4634,7 @@ var JSHINT = (function() {
         // Import bindings are immutable (see ES6 8.1.1.5.5)
         state.funct["(scope)"].addlabel(importName, {
           type: "const",
+          initialized: true,
           token: state.tokens.curr });
 
         if (state.tokens.next.value === ",") {
@@ -4697,6 +4699,7 @@ var JSHINT = (function() {
       if (this.block) {
         state.funct["(scope)"].addlabel(identifier, {
           type: exportType,
+          initialized: true,
           token: token });
 
         state.funct["(scope)"].setExported(identifier, token);

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3716,6 +3716,8 @@ var JSHINT = (function() {
       state.funct["(scope)"].addlabel(this.name, {
         type: "class",
         token: state.tokens.curr });
+
+      state.funct["(scope)"].definition.add(this.name, "class");
     } else if (state.tokens.next.identifier && state.tokens.next.value !== "extends") {
       // BindingIdentifier(opt)
       this.name = identifier();
@@ -3723,7 +3725,13 @@ var JSHINT = (function() {
     } else {
       this.name = state.nameStack.infer();
     }
+
     classtail(this);
+
+    if (isStatement) {
+      state.funct["(scope)"].definition.reset();
+    }
+
     return this;
   }
 

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -24,7 +24,8 @@ var scopeManager = function(state, predefined, exported, declared) {
       "(breakLabels)": Object.create(null),
       "(parent)": _current,
       "(type)": type,
-      "(params)": (type === "functionparams" || type === "catchparams") ? [] : null
+      "(params)": (type === "functionparams" || type === "catchparams") ? [] : null,
+      "(currentDefinition)": Object.create(null)
     };
     _scopeStack.push(_current);
   }
@@ -699,6 +700,15 @@ var scopeManager = function(state, predefined, exported, declared) {
       }
     },
 
+    definition: {
+      add: function(labelName, type) {
+        _current["(currentDefinition)"][labelName] = { type: type };
+      },
+      reset: function() {
+        _current["(currentDefinition)"] = Object.create(null);
+      }
+    },
+
     funct: {
       /**
        * Returns the label type given certain options
@@ -804,6 +814,13 @@ var scopeManager = function(state, predefined, exported, declared) {
         if (token) {
           token["(function)"] = _currentFunctBody;
           _current["(usages)"][labelName]["(tokens)"].push(token);
+        }
+
+        // blockscoped vars can't be used within their initializer (TDZ)
+        // (currentDefinitions) only contains blockscoped vars
+        var currentDefinition = _current["(currentDefinition)"][labelName];
+        if (currentDefinition) {
+          error("E056", token, labelName, currentDefinition.type);
         }
       },
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -925,12 +925,13 @@ exports.testConstRedeclaration = function (test) {
   ];
 
   TestRun(test)
-      .addError(2, "'a' has already been declared.")
-      .addError(9, "'a' has already been declared.")
-      .addError(13, "'b' has already been declared.")
-      .test(src, {
-        esnext: true
-      });
+    .addError(2, "'a' has already been declared.")
+    .addError(6, "'a' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(9, "'a' has already been declared.")
+    .addError(13, "'b' has already been declared.")
+    .test(src, {
+      esnext: true
+    });
 
   test.done();
 };
@@ -2154,4 +2155,38 @@ exports["TDZ within class heritage definition"] = function(test) {
     .test(code, { esversion: 6 });
 
   test.done();
-}
+};
+
+exports["TDZ within for in/of head"] = function(test) {
+  var code = [
+    "for (let a   in a);",
+    "for (const b in b);",
+    "for (let c   of c);",
+    "for (const d of d);",
+
+    // line 5
+    "for (let e   in { e });",
+    "for (const f in { f });",
+    "for (let g   of { g });",
+    "for (const h of { h });",
+
+    // line 9
+    "for (let i   in { method() { return i; } });",
+    "for (const j in { method() { return j; } });",
+    "for (let k   of { method() { return k; } });",
+    "for (const l of { method() { return l; } });"
+  ];
+
+  TestRun(test)
+    .addError(1, "'a' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(2, "'b' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(3, "'c' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(4, "'d' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(5, "'e' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(6, "'f' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(7, "'g' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(8, "'h' was used before it was declared, which is illegal for 'const' variables.")
+    .test(code, { esversion: 6 });
+
+  test.done();
+};

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2089,3 +2089,42 @@ exports["destructuring in setter parameter"] = function (test) {
 
   test.done();
 };
+
+exports["TDZ within initializer of lexical declarations"] = function(test) {
+  var code = [
+    "let a = a;",
+    "const b = b;",
+    "let c = () => c;",
+    "const d = () => d;",
+    // line 5
+    "let e = {",
+    "  x: e,",
+    "  y: () => e",
+    "};",
+    "const f = {",
+    "  x: f,",
+    "  y: () => f",
+    "};",
+    // line 13
+    "let g, h = g;",
+    "const i = 0, j = i;",
+    "let [ k, l ] = l;",
+    "const [ m, n ] = n;",
+    // line 17
+    "let o = (() => o) + o;",
+    "const p = (() => p) + p;"
+  ];
+
+  TestRun(test)
+    .addError(1, "'a' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(2, "'b' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(6, "'e' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(10, "'f' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(15, "'l' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(16, "'n' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(17, "'o' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(18, "'p' was used before it was declared, which is illegal for 'const' variables.")
+    .test(code, { esversion: 6 });
+
+  test.done();
+};

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2128,3 +2128,30 @@ exports["TDZ within initializer of lexical declarations"] = function(test) {
 
   test.done();
 };
+
+exports["TDZ within class heritage definition"] = function(test) {
+  var code = [
+    "let A = class extends A {};",
+    "let B = class extends { B } {};",
+    "let C = class extends { method() { return C; } } {};",
+    // line 4
+    "const D = class extends D {};",
+    "const E = class extends { E } {};",
+    "const F = class extends { method() { return F; } } {};",
+    // line 7
+    "class G extends G {}",
+    "class H extends { H } {}",
+    "class I extends { method() { return I; }} {}"
+  ];
+
+  TestRun(test)
+    .addError(1, "'A' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(2, "'B' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(4, "'D' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(5, "'E' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(7, "'G' was used before it was declared, which is illegal for 'class' variables.")
+    .addError(8, "'H' was used before it was declared, which is illegal for 'class' variables.")
+    .test(code, { esversion: 6 });
+
+  test.done();
+}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -116,7 +116,9 @@ exports.shadowEs6 = function (test) {
     [344, "'zzi' has already been declared."],
     [345, "'zzj' has already been declared."],
     [349, "'zzl' has already been declared."],
+    [349, "'zzl' was used before it was declared, which is illegal for 'const' variables."],
     [350, "'zzm' has already been declared."],
+    [350, "'zzm' was used before it was declared, which is illegal for 'let' variables."],
     [364, "'zj' has already been declared."]
   ];
 
@@ -759,11 +761,8 @@ exports.undef = function (test) {
 
   // block scope cannot use themselves in the declaration
   TestRun(test)
-    // JSHint does not currently enforce the correct temporal dead zone
-    // semantics in this case. Once this is fixed, the following errors
-    // should be thrown:
-    //.addError(1, "'a' was used before it was declared, which is illegal for 'let' variables.")
-    //.addError(2, "'b' was used before it was declared, which is illegal for 'const' variables.")
+    .addError(1, "'a' was used before it was declared, which is illegal for 'let' variables.")
+    .addError(2, "'b' was used before it was declared, which is illegal for 'const' variables.")
     .addError(5, "'e' is already defined.")
     .test([
       'let a = a;',


### PR DESCRIPTION
This patch includes work by @nicolo-ribaudo (originally submitted in gh-2701) and a refactoring of my own design.

I initially expected that this approach would reduce some of the noise
associated with explicit maintence of the standalone "definition" objects (e.g.
the calls to `state.funct["(scope)"].definition.reset`). While this turned out
to be true, I found that it *also* introduced a different kind of noise--see
the extra calls to `state.funct["(scope)"].initialize`.

I think the latter is preferable because it makes the source code more closely
match the spec language. Readers are more likely to know what it means to
"initialize a label" than what it means to "clear a definition."

Resolves #2637