### PR TITLE
Improve w120

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3570,7 +3570,10 @@ var JSHINT = (function() {
 
       if (state.tokens.next.id === "=") {
         advance("=");
-        if (!prefix && peek(0).id === "=" && state.tokens.next.identifier) {
+        if (!prefix && peek(0).id === "=" && state.tokens.next.identifier &&
+          state.funct["(scope)"].has(state.tokens.next.value) &&
+          !state.funct["(scope)"].block.has(state.tokens.next.value)
+          ) {
           warning("W120", state.tokens.next, state.tokens.next.value);
         }
         var id = state.tokens.prev;
@@ -3677,12 +3680,12 @@ var JSHINT = (function() {
         state.nameStack.set(state.tokens.curr);
 
         advance("=");
-        if (peek(0).id === "=" && state.tokens.next.identifier) {
-          if (!prefix && report &&
-              !state.funct["(params)"] ||
-              state.funct["(params)"].indexOf(state.tokens.next.value) === -1) {
-            warning("W120", state.tokens.next, state.tokens.next.value);
-          }
+        if (peek(0).id === "=" && state.tokens.next.identifier &&
+          !prefix && report &&
+          state.funct["(scope)"].has(state.tokens.next.value) &&
+          !state.funct["(scope)"].funct.has(state.tokens.next.value)
+          ) {
+          warning("W120", state.tokens.next, state.tokens.next.value);
         }
         var id = state.tokens.prev;
         // don't accept `in` in expression if prefix is used for ForIn/Of loop.

--- a/src/messages.js
+++ b/src/messages.js
@@ -200,7 +200,7 @@ var warnings = {
   W117: "'{a}' is not defined.",
   W118: "'{a}' is only available in Mozilla JavaScript extensions (use moz option).",
   W119: "'{a}' is only available in ES{b} (use 'esversion: {b}').",
-  W120: "You might be leaking a variable ({a}) here.",
+  W120: "'{a}' has been declared in a higher scope. Did you intend to create a new binding?",
   W121: "Extending prototype of native object: '{a}'.",
   W122: "Invalid typeof value '{a}'",
   W123: "'{a}' is already defined in outer scope.",

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -822,6 +822,10 @@ var scopeManager = function(state, predefined, exported, declared) {
         _current["(usages)"][labelName]["(modified)"].push(token);
       },
 
+      has: function(labelName) {
+        return !!_current["(labels)"][labelName];
+      },
+
       /**
        * Adds a new variable
        */

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1024,7 +1024,6 @@ exports.testConstModification = function (test) {
       .addError(6, "Attempting to override 'a' which is a constant.")
       .addError(7, "Attempting to override 'a' which is a constant.")
       .addError(8, "Attempting to override 'a' which is a constant.")
-      .addError(8, "You might be leaking a variable (a) here.")
       .addError(53, "Missing '()' invoking a constructor.")
       .addError(55, "Attempting to override 'f' which is a constant.")
       .test(src, {
@@ -1465,16 +1464,10 @@ exports.testPotentialVariableLeak = function (test) {
 
   // Real Error
   TestRun(test)
-    .addError(4, "You might be leaking a variable (b) here.")
-    .addError(5, "You might be leaking a variable (d) here.")
-    .addError(6, "You might be leaking a variable (f) here.")
-    .addError(8, "You might be leaking a variable (h) here.")
-    .addError(9, "You might be leaking a variable (j) here.")
-    .addError(12, "You might be leaking a variable (g) here.")
-    .addError(13, "You might be leaking a variable (k) here.")
-    .addError(14, "You might be leaking a variable (l) here.")
-    .addError(18, "You might be leaking a variable (p) here.")
-    .addError(20, "You might be leaking a variable (r) here.")
+    .addError(8, "'h' has been declared in a higher scope. Did you intend to create a new binding?")
+    .addError(9, "'j' has been declared in a higher scope. Did you intend to create a new binding?")
+    .addError(13, "'k' has been declared in a higher scope. Did you intend to create a new binding?")
+    .addError(14, "'l' has been declared in a higher scope. Did you intend to create a new binding?")
     .test(a, { esnext: true });
 
   // False Positive

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1465,9 +1465,16 @@ exports.testPotentialVariableLeak = function (test) {
 
   // Real Error
   TestRun(test)
-    .addError(2, "You might be leaking a variable (b) here.")
-    .addError(3, "You might be leaking a variable (d) here.")
-    .addError(4, "You might be leaking a variable (f) here.")
+    .addError(4, "You might be leaking a variable (b) here.")
+    .addError(5, "You might be leaking a variable (d) here.")
+    .addError(6, "You might be leaking a variable (f) here.")
+    .addError(8, "You might be leaking a variable (h) here.")
+    .addError(9, "You might be leaking a variable (j) here.")
+    .addError(12, "You might be leaking a variable (g) here.")
+    .addError(13, "You might be leaking a variable (k) here.")
+    .addError(14, "You might be leaking a variable (l) here.")
+    .addError(18, "You might be leaking a variable (p) here.")
+    .addError(20, "You might be leaking a variable (r) here.")
     .test(a, { esnext: true });
 
   // False Positive

--- a/tests/unit/fixtures/leak.js
+++ b/tests/unit/fixtures/leak.js
@@ -1,7 +1,23 @@
+var h;
+let j;
 function test() {
   var a = b = 1;
   const c = d = 2;
   let e = f = 3;
+
+  var g = h = 4;
+  let i = j = 5;
+  let k, l;
+  {
+    var m = g = 6;
+    const n = k = 6;
+    let o = l = 7;
+  }
+
+  var p;
+  var q = p = 8;
+  let r;
+  let s = r = 9;
 }
 
 test();

--- a/tests/unit/fixtures/leak.js
+++ b/tests/unit/fixtures/leak.js
@@ -14,6 +14,9 @@ function test() {
     let o = l = 7;
   }
 
+  // Although developers who use this form may expect that the assignment
+  // expressions create new bindings, the misunderstanding has no effect on
+  // program execution, so no warning is necessary.
   var p;
   var q = p = 8;
   let r;


### PR DESCRIPTION
I've split the patch into two commits to more clearly demonstrate the effect of
the change. The first commit simply adds tests (some of which "prove" incorrect
functionality). The second commit fixes the implementation, and updates the
test only by removing the invalid assertions and updating the expected message
for the valid assertions.

(Personally, I think this would best be avoided by disallowing variable
shadowing via `shadow: outer`, but that is a subjective decision that doesn't
help users contributing to codebases that disagree.)

This resolves gh-1788.

Commit message:

> Warning 120 (message "You might be leaking a variable ({a}) here.") is
> triggered when a binding statement contains an assignment expression whose left
> hand side is an identifier. For instance, the assignment to `x` triggers the
> warning in each of the following three statements:
> 
>     var v = x = null;
>     let l = x = null;
>     const c = x = null;
> 
> In these contexts, it is possible that the author mistakenly believes that a
> new binding for the `x` identifier is being created. Warning 120 was presumably
> implemented to help developers avoid unintentionally creating global
> bindings.
> 
> As implemented, JSHint does not consider whether the binding in question has
> already been created, so the following code also triggers the warning (despite
> being safe):
> 
>     var y;
>     var v2 = y = null;
> 
> JSHint maintains environment records for each scope, so this problem could be
> resolved by referencing the containing scope(s). Such a solution would not
> address a more fundamental problem: the warning is mostly duplicative of W117
> ("{a} is not defined."). Users are already alerted of the "leakage" when the
> `undef` option is set. JSHint already operates as expected for the following
> input, issuing W117 for line 2 but *not* for line 4:
> 
>     // jshint undef: true, -W120
>     var v = x = null;
>     var y;
>     var v2 = y = null;
> 
> W117 is preferable for two reasons:
> 
> 1. it is much more robust, as it covers a wide array of additional instances
>    where global bindings are being created
> 2. it is controlled by a dedicated linting option that is human-readable and
>    well documented
> 
> Although this makes the warning a good candidate for outright removal, the
> original intention suggests a special case that W120 is uniquely positioned to
> address: re-assignment of bindings in a "higher" scope. For example:
> 
>     let v1 = 0;
>     {
>       let v2 = v1 = 1;
>     }
> 
> Just as in previous examples, the author of this code may have mistakenly
> assumed that the second `let` statement created a new `v1` binding and that
> each instance of the `v1` identifier referenced a unique block-scoped binding.
> This is incorrect for the same reasons, and the mistake has similar
> implications for program correctness.
> 
> However, unlike previous examples, this mistake would *not* be
> identified by `undef`/W117 because `v1` is defined.
> 
> Refactoring W120 to address this concern is backwards compatabile with
> previous versions of JSHint because this is a special case of the
> previously-implemented behavior (the overall effect is a relaxing of
> linting constraints).
> 
> Re-write the conditions that trigger warning W120 to be limited to only
> those cases where the nested assignment expression may be misinterpreted
> as shadowing a binding in a higher scope. Update the warning message to
> describe the more specific issue.