### PR TITLE
Save rhino global object `this` in `global` variable.

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -40,7 +40,7 @@ module.exports = function(target, done) {
     ];
 
     if (target === "rhino") {
-      wrapped.splice(0, 0, "#!/usr/bin/env rhino", "var window = {};");
+      wrapped.splice(0, 0, "#!/usr/bin/env rhino", "var global = this;");
     }
 
     done(null, version, wrapped.join("\n"));


### PR DESCRIPTION
This is a rebase of https://github.com/segrey/jshint/commit/1824d740c2d6656e663de43cf6d95fc8a642c796 to latest master.

This fixes the rhino build, but does not replace the CLI -- the only jshint-rhino.js package invoked the CLI, but since 2.6.3 the CLI has been factored out.  Filed #2852 for this issue.

Fixes: #2308