### PR TITLE
[[FIX]] Return a non-zero exit code when file not found

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -422,7 +422,7 @@ function collect(fp, files, ignores, ext) {
 
   if (!shjs.test("-e", fp)) {
     cli.error("Can't open " + fp);
-    return;
+    exports.exit(1);
   }
 
   if (shjs.test("-d", fp)) {


### PR DESCRIPTION
Issue #2884 noted that when a file is not found the CLI returns with a zero exit code. This commit makes the program return 1 when a file can't be opened.

Fixes #2884