### PR TITLE
[[FEAT]] Added preset variables for protractor

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -283,6 +283,10 @@ var JSHINT = (function() {
       combine(predefined, vars.jasmine);
     }
 
+    if (state.option.protractor) {
+      combine(predefined, vars.protractor);
+    }
+
     if (state.option.jquery) {
       combine(predefined, vars.jquery);
     }

--- a/src/vars.js
+++ b/src/vars.js
@@ -722,3 +722,14 @@ exports.jasmine = {
   fit         : false,
   pending     : false
 };
+
+exports.protractor = {
+  "protractor" : false,
+  "browser"    : false,
+  "by"         : false,
+  "element"    : false,
+  "it"         : false,
+  "describe"   : false,
+  "beforeEach" : false,
+  "afterEach"  : false
+};


### PR DESCRIPTION
With other presets I expected that there would be a protractor preset
available as well. Now I can simply state in the .jshintrc `"protractor":true`
so it won't trigger errors on the default functions anymore.