### PR TITLE
Added missing "Storage" browser variable

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -195,6 +195,7 @@ exports.browser = {
   setTimeout           : false,
   SharedWorker         : false,
   status               : false,
+  Storage              : false,
   SVGAElement          : false,
   SVGAltGlyphDefElement: false,
   SVGAltGlyphElement   : false,


### PR DESCRIPTION
This variable is available globally in browsers, and can be used to override the behaviour of localStorage & sessionStorage.

e.g. http://stackoverflow.com/questions/14555347/html5-localstorage-error-with-safari-quota-exceeded-err-dom-exception-22-an/35623334#35623334
