### PR TITLE
[[FIX]] Report character position for camelcase errors

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -47,7 +47,7 @@ exports.register = function(linter) {
     if (data.name.replace(/^_+|_+$/g, "").indexOf("_") > -1 && !data.name.match(/^[A-Z0-9_]*$/)) {
       linter.warn("W106", {
         line: data.line,
-        char: data.from,
+        char: data.char,
         data: [ data.name ]
       });
     }

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -435,11 +435,11 @@ exports.testCamelcase = function (test) {
 
   // Require identifiers in camel case if camelcase is true
   TestRun(test)
-    .addError(5, "Identifier 'Foo_bar' is not in camel case.")
-    .addError(5, "Identifier 'test_me' is not in camel case.")
-    .addError(6, "Identifier 'test_me' is not in camel case.")
-    .addError(6, "Identifier 'test_me' is not in camel case.")
-    .addError(13, "Identifier 'test_1' is not in camel case.")
+    .addError(5, "Identifier 'Foo_bar' is not in camel case.", {character: 17})
+    .addError(5, "Identifier 'test_me' is not in camel case.", {character: 25})
+    .addError(6, "Identifier 'test_me' is not in camel case.", {character: 15})
+    .addError(6, "Identifier 'test_me' is not in camel case.", {character: 25})
+    .addError(13, "Identifier 'test_1' is not in camel case.", {character: 26})
     .test(source, { es3: true, camelcase: true });
 
 


### PR DESCRIPTION
Character positions were not being reported when camelcase errors were detected.
This fix will now report the character position correctly.

Fixes #2845