### PR TITLE
[[FIX]] Reserve `await` keyword in ES6 module code

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -134,22 +134,28 @@ var JSHINT = (function() {
     }
     var meta = token.meta;
 
-    if (meta && meta.isFutureReservedWord && state.inES5()) {
-      // ES3 FutureReservedWord in an ES5 environment.
-      if (!meta.es5) {
+    if (meta && meta.isFutureReservedWord) {
+      if (meta.moduleOnly && !state.option.module) {
         return false;
       }
 
-      // Some ES5 FutureReservedWord identifiers are active only
-      // within a strict mode environment.
-      if (meta.strictOnly) {
-        if (!state.option.strict && !state.isStrict()) {
+      if (state.inES5()) {
+        // ES3 FutureReservedWord in an ES5 environment.
+        if (!meta.es5) {
           return false;
         }
-      }
 
-      if (token.isProperty) {
-        return false;
+        // Some ES5 FutureReservedWord identifiers are active only
+        // within a strict mode environment.
+        if (meta.strictOnly) {
+          if (!state.option.strict && !state.isStrict()) {
+            return false;
+          }
+        }
+
+        if (token.isProperty) {
+          return false;
+        }
       }
     }
 
@@ -4694,6 +4700,7 @@ var JSHINT = (function() {
   // Future Reserved Words
 
   FutureReservedWord("abstract");
+  FutureReservedWord("await", { es5: true, moduleOnly: true });
   FutureReservedWord("boolean");
   FutureReservedWord("byte");
   FutureReservedWord("char");

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -3511,6 +3511,43 @@ exports.module.newcap = function(test) {
   test.done();
 };
 
+exports.module.await = function(test) {
+  var allPositions = [
+    "var await;",
+    "function await() {}",
+    "await: while (false) {}",
+    "void { await: null };",
+    "void {}.await;"
+  ];
+
+  TestRun(test)
+    .test(allPositions, { esversion: 3 });
+  TestRun(test)
+    .test(allPositions);
+  TestRun(test)
+    .test(allPositions, { esversion: 6 });
+
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'await' (a reserved word).")
+    .test("var await;", { esversion: 6, module: true });
+
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'await' (a reserved word).")
+    .test("function await() {}", { esversion: 6, module: true });
+
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw 'await' (a reserved word).")
+    .test("await: while (false) {}", { esversion: 6, module: true });
+
+  TestRun(test)
+    .test([
+      "void { await: null };",
+      "void {}.await;"
+    ], { esversion: 6, module: true });
+
+  test.done();
+};
+
 exports.esversion = function(test) {
   var code = [
     "// jshint esversion: 3",


### PR DESCRIPTION
(Little noisier than I would like... Use [`?w=1` to see a simplified changeset for the `isReserved` function](https://github.com/jshint/jshint/pull/2879/files?w=1).)

From the ECMAScript 2015 specification:

> The following tokens are reserved for used as keywords in future
> language extensions.
>
>     Syntax
>         FutureReservedWord::
>             enum
>             await
>
> await is only treated as a FutureReservedWord when Module is the goal
> symbol of the syntactic grammar.

http://www.ecma-international.org/ecma-262/6.0/#sec-future-reserved-words