### PR TITLE
Fix the check if a file is ignored

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -238,7 +238,7 @@ function isIgnored(fp, patterns) {
       return true;
     }
 
-    if (shjs.test("-d", fp) && ip.match(/^[^\/]*\/?$/) &&
+    if (shjs.test("-d", fp) && ip.match(/^[^\/\\]*[\/\\]?$/) &&
       fp.match(new RegExp("^" + ip + ".*"))) {
       return true;
     }

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -633,7 +633,17 @@ exports.group = {
 
     test.done();
   },
-  
+
+  testIgnoresWithSpecialChars: function (test) {
+    this.sinon.stub(process, "cwd").returns(path.resolve(__dirname, "special++chars"));
+    this.sinon.stub(shjs, "test").withArgs(sinon.match(/-[ed]/), ".").returns(true);
+    this.sinon.stub(shjs, "ls").withArgs(".").returns([]);
+    test.doesNotThrow(function() {
+      cli.interpret(["node", "jshint", ".", "--exclude=exclude1.js"]);
+    });
+    test.done();
+  },
+
   testMultipleIgnores: function (test) {
     var run = this.sinon.stub(cli, "run");
     var dir = __dirname + "/../examples/";


### PR DESCRIPTION
Without this fix JSHint fails if the three conditions are true: 
1. it's run on Windows,
2. the current path contains characters like `++`,
3. ignore patterns are specified via .jshintignore or command line.