### PR TITLE
[[CHORE]] Remove I003

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -524,15 +524,6 @@ var JSHINT = (function() {
           return;
         }
 
-        /**
-         * TODO: Remove in JSHint 3
-         */
-        if (key === "es5") {
-          if (val === "true" && state.option.es5) {
-            warning("I003");
-          }
-        }
-
         if (key === "validthis") {
           // `validthis` is valid only within a function scope.
 
@@ -656,12 +647,8 @@ var JSHINT = (function() {
 
         if (key === "esversion") {
           switch (val) {
-          case "5":
-            if (state.inES5(true)) {
-              warning("I003");
-            }
-            /* falls through */
           case "3":
+          case "5":
           case "6":
             state.option.moz = false;
             state.option.esversion = +val;
@@ -5134,10 +5121,6 @@ var JSHINT = (function() {
         } else {
           var optionKey = optionKeys[x];
           newOptionObj[optionKey] = o[optionKey];
-          if ((optionKey === "esversion" && o[optionKey] === 5) ||
-              (optionKey === "es5" && o[optionKey])) {
-            warningAt("I003", 0, 0);
-          }
         }
       }
     }

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -3313,69 +3313,6 @@ exports.varstmt = function (test) {
   test.done();
 };
 
-exports.errorI003 = function(test) {
-  var code = [
-    "// jshint browser: true",
-    "function f() {",
-    "  // jshint browser: false",
-    "}",
-    "f();"
-  ];
-
-  TestRun(test, "no es5 option with enforceall")
-    .test(code, { enforceall: true });
-
-  TestRun(test, "global overriding es5")
-    .addError(0, "ES5 option is now set per default")
-    .test(code, { es5: true });
-
-  var code2 = [
-    "// jshint browser: true",
-    "function f() {",
-    "  // jshint es5: true",
-    "}",
-    "f();"
-  ];
-
-  TestRun(test, "nested overriding es5")
-    .addError(3, "ES5 option is now set per default")
-    .test(code2, { enforceall: true });
-
-  var code3 = [
-    "// jshint es5: false",
-    "// jshint es5: true",
-    "// jshint es5: false",
-    "// jshint es5: true"
-  ];
-
-  TestRun(test, "toggling es5 option")
-    .test(code3, {});
-
-  var code4 = [
-    "// jshint es5: false",
-    "function a() {",
-    "  // jshint es5: true",
-    "  function b() {",
-    "    // jshint es5: false",
-    "    function c() {",
-    "      // jshint es5: true",
-    "      function d() {",
-    "      }",
-    "      d();",
-    "    }",
-    "    c();",
-    "  }",
-    "  b();",
-    "}",
-    "a();"
-  ];
-
-  TestRun(test, "toggling es5 option through nested scopes")
-    .test(code4, {});
-
-  test.done();
-};
-
 exports.module = {};
 exports.module.behavior = function(test) {
   var code = [
@@ -3578,7 +3515,6 @@ exports.esversion = function(test) {
     .test(es6code, { esversion: 6, es3: true });
 
   TestRun(test, "incompatibility with `es5`") // TODO: Remove in JSHint 3
-    .addError(0, "ES5 option is now set per default")
     .addError(0, "Incompatible values for the 'esversion' and 'es5' linting options. (0% scanned).")
     .test(es6code, { esversion: 6, es5: true });
 


### PR DESCRIPTION
This warning is inappropriate in cases where `esversion` has been
globally set to a value other than `5` (e.g. in a project's `.jshintrc`
file) and a specific file overrides this value with an in-line
directive.

Although it is possible to detect this case while interpreting option
values, the warning itself has minimal utility. Some users may set
options to their default values in the interest of explicitness.
Preventing this practice (and doing so inconsistently--only for the
`esversion` option) adds little value.

Remove I003 completely.