### PR TITLE
Always resolve ignored paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "phantomjs":                      "1.9.13",
     "regenerate":                     "1.2.x",
     "sinon":                          "1.12.x",
-    "unicode-6.3.0":                  "0.1.x"
+    "unicode-6.3.0":                  "0.1.x",
+    "recursive-readdir":              "2.1.x"
   },
 
   "license": "(MIT AND JSON)",

--- a/src/cli.js
+++ b/src/cli.js
@@ -571,10 +571,11 @@ var exports = {
       (!opts.extensions ? "" : "|" +
         opts.extensions.replace(/,/g, "|").replace(/[\. ]/g, "")) + ")$");
 
-    var ignores = !opts.ignores ? loadIgnores({ cwd: opts.cwd }) :
-                                  opts.ignores.map(function(target) {
-                                    return path.resolve(target);
-                                  });
+    var ignores = opts.ignores || loadIgnores({ cwd: opts.cwd });
+
+    ignores = ignores.map(function(target) {
+      return path.resolve(target);
+    });
 
     opts.args.forEach(function(target) {
       collect(target, files, ignores, reg);

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -678,8 +678,8 @@ exports.group = {
     var result = null;
 
     cli.run({
-      args: [dir + "../tests/unit/fixtures/ignored.js"],
-      cwd: dir + "../tests/unit/fixtures/",
+      args: [ dir +"../tests/unit/fixtures/ignoredApi"],
+      cwd: dir + "../tests/unit/fixtures/ignoredApi",
       reporter: function (results) { result = results; }
     });
 

--- a/tests/helpers/browser/server.js
+++ b/tests/helpers/browser/server.js
@@ -5,6 +5,7 @@ var Stream = require("stream");
 var path = require("path");
 var url = require("url");
 
+var recursive_readdir = require("recursive-readdir");
 var browserify = require("browserify");
 var buildJSHint = require(__dirname + "/../../../scripts/build");
 
@@ -22,9 +23,10 @@ var streams = {
     var fixtureStream = new Stream.Readable();
     fixtureStream._read = fixtureStream.write = function() {};
 
-    fs.readdir(fixtureDir, function(err, files) {
+    recursive_readdir(fixtureDir, function(err, files) {
       var src = "";
       var fsCache = {};
+      var absoluteHeadLength = path.resolve(fixtureDir, "../../..").length;
 
       if (err) {
         done(err);
@@ -32,10 +34,10 @@ var streams = {
       }
 
       files.forEach(function(fileName) {
-        var relativeName = "/tests/unit/fixtures/" + fileName;
+        var relativeName = fileName.substr(absoluteHeadLength).replace(/\\/g, "/");
 
         fsCache[relativeName] = fs.readFileSync(
-          fixtureDir + "/" + fileName, { encoding: "utf-8" }
+          fileName, { encoding: "utf-8" }
         );
       });
 

--- a/tests/unit/fixtures/ignoredApi/.jshintignore
+++ b/tests/unit/fixtures/ignoredApi/.jshintignore
@@ -1,0 +1,2 @@
+foo.js
+dir/

--- a/tests/unit/fixtures/ignoredApi/dir/bar.js
+++ b/tests/unit/fixtures/ignoredApi/dir/bar.js
@@ -1,0 +1,14 @@
+//jshint -W008
+
+var a = .12;
+var b = 12.;
+
+function test() {
+  //jshint -W033
+  return a
+}
+
+function test2() {
+  return a
+}
+

--- a/tests/unit/fixtures/ignoredApi/foo.js
+++ b/tests/unit/fixtures/ignoredApi/foo.js
@@ -1,0 +1,14 @@
+//jshint -W008
+
+var a = .12;
+var b = 12.;
+
+function test() {
+  //jshint -W033
+  return a
+}
+
+function test2() {
+  return a
+}
+


### PR DESCRIPTION
Having issue with the inconsistent handling of the paths in .jshintignore between using the jshint cli and tools such as [mocha-jshint](https://github.com/ebdrup/mocha-jshint) where the paths aren't always resolved.

For example, a folder with a trailing slash in the .jshintignore, such as `node_modules/`, will successfully be ignored when using the jshint cli but will not with mocha-jshint.

This has been [previously found](https://github.com/jshint/jshint/pull/1837/files#diff-d9d9214113dea1c364abd4ba3c70be11L563) but the pull request (in which this issue was only a small part) was eventually abandoned. I've gone ahead and pulled the fix out into this quick patch in the hopes it goes through easier.
