### PR TITLE
[[Fix]] Abort in the presence of invalid config

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -330,7 +330,7 @@ var JSHINT = (function() {
 
   // Produce an error warning.
   function quit(code, line, chr) {
-    var percentage = Math.floor((line / state.lines.length) * 100);
+    var percentage = Math.floor((line / state.lines.length) * 100) || 0;
     var message = messages.errors[code].desc;
 
     throw {

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -333,7 +333,7 @@ var JSHINT = (function() {
     var percentage = Math.floor((token.line / state.lines.length) * 100);
     var message = messages.errors[code].desc;
 
-    var descriptor = {
+    var exception = {
       name: "JSHintError",
       line: token.line,
       character: token.from,
@@ -344,10 +344,10 @@ var JSHINT = (function() {
       b: b
     };
 
-    descriptor.reason = supplant(message, descriptor) + " (" + percentage +
+    exception.reason = supplant(message, exception) + " (" + percentage +
       "% scanned).";
 
-    throw descriptor;
+    throw exception;
   }
 
   function removeIgnoredMessages() {

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -329,14 +329,14 @@ var JSHINT = (function() {
   }
 
   // Produce an error warning.
-  function quit(code, line, chr) {
-    var percentage = Math.floor((line / state.lines.length) * 100) || 0;
+  function quit(code, token) {
+    var percentage = Math.floor((token.line / state.lines.length) * 100);
     var message = messages.errors[code].desc;
 
     throw {
       name: "JSHintError",
-      line: line,
-      character: chr,
+      line: token.line,
+      character: token.from,
       message: message + " (" + percentage + "% scanned).",
       raw: message,
       code: code
@@ -369,8 +369,8 @@ var JSHINT = (function() {
       t = state.tokens.curr;
     }
 
-    l = t.line || 0;
-    ch = t.from || 0;
+    l = t.line;
+    ch = t.from;
 
     w = {
       id: "(error)",
@@ -392,7 +392,7 @@ var JSHINT = (function() {
     removeIgnoredMessages();
 
     if (JSHINT.errors.length >= state.option.maxerr)
-      quit("E043", l, ch);
+      quit("E043", t);
 
     return w;
   }
@@ -829,7 +829,7 @@ var JSHINT = (function() {
       state.tokens.next = lookahead.shift() || lex.token();
 
       if (!state.tokens.next) { // No more tokens left, give up
-        quit("E041", state.tokens.curr.line);
+        quit("E041", state.tokens.curr);
       }
 
       if (state.tokens.next.id === "(end)" || state.tokens.next.id === "(error)") {
@@ -1237,7 +1237,7 @@ var JSHINT = (function() {
       }
 
       if (!left || !right) {
-        quit("E041", state.tokens.curr.line);
+        quit("E041", state.tokens.curr);
       }
 
       if (left.id === "!") {
@@ -2024,7 +2024,9 @@ var JSHINT = (function() {
   // ECMAScript parser
 
   delim("(endline)");
-  delim("(begin)");
+  (function(x) {
+    x.line = x.from = 0;
+  })(delim("(begin)"));
   delim("(end)").reach = true;
   delim("(error)").reach = true;
   delim("}").reach = true;
@@ -2319,7 +2321,7 @@ var JSHINT = (function() {
     this.right = expression(150);
 
     if (!this.right) { // '!' followed by nothing? Give up.
-      quit("E041", this.line || 0);
+      quit("E041", this);
     }
 
     if (bang[this.right.id] === true) {
@@ -2333,7 +2335,7 @@ var JSHINT = (function() {
     this.first = this.right = p;
 
     if (!p) { // 'typeof' followed by nothing? Give up.
-      quit("E041", this.line || 0, this.character || 0);
+      quit("E041", this);
     }
 
     // The `typeof` operator accepts unresolvable references, so the operand
@@ -5178,7 +5180,7 @@ var JSHINT = (function() {
           newOptionObj[optionKey] = o[optionKey];
           if ((optionKey === "esversion" && o[optionKey] === 5) ||
               (optionKey === "es5" && o[optionKey])) {
-            warning("I003");
+            warningAt("I003", 0, 0);
           }
 
           if (optionKeys[x] === "newcap" && o[optionKey] === false)
@@ -5292,7 +5294,7 @@ var JSHINT = (function() {
     });
 
     lex.on("fatal", function(ev) {
-      quit("E041", ev.line, ev.from);
+      quit("E041", ev);
     });
 
     lex.on("Identifier", function(ev) {
@@ -5347,7 +5349,7 @@ var JSHINT = (function() {
       }
 
       if (state.tokens.next.id !== "(end)") {
-        quit("E041", state.tokens.curr.line);
+        quit("E041", state.tokens.curr);
       }
 
       state.funct["(scope)"].unstack();

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -215,7 +215,7 @@ var JSHINT = (function() {
      * `globalstrict` because both `true` and `false` should trigger an error.
      */
     if (state.option.strict === "global" && "globalstrict" in state.option) {
-      error("E059", state.tokens.next, "strict", "globalstrict");
+      quit("E059", state.tokens.next, "strict", "globalstrict");
     }
 
     if (state.option.module) {
@@ -5325,15 +5325,15 @@ var JSHINT = (function() {
       }
     }
 
-    assume();
-
-    // combine the passed globals after we've assumed all our options
-    combine(predefined, g || {});
-
-    //reset values
-    comma.first = true;
-
     try {
+      assume();
+
+      // combine the passed globals after we've assumed all our options
+      combine(predefined, g || {});
+
+      //reset values
+      comma.first = true;
+
       advance();
       switch (state.tokens.next.id) {
       case "{":

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -329,18 +329,25 @@ var JSHINT = (function() {
   }
 
   // Produce an error warning.
-  function quit(code, token) {
+  function quit(code, token, a, b) {
     var percentage = Math.floor((token.line / state.lines.length) * 100);
     var message = messages.errors[code].desc;
 
-    throw {
+    var descriptor = {
       name: "JSHintError",
       line: token.line,
       character: token.from,
       message: message + " (" + percentage + "% scanned).",
       raw: message,
-      code: code
+      code: code,
+      a: a,
+      b: b
     };
+
+    descriptor.reason = supplant(message, descriptor) + " (" + percentage +
+      "% scanned).";
+
+    throw descriptor;
   }
 
   function removeIgnoredMessages() {
@@ -5361,7 +5368,7 @@ var JSHINT = (function() {
           scope     : "(main)",
           raw       : err.raw,
           code      : err.code,
-          reason    : err.message,
+          reason    : err.reason,
           line      : err.line || nt.line,
           character : err.character || nt.from
         }, null);

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1679,13 +1679,45 @@ exports.globalstrict = function (test) {
   // Don't enforce "use strict"; if strict has been explicitly set to false
   TestRun(test).test(code[1], { es3: true, globalstrict: true, strict: false });
 
-  TestRun(test, "co-occurence with 'strict: global'")
-    .addError(0, "Incompatible values for the 'strict' and 'globalstrict' linting options.")
-    .test(code, { strict: "global", globalstrict: false });
+  TestRun(test, "co-occurence with 'strict: global' (via configuration)")
+    .addError(0, "Incompatible values for the 'strict' and 'globalstrict' linting options. (0% scanned).")
+    .test("this is not JavaScript", { strict: "global", globalstrict: false });
 
-  TestRun(test, "co-occurence with 'strict: global'")
-    .addError(0, "Incompatible values for the 'strict' and 'globalstrict' linting options.")
-    .test(code, { strict: "global", globalstrict: true });
+  TestRun(test, "co-occurence with 'strict: global' (via configuration)")
+    .addError(0, "Incompatible values for the 'strict' and 'globalstrict' linting options. (0% scanned).")
+    .test("this is not JavaScript", { strict: "global", globalstrict: true });
+
+  TestRun(test, "co-occurence with 'strict: global' (via in-line directive")
+    .addError(2, "Incompatible values for the 'strict' and 'globalstrict' linting options. (66% scanned).")
+    .test([
+      "",
+      "// jshint globalstrict: true",
+      "this is not JavaScript"
+    ], { strict: "global" });
+
+  TestRun(test, "co-occurence with 'strict: global' (via in-line directive")
+    .addError(2, "Incompatible values for the 'strict' and 'globalstrict' linting options. (66% scanned).")
+    .test([
+      "",
+      "// jshint globalstrict: false",
+      "this is not JavaScript"
+    ], { strict: "global" });
+
+  TestRun(test, "co-occurence with 'strict: global' (via in-line directive")
+    .addError(2, "Incompatible values for the 'strict' and 'globalstrict' linting options. (66% scanned).")
+    .test([
+      "",
+      "// jshint strict: global",
+      "this is not JavaScript"
+    ], { globalstrict: true });
+
+  TestRun(test, "co-occurence with 'strict: global' (via in-line directive")
+    .addError(2, "Incompatible values for the 'strict' and 'globalstrict' linting options. (66% scanned).")
+    .test([
+      "",
+      "// jshint strict: global",
+      "this is not JavaScript"
+    ], { globalstrict: false });
 
   TestRun(test, "co-occurence with internally-set 'strict: gobal' (module code)")
     .test(code, { strict: true, globalstrict: false, esnext: true, module: true });

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -45,6 +45,10 @@ exports.other = function (test) {
     .addError(1, "Unrecoverable syntax error. (100% scanned).")
     .test("typeof;");
 
+  TestRun(test)
+    .addError(1, "Unrecoverable syntax error. (0% scanned).")
+    .test("}");
+
   test.done();
 };
 


### PR DESCRIPTION
> When an invalid set of configuration values is encountered, linting cannot
> continue because the expectations are ambiguous. In this event, report the
> error and cease linting.

Note that the current behavior of JSHint is to issue an error and continue linting. As @nicolo-ribaudo pointed out in gh-2760, a distinct "invalid configuration" error is reported for every inline directive encountered thereafter. In addition, because the program is in an invalid state, it's difficult to say how it will apply linting rules in general. That's why I'm proposing that we halt all linting in this case.

This change is **not** critical. If we want to play it safe while vetting 2.9.1's release candidate, then we can proceed with the existing behavior. The program will fail regardless, so even a patch release could implement this change.  Merging it now simply means that 2.9.1 will be less noisy in response to invalid configurations.

This depends on gh-2749. If we want to be super-conservative, [I wrote another implementation that does *not* depend on that patch](https://github.com/jshint/jshint/compare/jshint:46db923...jugglinmike:767c47d), but I think that version is weaker overall.

Resolves gh-2760