### PR TITLE
[[Fix]] Do not disable ES6 when `moz` is set

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -22,11 +22,11 @@ var state = {
 
   /**
    * @param {boolean} strict - When `true`, only consider ES6 when in
-   *                           "esversion: 6" code and *not* in "moz".
+   *                           "esversion: 6" code.
    */
   inES6: function(strict) {
     if (strict) {
-      return !this.option.moz && this.option.esversion === 6;
+      return this.option.esversion === 6;
     }
     return this.option.moz || this.option.esversion >= 6;
   },

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1939,6 +1939,26 @@ exports.esnext = function (test) {
   test.done();
 };
 
+// The `moz` option should not preclude ES6
+exports.mozAndEs6 = function (test) {
+  var src = [
+   "var x = () => {};",
+   "function* toArray(...rest) {",
+   "  void new.target;",
+   "  yield rest;",
+   "}",
+   "var y = [...x];"
+  ];
+
+  TestRun(test)
+    .test(src, { esversion: 6 });
+
+  TestRun(test)
+    .test(src, { esversion: 6, moz: true });
+
+  test.done();
+};
+
 /*
  * Tests the `maxlen` option
  */


### PR DESCRIPTION
Although environments implementing Mozilla extensions are not
necessarily ES6-compliant, they are not mutually exclusive. Ensure that
for configurations that specify both ES6 and `moz`, the semantics of
both environments are applied consistently.

Resolves gh-2785.