### PR TITLE
[[FIX]] Don't throw '(NaN% scanned)'

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -330,7 +330,7 @@ var JSHINT = (function() {
 
   // Produce an error warning.
   function quit(code, line, chr) {
-    var percentage = Math.floor((line / state.lines.length) * 100);
+    var percentage = Math.floor((line / state.lines.length) * 100) || 0;
     var message = messages.errors[code].desc;
 
     throw {

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -329,14 +329,14 @@ var JSHINT = (function() {
   }
 
   // Produce an error warning.
-  function quit(code, line, chr) {
-    var percentage = Math.floor((line / state.lines.length) * 100) || 0;
+  function quit(code, token) {
+    var percentage = Math.floor((token.line / state.lines.length) * 100);
     var message = messages.errors[code].desc;
 
     throw {
       name: "JSHintError",
-      line: line,
-      character: chr,
+      line: token.line,
+      character: token.from,
       message: message + " (" + percentage + "% scanned).",
       raw: message,
       code: code
@@ -369,8 +369,8 @@ var JSHINT = (function() {
       t = state.tokens.curr;
     }
 
-    l = t.line || 0;
-    ch = t.from || 0;
+    l = t.line;
+    ch = t.from;
 
     w = {
       id: "(error)",
@@ -392,7 +392,7 @@ var JSHINT = (function() {
     removeIgnoredMessages();
 
     if (JSHINT.errors.length >= state.option.maxerr)
-      quit("E043", l, ch);
+      quit("E043", t);
 
     return w;
   }
@@ -829,7 +829,7 @@ var JSHINT = (function() {
       state.tokens.next = lookahead.shift() || lex.token();
 
       if (!state.tokens.next) { // No more tokens left, give up
-        quit("E041", state.tokens.curr.line);
+        quit("E041", state.tokens.curr);
       }
 
       if (state.tokens.next.id === "(end)" || state.tokens.next.id === "(error)") {
@@ -1237,7 +1237,7 @@ var JSHINT = (function() {
       }
 
       if (!left || !right) {
-        quit("E041", state.tokens.curr.line);
+        quit("E041", state.tokens.curr);
       }
 
       if (left.id === "!") {
@@ -2024,7 +2024,9 @@ var JSHINT = (function() {
   // ECMAScript parser
 
   delim("(endline)");
-  delim("(begin)");
+  (function(x) {
+    x.line = x.from = 0;
+  })(delim("(begin)"));
   delim("(end)").reach = true;
   delim("(error)").reach = true;
   delim("}").reach = true;
@@ -2319,7 +2321,7 @@ var JSHINT = (function() {
     this.right = expression(150);
 
     if (!this.right) { // '!' followed by nothing? Give up.
-      quit("E041", this.line || 0);
+      quit("E041", this);
     }
 
     if (bang[this.right.id] === true) {
@@ -2333,7 +2335,7 @@ var JSHINT = (function() {
     this.first = this.right = p;
 
     if (!p) { // 'typeof' followed by nothing? Give up.
-      quit("E041", this.line || 0, this.character || 0);
+      quit("E041", this);
     }
 
     // The `typeof` operator accepts unresolvable references, so the operand
@@ -5178,7 +5180,7 @@ var JSHINT = (function() {
           newOptionObj[optionKey] = o[optionKey];
           if ((optionKey === "esversion" && o[optionKey] === 5) ||
               (optionKey === "es5" && o[optionKey])) {
-            warning("I003");
+            warningAt("I003", 0, 0);
           }
 
           if (optionKeys[x] === "newcap" && o[optionKey] === false)
@@ -5292,7 +5294,7 @@ var JSHINT = (function() {
     });
 
     lex.on("fatal", function(ev) {
-      quit("E041", ev.line, ev.from);
+      quit("E041", ev);
     });
 
     lex.on("Identifier", function(ev) {
@@ -5347,7 +5349,7 @@ var JSHINT = (function() {
       }
 
       if (state.tokens.next.id !== "(end)") {
-        quit("E041", state.tokens.curr.line);
+        quit("E041", state.tokens.curr);
       }
 
       state.funct["(scope)"].unstack();

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -45,6 +45,10 @@ exports.other = function (test) {
     .addError(1, "Unrecoverable syntax error. (100% scanned).")
     .test("typeof;");
 
+  TestRun(test)
+    .addError(1, "Unrecoverable syntax error. (0% scanned).")
+    .test("}");
+
   test.done();
 };
 


### PR DESCRIPTION
A very low priority fix...

(note `0% scanned` instead of `NaN% scanned`)

```
nicol@DESKTOP-EDGLMME MINGW64 ~/Documents/jshint (master)
$ bin/jshint demo.js
demo.js: line 1, col 1, Unrecoverable syntax error. (NaN% scanned).

1 error

nicol@DESKTOP-EDGLMME MINGW64 ~/Documents/jshint (0%-scanned)
$ bin/jshint demo.js
demo.js: line 1, col 1, Unrecoverable syntax error. (0% scanned).

1 error
```

demo.js
```js
}
```