### PR TITLE
[[FIX]] Do not require global USD for any envs

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -248,9 +248,6 @@ var JSHINT = (function() {
 
     if (state.option.phantom) {
       combine(predefined, vars.phantom);
-      if (state.option.strict === true) {
-        state.option.strict = "global";
-      }
     }
 
     if (state.option.prototypejs) {
@@ -260,9 +257,6 @@ var JSHINT = (function() {
     if (state.option.node) {
       combine(predefined, vars.node);
       combine(predefined, vars.typed);
-      if (state.option.strict === true) {
-        state.option.strict = "global";
-      }
     }
 
     if (state.option.devel) {
@@ -282,9 +276,6 @@ var JSHINT = (function() {
       combine(predefined, vars.browser);
       combine(predefined, vars.typed);
       combine(predefined, vars.browserify);
-      if (state.option.strict === true) {
-        state.option.strict = "global";
-      }
     }
 
     if (state.option.nonstandard) {
@@ -651,7 +642,6 @@ var JSHINT = (function() {
           case "false":
             state.option.strict = false;
             break;
-          case "func":
           case "global":
           case "implied":
             state.option.strict = val;

--- a/src/options.js
+++ b/src/options.js
@@ -885,13 +885,14 @@ exports.val = {
    * them to produce errors.  It also fixes mistakes that made it difficult
    * for the JavaScript engines to perform certain optimizations.
    *
-   * - "func"    - there must be a `"use strict";` directive at function level
    * - "global"  - there must be a `"use strict";` directive at global level
    * - "implied" - lint the code as if there is the `"use strict";` directive
    * - false     - disable warnings about strict mode
-   * - true      - same as `"func"`, but environment options have precedence over
-   *               this (e.g. `node`, `module`, `browserify` and `phantomjs` can
-   *               set `strict: global`)
+   * - true      - there must be a `"use strict";` directive at function level;
+   *               this is preferable for scripts intended to be loaded in web
+   *               browsers directly because enabling strict mode globally
+   *               could adversely effect other scripts running on the same
+   *               page
    */
   strict      : true,
 

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -89,10 +89,6 @@ exports.node = function (test) {
   TestRun(test, "gh-2657")
     .test("'use strict';var a;", { node: true });
 
-  // Implied `strict: global` if `strict` is `true`
-  JSHINT("", { node: true, strict: true });
-  test.strictEqual(JSHINT.data().options.strict, "global");
-
   test.done();
 };
 


### PR DESCRIPTION
In web browsers, enabling ES5 "strict mode" at a global level effects
all scripts executed in the same context. For this reason, the `strict`
option was originally implemented to enforce the directive's use in
function scope only.  However: the Browserify, Node.js, and PhantomJS
environments do not suffer from this problem.

Recent improvements to the option's behavior included making JSHint's
interpretation of `strict: true` to be contextual: in those environments
where a global `use strict` directive is "safe," enabling the option
would require the global directive.

Although this change is an improvement (because it encourages more code
to be written in strict mode), it is backwards incompatible. Moreover,
the option's documentation in JSHint 2.8.0 explicitly described the
sub-optimal behavior:

> *Note:* This option enables strict mode for function scope only. It
> *prohibits* the global scoped strict mode because it might break
> third-party widgets on your page. If you really want to use global
> strict mode, see the *globalstrict* option.

For this reason, `strict: true` should continue to trigger the "legacy"
behavior. The change brings that configuration completely in-line with
the recently-introduced `strict: func`, and because `strict: func` has
not been released in a stable version, it can safely be removed.

@lukeapage @nicolo-ribaudo This effectively reverts gh-2576, so I'd appreciate if either of you could weigh in--I want to make sure I'm not missing something important!