### PR TITLE
[[CHORE]] Update JSHint

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "coveralls":                      "2.11.x",
     "istanbul":                       "0.3.x",
     "jscs":                           "1.11.x",
-    "jshint":                         "2.6.x",
+    "jshint":                         "2.9.1",
     "mock-stdin":                     "0.3.x",
     "nodeunit":                       "0.9.x",
     "phantom":                        "~0.7.2",

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -29,7 +29,6 @@
  */
 
 /*jshint quotmark:double */
-/*global console:true */
 /*exported console */
 
 var _            = require("lodash");


### PR DESCRIPTION
The latest stable version of JSHint revealed an erroneous configuration:
when the `console` identifier is listed as a global variable, JSHint
creates an internal "label" to track references to that binding. The
local `console` variable in `jshint.js` shadows this global reference,
meaning the global binding is never referenced.

Lint the in-development codebase with the latest stable version of
JSHint. Update the configuration to avoid the new (valid) warning.

Supersedes gh-2810.