### PR TITLE
Remove deprecated es5 and esnext options

### DIFF
--- a/examples/.jshintrc
+++ b/examples/.jshintrc
@@ -42,8 +42,7 @@
     "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
     "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
     "eqnull"        : false,     // true: Tolerate use of `== null`
-    "es5"           : true,      // true: Allow ES5 syntax (ex: getters and setters)
-    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "esversion"     : 5,         // {int} Specify the ECMAScript version to which the code must adhere. 
     "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
                                  // (ex: `for each`, multiple try/catch, function expression…)
     "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`


### PR DESCRIPTION
This removes the deprecated `es5` and `esnext` options from the example file.