### PR TITLE
Remove unsupported indent option

### DIFF
--- a/examples/.jshintrc
+++ b/examples/.jshintrc
@@ -12,7 +12,6 @@
     "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
     "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
     "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
-    "indent"        : 4,        // {int} Number of spaces to use for indentation
     "latedef"       : false,    // true: Require variables/functions to be defined before being used
     "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
     "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`


### PR DESCRIPTION
Indent is no longer supported as of v2.5.0[0].

[0] https://github.com/jshint/jshint/issues/655