### PR TITLE
[[FEAT]] Support QUnit's global notOk

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -468,6 +468,7 @@ exports.qunit = {
   module         : false,
   notDeepEqual   : false,
   notEqual       : false,
+  notOk          : false,
   notPropEqual   : false,
   notStrictEqual : false,
   ok             : false,


### PR DESCRIPTION
Adds support for notOk exposed to the global object since QUnit 1.18.0

Ref https://github.com/jquery/qunit/releases/tag/1.18.0