### PR TITLE
[[Fix]] Disallow ambiguous configuration values

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -187,19 +187,30 @@ var JSHINT = (function() {
   }
 
   function assume() {
+    var badESOpt = null;
     processenforceall();
 
     /**
      * TODO: Remove in JSHint 3
      */
-    if (!state.option.esversion && !state.option.moz) {
+    if (state.option.esversion) {
       if (state.option.es3) {
-        state.option.esversion = 3;
+        badESOpt = "es3";
+      } else if (state.option.es5) {
+        badESOpt = "es5";
       } else if (state.option.esnext) {
-        state.option.esversion = 6;
-      } else {
-        state.option.esversion = 5;
+        badESOpt = "esnext";
       }
+
+      if (badESOpt) {
+        quit("E059", state.tokens.next, "esversion", badESOpt);
+      }
+
+      state.esVersion = state.option.esversion;
+    } else if (state.option.es3) {
+      state.esVersion = 3;
+    } else if (state.option.esnext) {
+      state.esVersion = 6;
     }
 
     if (state.inES5()) {
@@ -673,31 +684,6 @@ var JSHINT = (function() {
           if (!hasParsedCode(state.funct)) {
             error("E055", state.tokens.next, "module");
           }
-        }
-
-        /**
-         * TODO: Remove in JSHint 3
-         */
-        var esversions = {
-          es3   : 3,
-          es5   : 5,
-          esnext: 6
-        };
-        if (_.has(esversions, key)) {
-          switch (val) {
-          case "true":
-            state.option.moz = false;
-            state.option.esversion = esversions[key];
-            break;
-          case "false":
-            if (!state.option.moz) {
-              state.option.esversion = 5;
-            }
-            break;
-          default:
-            error("E002", nt);
-          }
-          return;
         }
 
         if (key === "esversion") {

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -193,24 +193,9 @@ var JSHINT = (function() {
     /**
      * TODO: Remove in JSHint 3
      */
-    if (state.option.esversion) {
-      if (state.option.es3) {
-        badESOpt = "es3";
-      } else if (state.option.es5) {
-        badESOpt = "es5";
-      } else if (state.option.esnext) {
-        badESOpt = "esnext";
-      }
-
-      if (badESOpt) {
-        quit("E059", state.tokens.next, "esversion", badESOpt);
-      }
-
-      state.esVersion = state.option.esversion;
-    } else if (state.option.es3) {
-      state.esVersion = 3;
-    } else if (state.option.esnext) {
-      state.esVersion = 6;
+    badESOpt = state.inferEsVersion();
+    if (badESOpt) {
+      quit("E059", state.tokens.next, "esversion", badESOpt);
     }
 
     if (state.inES5()) {

--- a/src/state.js
+++ b/src/state.js
@@ -26,20 +26,20 @@ var state = {
    */
   inES6: function(strict) {
     if (strict) {
-      return this.option.esversion === 6;
+      return this.esVersion === 6;
     }
-    return this.option.moz || this.option.esversion >= 6;
+    return this.option.moz || this.esVersion >= 6;
   },
 
   /**
    * @param {boolean} strict - When `true`, return `true` only when
-   *                           esversion is exactly 5
+   *                           esVersion is exactly 5
    */
   inES5: function(strict) {
     if (strict) {
-      return (!this.option.esversion || this.option.esversion === 5) && !this.option.moz;
+      return (!this.esVersion || this.esVersion === 5) && !this.option.moz;
     }
-    return !this.option.esversion || this.option.esversion >= 5 || this.option.moz;
+    return !this.esVersion || this.esVersion >= 5 || this.option.moz;
   },
 
 
@@ -51,6 +51,7 @@ var state = {
     };
 
     this.option = {};
+    this.esVersion = 5;
     this.funct = null;
     this.ignored = {};
     this.directive = {};

--- a/src/state.js
+++ b/src/state.js
@@ -42,6 +42,41 @@ var state = {
     return !this.esVersion || this.esVersion >= 5 || this.option.moz;
   },
 
+  /**
+   * Determine the current version of the input language by inspecting the
+   * value of all ECMAScript-version-related options. This logic is necessary
+   * to ensure compatibility with deprecated options `es3`, `es5`, and
+   * `esnext`, and it may be drastically simplified when those options are
+   * removed.
+   *
+   * @returns {string|null} - the name of any incompatible option detected,
+   *                          `null` otherwise
+   */
+  inferEsVersion: function() {
+    var badOpt = null;
+
+    if (this.option.esversion) {
+      if (this.option.es3) {
+        badOpt = "es3";
+      } else if (this.option.es5) {
+        badOpt = "es5";
+      } else if (this.option.esnext) {
+        badOpt = "esnext";
+      }
+
+      if (badOpt) {
+        return badOpt;
+      }
+
+      this.esVersion = this.option.esversion;
+    } else if (this.option.es3) {
+      this.esVersion = 3;
+    } else if (this.option.esnext) {
+      this.esVersion = 6;
+    }
+
+    return null;
+  },
 
   reset: function() {
     this.tokens = {

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -3446,22 +3446,44 @@ exports.esversion = function(test) {
     .test(arrayComprehension, { esnext: true });
 
 
-  TestRun(test, "precedence over `es3`") // TODO: Remove in JSHint 3
+  TestRun(test, "incompatibility with `es3`") // TODO: Remove in JSHint 3
+    .addError(0, "Incompatible values for the 'esversion' and 'es3' linting options. (0% scanned).")
     .test(es6code, { esversion: 6, es3: true });
 
-  TestRun(test, "precedence over `es5`") // TODO: Remove in JSHint 3
+  TestRun(test, "incompatibility with `es5`") // TODO: Remove in JSHint 3
     .addError(0, "ES5 option is now set per default")
+    .addError(0, "Incompatible values for the 'esversion' and 'es5' linting options. (0% scanned).")
     .test(es6code, { esversion: 6, es5: true });
 
-  TestRun(test, "precedence over `esnext`") // TODO: Remove in JSHint 3
-    .addError(2, "'computed property names' is only available in ES6 (use 'esversion: 6').")
+  TestRun(test, "incompatibility with `esnext`") // TODO: Remove in JSHint 3
+    .addError(0, "Incompatible values for the 'esversion' and 'esnext' linting options. (0% scanned).")
     .test(es6code, { esversion: 3, esnext: true });
+
+  TestRun(test, "imcompatible option specified in-line")
+    .addError(2, "Incompatible values for the 'esversion' and 'es3' linting options. (66% scanned).")
+    .test(["", "// jshint esversion: 3", ""], { es3: true });
+
+  TestRun(test, "incompatible option specified in-line")
+    .addError(2, "Incompatible values for the 'esversion' and 'es3' linting options. (66% scanned).")
+    .test(["", "// jshint es3: true", ""], { esversion: 3 });
+
+  TestRun(test, "compatible option specified in-line")
+    .addError(3, "'class' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
+    .test(["", "// jshint esversion: 3", "class A {}"], { esversion: 3 });
+
+  TestRun(test, "compatible option specified in-line")
+    .addError(3, "'class' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
+    .test(["", "// jshint esversion: 3", "class A {}"], { esversion: 6 });
+
+  TestRun(test, "compatible option specified in-line")
+    .test(["", "// jshint esversion: 6", "class A {}"], { esversion: 3 });
 
   var code2 = [ // TODO: Remove in JSHint 3
     "/* jshint esversion: 3, esnext: true */"
   ].concat(es6code);
 
-  TestRun(test, "the last has the precedence (inline configuration)") // TODO: Remove in JSHint 3
+  TestRun(test, "incompatible options specified in-line") // TODO: Remove in JSHint 3
+    .addError(1, "Incompatible values for the 'esversion' and 'esnext' linting options. (25% scanned).")
     .test(code2);
 
   var code3 = [


### PR DESCRIPTION
While working on gh-2801, @rwaldron and I identified another opportunity to
disallow ambiguous configurations. As of this writing, the `esversion` option
is not yet available in any stable release, which means that we are free to
introduce hard failures in its interpretation. This will not be possible
following the next stable release, and that is why we are considering it during
the release candidate phase.

@rwaldron: This required more refactoring than I expected, but (as I tried to
explain in the commit message) I think it's necessary. During your review,
please pay close attention to the handling of the `moz` option in particular.
As you know, the codebase has always made surprising assumptions about that
option. I believe the simplifications in this patch are all valid, but I would
especially appreciate your verification of that detail.

I want to be conservative with the changes we introduce to a release candidate;
do you this is warranted given the circumstances? We would of course vet this
with the recent fixes in another RC.