### PR TITLE
[[FIX]] Allow Expression within for-in head

### DIFF
--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7446,3 +7446,22 @@ exports.parsingCommas = function (test) {
 
   test.done();
 };
+
+exports.forInExpr = function (test) {
+  TestRun(test)
+    .test([
+      "for (var x in [], []) {}"
+    ]);
+
+  TestRun(test)
+    .addError(2, "Expected ')' to match '(' from line 2 and instead saw ','.")
+    .addError(2, "Expected an identifier and instead saw ')'.")
+    .addError(2, "Expected an assignment or function call and instead saw an expression.")
+    .addError(2, "Missing semicolon.")
+    .test([
+      "for (var x in [], []) {}",
+      "for (var x of {}, {}) {}"
+    ], { esversion: 6 });
+
+  test.done();
+};


### PR DESCRIPTION
As per the ES2015 language grammar:

> A.3 Statements
>
> [...]
>
> IterationStatement[Yield, Return] :
>
>   [...]
>
>   for ( [lookahead ∉ {let [}] LeftHandSideExpression[?Yield] in Expression[In, ?Yield] ) Statement[?Yield, ?Return]
>   for ( var ForBinding[?Yield] in Expression[In, ?Yield] ) Statement[?Yield, ?Return]
>   for ( ForDeclaration[?Yield] in Expression[In, ?Yield] ) Statement[?Yield, ?Return]
>   for ( [lookahead ≠ let ] LeftHandSideExpression[?Yield] of AssignmentExpression[In, ?Yield] ) Statement[?Yield, ?Return]
>   for ( var ForBinding[?Yield] of AssignmentExpression[In, ?Yield] ) Statement[?Yield, ?Return]
>   for ( ForDeclaration[?Yield] of AssignmentExpression[In, ?Yield] ) Statement[?Yield, ?Return]

http://www.ecma-international.org/ecma-262/6.0/#sec-statements

Resolves gh-2891