### PR TITLE
[[Fix]] Expand effect of `funcscope` option

### DIFF
--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -739,7 +739,9 @@ var scopeManager = function(state, predefined, exported, declared) {
        * see block.add for block scoped
        */
       add: function(labelName, type, tok, unused) {
-        _current["(labels)"][labelName] = {
+        var targetScope = state.option.funcscope ? _currentFunctBody : _current;
+
+        targetScope["(labels)"][labelName] = {
           "(type)" : type,
           "(token)": tok,
           "(blockscoped)": false,

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1900,6 +1900,31 @@ exports.scope = function (test) {
   test.done();
 };
 
+exports.scopeUnused = function (test) {
+  var src = [
+    '(function() {',
+    '  var x;',
+    '  {',
+    '    var x;',
+    '    void x;',
+    '  }',
+    '  {',
+    '    var x;',
+    '  }',
+    '}());'
+  ];
+
+  TestRun(test)
+    .addError(2, "'x' is defined but never used.")
+    .addError(8, "'x' is defined but never used.")
+    .test(src, { shadow: true, unused: true });
+
+  TestRun(test)
+    .test(src, { funcscope: true, shadow: true, unused: true });
+
+  test.done();
+};
+
 /*
  * Tests `esnext` and `moz` options.
  *

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2969,7 +2969,6 @@ exports["make sure var variables can shadow let variables"] = function (test) {
     .addError(1, "'a' is defined but never used.")
     .addError(2, "'b' is defined but never used.")
     .addError(3, "'c' is defined but never used.")
-    .addError(9, "'d' is defined but never used.")
     .addError(9, "'d' has already been declared.")
     .test(code, { esnext: true, unused: true, undef: true, funcscope: true });
 


### PR DESCRIPTION
JSHint generally treats `var` bindings as block-scoped in order to
promote code readability and safety. It exposes the `funcscope` option
to disable this behavior and instead interpret `var` bindings as
function-scoped.

The `funcscope` option *only* controls reporting of W038--the "used out
of scope" warning. In order to consistently apply var-scoping semantics
to `var` statements, the option should also control the emission of
W098--the "unused" warning.

Update JSHint's scope manager to track variable bindings according to
the state of the `funcscope` option.

Closely related: gh-2654