### PR TITLE
[[FIX]] Emit correct token value from "module" API

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -1776,7 +1776,7 @@ Lexer.prototype = {
         this.triggerAsync("Identifier", {
           line: this.line,
           char: this.char,
-          from: this.form,
+          from: this.from,
           name: token.value,
           raw_name: token.text,
           isProperty: state.tokens.curr.id === "."

--- a/tests/unit/module-api.js
+++ b/tests/unit/module-api.js
@@ -1,0 +1,69 @@
+/**
+ * The JSHint API does not allow for un-registering "modules", and the Nodeunit
+ * API does not support per-group setup/teardown logic. These deficiencies
+ * necessitate additional logic in the test suite in order to test the JSHint
+ * "module" API hygienically:
+ *
+ * - Only one JSHint "module" should be added at any time, regardless of the
+ *   number of tests executed
+ * - No JSHint "module" should run following the completion of this group of
+ *   tests
+ */
+"use strict";
+
+var JSHINT  = require("../..").JSHINT;
+var TestRun = require("../helpers/testhelper").setup.testRun;
+
+var firstRun = true;
+var testContext = null;
+var suiteSetup = function (done) {
+  JSHINT.addModule(function (linter) {
+    if (!testContext) {
+      return;
+    }
+    testContext.onAddModule(linter);
+  });
+
+  done();
+};
+exports.setUp = function (done) {
+  testContext = this;
+
+  if (firstRun) {
+    firstRun = false;
+    suiteSetup(done);
+    return;
+  }
+
+  done();
+};
+exports.tearDown = function (done) {
+  testContext = null;
+  done();
+};
+
+exports["test for GH-1103"] = function (test) {
+  var code = [ "var ohnoes = 42;" ];
+
+  var run = TestRun(test);
+
+  var patch = true;
+
+  this.onAddModule = function (linter) {
+    if (!patch) {
+      return;
+    }
+    patch = false;
+
+    var ohnoes = "oh noes";
+    Array.prototype.ohnoes = function () {
+      linter.warn("E024", { line: 1, char: 1, data: [ ohnoes += "!" ] });
+    };
+  };
+
+  run.test(code);
+
+  test.done();
+
+  delete Array.prototype.ohnoes;
+};

--- a/tests/unit/module-api.js
+++ b/tests/unit/module-api.js
@@ -67,3 +67,42 @@ exports["test for GH-1103"] = function (test) {
 
   delete Array.prototype.ohnoes;
 };
+
+exports.identifiers = function (test) {
+  var src = [
+    "var x = {",
+    "  y: 23,",
+    "  'z': 45",
+    "};"
+  ];
+  var expected = [
+    {
+      line: 1,
+      char: 6,
+      from: 5,
+      name: 'x',
+      raw_name: 'x',
+      isProperty: false
+    },
+    {
+      line: 2,
+      char: 4,
+      from: 3,
+      name: 'y',
+      raw_name: 'y',
+      isProperty: false
+    }
+  ];
+  var actual = [];
+  this.onAddModule = function (linter) {
+    linter.on("Identifier", function(x) {
+      actual.push(x);
+    });
+  };
+
+  JSHINT(src);
+
+  test.deepEqual(actual, expected);
+
+  test.done();
+};

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -6161,32 +6161,6 @@ exports["test for GH-1089"] = function (test) {
   test.done();
 };
 
-exports["test for GH-1103"] = function (test) {
-  var code = [ "var ohnoes = 42;" ];
-
-  var run = TestRun(test);
-
-  var patch = true;
-
-  JSHINT.addModule(function (linter) {
-    if (!patch) {
-      return;
-    }
-    patch = false;
-
-    var ohnoes = "oh noes";
-    Array.prototype.ohnoes = function () {
-      linter.warn("E024", { line: 1, char: 1, data: [ ohnoes += "!" ] });
-    };
-  });
-
-  run.test(code);
-
-  test.done();
-
-  delete Array.prototype.ohnoes;
-};
-
 exports["test for GH-1105"] = function (test) {
   var code = [
     "while (true) {",


### PR DESCRIPTION
I found this bug while reviewing gh-2846. The fix there is valid, but it did
not address an underlying problem with the little-known "module" API.

Unfortunately, neither JSHint nor NodeUnit are built to support testing this
behavior effectively. As noted in the first (test-only) commit, I've factored
the only test for the API into its own file and encapsulated necessary
setup/teardown logic there.

The second commit addresses the bug.

As an aside: I'm not convinced that this API is useful (or used!), but it ought
to at least be correct.

