### PR TITLE
[[FIX]] Do not enable `newcap` within strict mode

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -738,9 +738,6 @@ var JSHINT = (function() {
             state.option[key] = (val === "true");
           }
 
-          if (key === "newcap") {
-            state.option["(explicitNewcap)"] = true;
-          }
           return;
         }
 
@@ -1776,9 +1773,6 @@ var JSHINT = (function() {
     }
 
     if (state.isStrict()) {
-      if (!state.option["(explicitNewcap)"]) {
-        state.option.newcap = true;
-      }
       state.option.undef = true;
     }
   }
@@ -5180,9 +5174,6 @@ var JSHINT = (function() {
               (optionKey === "es5" && o[optionKey])) {
             warning("I003");
           }
-
-          if (optionKeys[x] === "newcap" && o[optionKey] === false)
-            newOptionObj["(explicitNewcap)"] = true;
         }
       }
     }

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1618,7 +1618,6 @@ exports.strict = function (test) {
   run.test(src2, { es3: true, strict: false });
 
   TestRun(test)
-    .addError(6, "Missing 'new' prefix when invoking a constructor.")
     .test(src3, {es3 : true});
 
   TestRun(test).test(code2, { es3: true, strict: true });
@@ -3207,6 +3206,20 @@ exports.module.declarationRestrictions = function( test ) {
       "  /* jshint validthis:true */",
       "}"
     ], { esnext: true });
+
+  test.done();
+};
+
+exports.module.newcap = function(test) {
+  var code = [
+    "var ctor = function() {};",
+    "var Ctor = function() {};",
+    "var c1 = new ctor();",
+    "var c2 = Ctor();"
+  ];
+
+  TestRun(test, "The `newcap` option is not automatically enabled for module code.")
+    .test(code, { esversion: 6, module: true });
 
   test.done();
 };

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5939,6 +5939,24 @@ exports["class method this"] = function (test) {
   test.done();
 };
 
+exports.classNewcap = function (test) {
+  var code = [
+    "class C {",
+    "  m() {",
+    "    var ctor = function() {};",
+    "    var Ctor = function() {};",
+    "    var c1 = new ctor();",
+    "    var c2 = Ctor();",
+    "  }",
+    "}"
+  ];
+
+  TestRun(test, "The `newcap` option is not automatically enabled within class bodies.")
+    .test(code, { esversion: 6 });
+
+  test.done();
+};
+
 exports.classExpression = function (test) {
   var code = [
     "void class MyClass {",


### PR DESCRIPTION
@rwaldron You're gonna love this.

Since the first public release of JSLint (ca120a7), this codebase has
automatically enabled the `newcap` option for all strict mode code:

    function use_strict() {
        if (nexttoken.value === 'use strict') {
            advance();
            advance(';');
            strict_mode = true;
            option.newcap = true;
            option.undef = true;
            return true;
        } else {
            return false;
        }
    }

Commit 8de8247 unified the way JSHint detects and enforces strict mode
across contexts. Among other modifications, it included the following
change:

    - if (state.tokens.curr.value === "use strict") {
    + if (state.isStrict()) {
        if (!state.option["(explicitNewcap)"]) {
          state.option.newcap = true;
        }
        state.option.undef = true;
      }

This change introduced a regression: it enables the `newcap` option for
class bodies and ES2015 module code as well.

Because ES5's strict mode and the warnings enabled by the `newcap`
option are orthogonal (and because as a stylistic concern, the `newcap`
is deprecated) correct the regression by relaxing the behavior for all
cases--do not automatically enable `newcap` when entering strict mode,
for whatever reason.