### PR TITLE
[[Fix]] Correct `unused` for function-scoped vars

### DIFF
--- a/tests/regression/thirdparty.js
+++ b/tests/regression/thirdparty.js
@@ -214,7 +214,6 @@ exports.codemirror3 = function (test) {
     .addError(1342, "Value of 'e' may be overwritten in IE 8 and earlier.")
     .addError(1526, "Value of 'e' may be overwritten in IE 8 and earlier.")
     .addError(1533, "Value of 'e' may be overwritten in IE 8 and earlier.")
-    .addError(3168, "'ok' is defined but never used.")
     .addError(4093, "Unnecessary semicolon.")
     .test(src, opt, { CodeMirror: true });
 

--- a/tests/unit/fixtures/scope-cross-blocks.js
+++ b/tests/unit/fixtures/scope-cross-blocks.js
@@ -1,0 +1,35 @@
+(function() {
+  void funcBefore;
+  void topBlockBefore;
+  void nestedBlockBefore;
+
+  var funcBefore, funcAfter;
+
+  {
+    void funcBefore;
+    void topBlockBefore;
+    void nestedBlockBefore;
+
+    var topBlockBefore, topBlockAfter;
+
+    {
+      void funcBefore;
+      void topBlockBefore;
+      void nestedBlockBefore;
+
+      var nestedBlockBefore, nestedBlockAfter;
+
+      void nestedBlockAfter;
+      void topBlockAfter;
+      void funcAfter;
+    }
+
+    void nestedBlockAfter;
+    void topBlockAfter;
+    void funcAfter;
+  }
+
+  void nestedBlockAfter;
+  void topBlockAfter;
+  void funcAfter;
+}());

--- a/tests/unit/fixtures/unused-cross-blocks.js
+++ b/tests/unit/fixtures/unused-cross-blocks.js
@@ -1,0 +1,63 @@
+(function() {
+  // Usage in same scope as declaration (function)
+  var func1;
+  void func1;
+  void func2;
+  var func2;
+
+  var func3, func4, func5, func6;
+  var unusedFunc;
+
+  {
+    void func3;
+
+    // Redeclaration (direct descendent of function)
+    var func4;
+    void func4;
+    void func5;
+    var func5;
+
+    // Usage in same scope as declaration (block)
+    var topBlock1;
+    void topBlock1;
+    void topBlock2;
+    var topBlock2;
+
+    var topBlock3, topBlock4, topBlock5, topBlock6, topBlock7;
+    var unusedTopBlock;
+
+    {
+      void func6;
+
+      // Redeclaration (indirect descendent of function)
+      var func7;
+      void func7;
+      void func8;
+      var func8;
+
+      void topBlock5;
+
+      // Redeclaration (direct descendent of block)
+      var topBlock6;
+      void topBlock6;
+      void topBlock7;
+      var topBlock7;
+
+      // Usage in same scope as declaration (nested block)
+      var nestedBlock1;
+      void nestedBlock1;
+      void nestedBlock2;
+      var nestedBlock2;
+
+      var unusedNestedBlock;
+
+      {
+        // Redeclaration (indirect descendent of block)
+        var topBlock3;
+        void topBlock3;
+        void topBlock4;
+        var topBlock4;
+      }
+    }
+  }
+})();

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -2969,7 +2969,6 @@ exports["make sure var variables can shadow let variables"] = function (test) {
     .addError(1, "'a' is defined but never used.")
     .addError(2, "'b' is defined but never used.")
     .addError(3, "'c' is defined but never used.")
-    .addError(9, "'d' is defined but never used.")
     .addError(9, "'d' has already been declared.")
     .test(code, { esnext: true, unused: true, undef: true, funcscope: true });
 


### PR DESCRIPTION
In the absence of the `funcscope` option, JSHint validates
function-scoped variable references as though they were block scoped.
JSHint does not apply block-scoping semantics to reference counting,
however: re-declarations within nested blocks are *not* considered
distinct when determining whether a given binding is used.

Ensure that when a variable is re-declared within the same function
scope, usage tracking is "shared" across all identifiers.

This change required correcting two existing tests. Both alterations
removed warnings, meaning they do not reflect a backwards-incompatible
change in behavior.

1. In the following source code, the variable `ok` is used, so JSHint
   should not report otherwise:

        function(match) {
          var ch = this.string.charAt(this.pos);
          if (typeof match == "string") var ok = ch == match;
          else var ok = ch && (match.test ? match.test(ch) :
          if (ok) {++this.pos; return ch;}
        }

2. In the following source code, the `var` declaration for `d` is not
   technically used, but it is also invalid due to ES2015 block scoping
   semantics. Because JSHint continues to correctly emit an error for
   this code, the removal of the "unused" warning has little practical
   effect.

        function sup(a) {
          var b = 4;
          let c = 5;
          let d = 6;
          if (false) {
            var d = 7;
          }
          return b + c + a + d;
        }