### PR TITLE
[[FIX]] `freeze` now errors when an ECMA6 object's prototype is edited.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1284,10 +1284,11 @@ var JSHINT = (function() {
       "Array", "ArrayBuffer", "Boolean", "Collator", "DataView", "Date",
       "DateTimeFormat", "Error", "EvalError", "Float32Array", "Float64Array",
       "Function", "Infinity", "Intl", "Int16Array", "Int32Array", "Int8Array",
-      "Iterator", "Number", "NumberFormat", "Object", "RangeError",
-      "ReferenceError", "RegExp", "StopIteration", "String", "SyntaxError",
+      "Iterator", "Map", "Number", "NumberFormat", "Object", "Promise", "Proxy", "RangeError",
+      "Symbol", "Set",
+      "ReferenceError", "Reflect", "RegExp", "StopIteration", "String", "SyntaxError",
       "TypeError", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray",
-      "URIError"
+      "URIError", "WeakMap", "WeakSet"
     ];
 
     function walkPrototype(obj) {


### PR DESCRIPTION
Issue #2859 noted that when jshint `freeze: true` and `esversion: 6`, it did not give errors when extending the prototype of a ECMA6 object. This commit adds all of the natives to the list of natives in `jshint.js` so that these errors can be correctly reported.

Fixes #2859