### PR TITLE
[[FIX]] Do not fail on valid configurations

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -215,9 +215,6 @@ var JSHINT = (function() {
     }
 
     if (state.option.module) {
-      if (state.option.strict === true) {
-        state.option.strict = "global";
-      }
       /**
        * TODO: Extend this restriction to *all* ES6-specific options.
        */
@@ -300,10 +297,6 @@ var JSHINT = (function() {
 
     if (state.option.wsh) {
       combine(predefined, vars.wsh);
-    }
-
-    if (state.option.globalstrict && state.option.strict !== false) {
-      state.option.strict = "global";
     }
 
     if (state.option.yui) {
@@ -1647,8 +1640,7 @@ var JSHINT = (function() {
     if (r && !(r.identifier && r.value === "function") &&
         !(r.type === "(punctuator)" && r.left &&
           r.left.identifier && r.left.value === "function")) {
-      if (!state.isStrict() &&
-          state.option.strict === "global") {
+      if (!state.isStrict() && state.stmtMissingStrict()) {
         warning("E007");
       }
     }
@@ -5296,10 +5288,7 @@ var JSHINT = (function() {
         directives();
 
         if (state.directive["use strict"]) {
-          if (state.option.strict !== "global" &&
-              !((state.option.strict === true || !state.option.strict) &&
-                (state.option.globalstrict || state.option.module || state.option.node ||
-                 state.option.phantom || state.option.browserify))) {
+          if (!state.allowsGlobalUsd()) {
             warning("W097", state.tokens.prev);
           }
         }

--- a/src/state.js
+++ b/src/state.js
@@ -14,6 +14,42 @@ var state = {
       this.option.module || this.option.strict === "implied";
   },
 
+  /**
+   * Determine if the current state warrants a warning for statements outside
+   * of strict mode code.
+   *
+   * While emitting warnings based on function scope would be more intuitive
+   * (and less noisy), JSHint observes statement-based semantics in order to
+   * preserve legacy behavior.
+   *
+   * This method does not take the state of the parser into account, making no
+   * distinction between global code and function code. Because the "missing
+   * 'use strict'" warning is *also* reported at function boundaries, this
+   * function interprets `strict` option values `true` and `undefined` as
+   * equivalent.
+   */
+  stmtMissingStrict: function() {
+    if (this.option.strict === "global") {
+      return true;
+    }
+
+    if (this.option.strict === false) {
+      return false;
+    }
+
+    if (this.option.globalstrict) {
+      return true;
+    }
+
+    return false;
+  },
+
+  allowsGlobalUsd: function() {
+    return this.option.strict === "global" || this.option.globalstrict ||
+      this.option.module || this.option.node || this.option.phantom ||
+      this.option.browserify;
+  },
+
   // Assumption: chronologically ES3 < ES5 < ES6 < Moz
 
   inMoz: function() {

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1905,6 +1905,22 @@ exports.globalstrict = function (test) {
   TestRun(test, "gh-2661")
     .test("'use strict';", { strict: false, globalstrict: true });
 
+  TestRun(test, "gh-2836 (1)")
+    .test([
+      "// jshint globalstrict: true",
+      // The specific option set by the following directive is not relevant.
+      // Any option set by another directive will trigger the regression.
+      "// jshint undef: true"
+    ]);
+
+  TestRun(test, "gh-2836 (2)")
+    .test([
+      "// jshint strict: true, globalstrict: true",
+      // The specific option set by the following directive is not relevant.
+      // Any option set by another directive will trigger the regression.
+      "// jshint undef: true"
+    ]);
+
   test.done();
 };
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1772,6 +1772,46 @@ exports.strictEnvs = function (test) {
   test.done();
 };
 
+/**
+ * The following test asserts sub-optimal behavior.
+ *
+ * Through the `strict` and `globalstrict` options, JSHint can be configured to
+ * issue warnings when code is not in strict mode. Historically, JSHint has
+ * issued these warnings on a per-statement basis in global code, leading to
+ * "noisy" output through the repeated reporting of the missing directive.
+ */
+exports.strictNoise = function (test) {
+  TestRun(test, "global scope")
+    .addError(1, "Missing \"use strict\" statement.")
+    .addError(2, "Missing \"use strict\" statement.")
+    .test([
+      "void 0;",
+      "void 0;",
+    ], { strict: true, globalstrict: true });
+
+  TestRun(test, "function scope")
+    .addError(2, "Missing \"use strict\" statement.")
+    .test([
+      "(function() {",
+      "  void 0;",
+      "  void 0;",
+      "}());",
+    ], { strict: true });
+
+  TestRun(test, "function scope")
+    .addError(2, "Missing \"use strict\" statement.")
+    .test([
+      "(function() {",
+      "  (function() {",
+      "    void 0;",
+      "    void 0;",
+      "  }());",
+      "}());",
+    ], { strict: true });
+
+  test.done();
+};
+
 /** Option `globalstrict` allows you to use global "use strict"; */
 exports.globalstrict = function (test) {
   var code = [


### PR DESCRIPTION
In addressing gh-2836, I ran across some inefficient/noisy behavior. Rather
than address that as part of the bug fix, I'm going to follow up with a
separate commit. For now, I'm submitting a separate commit to assert the
undesirable behavior, just to document that it isn't a regression introduced by
my bug fix.

Resolves gh-2836.