### PR TITLE
[[FIX]] Make the 'freeze' option less strict

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1340,8 +1340,10 @@ var JSHINT = (function() {
       while (!obj.identifier && typeof obj.left === "object")
         obj = obj.left;
 
-      if (obj.identifier && natives.indexOf(obj.value) >= 0)
+      if (obj.identifier && natives.indexOf(obj.value) >= 0 &&
+          state.funct["(scope)"].isPredefined(obj.value)) {
         return obj.value;
+      }
     }
 
     var prototype = walkPrototype(left);

--- a/tests/unit/fixtures/nativeobject.js
+++ b/tests/unit/fixtures/nativeobject.js
@@ -17,3 +17,13 @@ Boolean.prototype = {
 NonArray.prototype.random = function () {
   return 4;
 };
+
+{
+  let Array = {};
+  Array.prototype.method = function() {};
+}
+
+(function() {
+  var Array = 2;
+  Array.prototype.method = function() {};
+}());

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2276,10 +2276,10 @@ exports.freeze = function (test) {
   TestRun(test)
     .addError(3, "Extending prototype of native object: 'Array'.")
     .addError(13, "Extending prototype of native object: 'Boolean'.")
-    .test(src, { freeze: true });
+    .test(src, { freeze: true, esversion: 6 });
 
   TestRun(test)
-    .test(src);
+    .test(src, { esversion: 6 });
 
   test.done();
 };


### PR DESCRIPTION
> Don't warn when the prototype of a local variable
named as a native object is modified.

> Fixes gh-1600