### PR TITLE
[[FIX]] Allow ignoring W020 and W021

### DIFF
--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -305,7 +305,9 @@ var scopeManager = function(state, predefined, exported, declared) {
           if ((usedLabelType === "function" || usedLabelType === "class") &&
               usage["(reassigned)"]) {
             for (j = 0; j < usage["(reassigned)"].length; j++) {
-              error("W021", usage["(reassigned)"][j], usedLabelName, usedLabelType);
+              if (!usage["(reassigned)"][j].ignoreW021) {
+                warning("W021", usage["(reassigned)"][j], usedLabelName, usedLabelType);
+              }
             }
           }
           continue;
@@ -343,7 +345,9 @@ var scopeManager = function(state, predefined, exported, declared) {
             // check for re-assigning a read-only (set to false) predefined
             if (_current["(predefined)"][usedLabelName] === false && usage["(reassigned)"]) {
               for (j = 0; j < usage["(reassigned)"].length; j++) {
-                warning("W020", usage["(reassigned)"][j]);
+                if (!usage["(reassigned)"][j].ignoreW020) {
+                  warning("W020", usage["(reassigned)"][j]);
+                }
               }
             }
           }
@@ -784,6 +788,8 @@ var scopeManager = function(state, predefined, exported, declared) {
       },
 
       reassign: function(labelName, token) {
+        token.ignoreW020 = state.ignored.W020;
+        token.ignoreW021 = state.ignored.W021;
 
         this.modify(labelName, token);
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1997,3 +1997,37 @@ exports.duplicateProto = function (test) {
 
   test.done();
 };
+
+exports["gh-2761"] = function (test) {
+  var code = [
+    "/* global foo: false */",
+    "foo = 2;",
+    "// jshint -W020",
+    "foo = 3;",
+    "// jshint +W020",
+    "foo = 4;"
+  ];
+
+  TestRun(test, "W020")
+    .addError(2, "Read only.")
+    .addError(6, "Read only.")
+    .test(code);
+
+  code = [
+    "function a() {}",
+    "a = 2;",
+    "// jshint -W021",
+    "a = 3;",
+    "// jshint +W021",
+    "a = 4;"
+  ];
+
+  TestRun(test, "W021")
+    .addError(2, "Reassignment of 'a', which is is a function. " +
+              "Use 'var' or 'let' to declare bindings that may change.")
+    .addError(6, "Reassignment of 'a', which is is a function. " +
+              "Use 'var' or 'let' to declare bindings that may change.")
+    .test(code);
+
+  test.done();
+};


### PR DESCRIPTION
I couldn't just move the checks to the `reassign` function because it would have generated warnings when a variable is defined after its assignment.
e.g.
```js
/* global foo: false */
(function() {
  foo = 2;
  var foo;
})();
```

Fixes gh-2761