### PR TITLE
[[FIX]] Throw W033 instead of E058 when the ; after a do-while stmt is missing

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1597,7 +1597,7 @@ var JSHINT = (function() {
     }
   }
 
-  function parseFinalSemicolon() {
+  function parseFinalSemicolon(stmt) {
     if (state.tokens.next.id !== ";") {
       // don't complain about unclosed templates / strings
       if (state.tokens.next.isUnclosed) return advance();
@@ -1606,13 +1606,13 @@ var JSHINT = (function() {
                      state.tokens.next.id !== "(end)";
       var blockEnd = checkPunctuator(state.tokens.next, "}");
 
-      if (sameLine && !blockEnd) {
+      if (sameLine && !blockEnd && !(stmt.value === "do" && state.inES6())) {
         errorAt("E058", state.tokens.curr.line, state.tokens.curr.character);
       } else if (!state.option.asi) {
         // If this is the last statement in a block that ends on
         // the same line *and* option lastsemic is on, ignore the warning.
         // Otherwise, complain about missing semicolon.
-        if ((blockEnd && !state.option.lastsemic) || !sameLine) {
+        if (!(blockEnd && sameLine && state.option.lastsemic)) {
           warningAt("W033", state.tokens.curr.line, state.tokens.curr.character);
         }
       }
@@ -1693,7 +1693,7 @@ var JSHINT = (function() {
       } else if (state.option.nonew && r && r.left && r.id === "(" && r.left.id === "new") {
         warning("W031", t);
       }
-      parseFinalSemicolon();
+      parseFinalSemicolon(t);
     }
 
 

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1606,7 +1606,7 @@ var JSHINT = (function() {
                      state.tokens.next.id !== "(end)";
       var blockEnd = checkPunctuator(state.tokens.next, "}");
 
-      if (sameLine && !blockEnd && !(stmt.value === "do" && state.inES6())) {
+      if (sameLine && !blockEnd && !(stmt.value === "do" && state.inES6(true))) {
         errorAt("E058", state.tokens.curr.line, state.tokens.curr.character);
       } else if (!state.option.asi) {
         // If this is the last statement in a block that ends on

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -666,6 +666,10 @@ exports["missing semicolons not influenced by asi"] = function (test) {
     .addError(1, "Missing semicolon.", { code: "E058" })
     .test(code);
 
+  TestRun(test, "do-while as es5+moz")
+    .addError(1, "Missing semicolon.", { code: "E058" })
+    .test(code, { moz: true });
+
   TestRun(test, "do-while as es6")
     .addError(1, "Missing semicolon.", { code: "W033" })
     .test(code, { esversion: 6 });

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -660,6 +660,19 @@ exports["missing semicolons not influenced by asi"] = function (test) {
 
   TestRun(test).test(code, { expr: true, asi: true });
 
+  code = "do {} while (false) var a;";
+
+  TestRun(test, "do-while as es5")
+    .addError(1, "Missing semicolon.", { code: "E058" })
+    .test(code);
+
+  TestRun(test, "do-while as es6")
+    .addError(1, "Missing semicolon.", { code: "W033" })
+    .test(code, { esversion: 6 });
+
+  TestRun(test, "do-while as es6 with asi")
+    .test(code, { esversion: 6, asi: true });
+
   test.done();
 };
 


### PR DESCRIPTION
In ES6, `;` is always inserted after a do-while statement (even if there isn't a line break): - [11.9.1 Rules of Automatic Semicolon Insertion](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-rules-of-automatic-semicolon-insertion).

This pr makes JSHint trigger a warning (which can be disabled using `asi: true`) instead of an error.
