### PR TITLE
Find .jshintignore relative to file. Fixes #2595

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -188,7 +188,9 @@ function findFile(name, cwd) {
     return null;
   }
 
-  return findFile(name, parent);
+  var result = findFile(name, parent);
+  findFileResults[filename] = result;
+  return result;
 }
 
 /**

--- a/src/cli.js
+++ b/src/cli.js
@@ -563,7 +563,8 @@ var exports = {
    *
    * @param {object} post-processed options from 'interpret':
    *                   args     - CLI arguments
-   *                   ignores  - A list of files/dirs to ignore (defaults to .jshintignores)
+   *                   ignores  - A list of files/dirs to ignore (defaults to
+   *                     the contents of .jshintignore)
    *                   extensions - A list of non-dot-js extensions to check
    */
   gather: function(opts) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -431,7 +431,8 @@ function collect(fp, files, ignores, ext) {
     shjs.ls(fp).forEach(function(item) {
       var itempath = path.join(fp, item);
       if (shjs.test("-d", itempath) || item.match(ext)) {
-        collect(itempath, files, ignores, ext);
+        var dirIgnores = loadIgnores({ cwd: path.resolve(itempath) });
+        collect(itempath, files, ignores.concat(dirIgnores), ext);
       }
     });
 
@@ -574,13 +575,13 @@ var exports = {
       (!opts.extensions ? "" : "|" +
         opts.extensions.replace(/,/g, "|").replace(/[\. ]/g, "")) + ")$");
 
-    var ignores = !opts.ignores ? loadIgnores({ cwd: opts.cwd }) :
-                                  opts.ignores.map(function(target) {
-                                    return path.resolve(target);
-                                  });
+    var ignores = (opts.ignores || []).map(function(target) {
+      return path.resolve(target);
+    });
 
     opts.args.forEach(function(target) {
-      collect(target, files, ignores, reg);
+      var dirIgnores = loadIgnores({ cwd: path.resolve(target) });
+      collect(target, files, ignores.concat(dirIgnores), reg);
     });
 
     return files;


### PR DESCRIPTION
This makes it so `.jshintignore` is now also loaded from the directories of processed files like `.jshintrc` is, instead of being loaded based on the current working directory. This fixes #2595.

There's also a commit improving findFile's caching. Previously, if you ran `findFile("e.js", "/a/b/c/d")`, and only "/a/e.js" existed, then the only cache entry added would be for "/a/e.js", which would only allow calls to `findFile("e.js", "/a")` to be answered by the cache. Future calls to `findFile("e.js", "/a/b/c/d")` would still check for "/a/b/c/d/e.js", "/a/b/c/e.js", "/a/b/e.js" before finally being able to make use of the cached entry.

Now, every recursive call makes a cache entry, so future calls to `findFile("e.js", "/a/b/c/d")` can immediately result in "/a/e.js".