### PR TITLE
[[FEAT]] Error for literals on rhs of `instanceof`

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2141,14 +2141,13 @@ var JSHINT = (function() {
   infix("instanceof", function(left, token) {
     var right;
     var scope = state.funct["(scope)"];
-    var redefinedUndefined = scope.has("undefined");
     token.left = left;
     token.right = right = expression(120);
 
     if (right.id === "(number)" ||
         right.id === "(string)" ||
         right.value === "null" ||
-        (right.value === "undefined" && !redefinedUndefined) ||
+        (right.value === "undefined" && !scope.has("undefined")) ||
         right.arity === "unary" ||
         right.id === "{" ||
         (right.id === "[" && !right.right) ||

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2138,7 +2138,31 @@ var JSHINT = (function() {
   bitwise(">>", "shiftright", 120);
   bitwise(">>>", "shiftrightunsigned", 120);
   infix("in", "in", 120);
-  infix("instanceof", "instanceof", 120);
+  infix("instanceof", function(left, token) {
+    var right;
+    var scope = state.funct["(scope)"];
+    var redefinedUndefined = scope.has("undefined");
+    token.left = left;
+    token.right = right = expression(120);
+
+    if (right.id === "(number)" ||
+        right.id === "(string)" ||
+        right.value === "null" ||
+        (right.value === "undefined" && !redefinedUndefined) ||
+        right.arity === "unary" ||
+        right.id === "{" ||
+        (right.id === "[" && !right.right) ||
+        right.id === "(regexp)" ||
+        (right.id === "(template)" && !right.tag)) {
+      error("E060");
+    }
+
+    if (right.id === "function") {
+      warning("W139");
+    }
+
+    return token;
+  }, 120);
   infix("+", function(left, that) {
     var right;
     that.left = left;

--- a/src/messages.js
+++ b/src/messages.js
@@ -74,7 +74,8 @@ var errors = {
   E056: "'{a}' was used before it was declared, which is illegal for '{b}' variables.",
   E057: "Invalid meta property: '{a}.{b}'.",
   E058: "Missing semicolon.",
-  E059: "Incompatible values for the '{a}' and '{b}' linting options."
+  E059: "Incompatible values for the '{a}' and '{b}' linting options.",
+  E060: "Literals and unary operators cannot be used after the `instanceof` operator."
 };
 
 var warnings = {
@@ -219,7 +220,8 @@ var warnings = {
   W135: "{a} may not be supported by non-browser environments.",
   W136: "'{a}' must be in function scope.",
   W137: "Empty destructuring.",
-  W138: "Regular parameters should not come after default parameters."
+  W138: "Regular parameters should not come after default parameters.",
+  W139: "Function declarations should not be used after the `instanceof` operator."
 };
 
 var info = {

--- a/src/messages.js
+++ b/src/messages.js
@@ -75,7 +75,7 @@ var errors = {
   E057: "Invalid meta property: '{a}.{b}'.",
   E058: "Missing semicolon.",
   E059: "Incompatible values for the '{a}' and '{b}' linting options.",
-  E060: "Literals and unary operators cannot be used after the `instanceof` operator."
+  E060: "Non-callable values cannot be used as the second operand to instanceof."
 };
 
 var warnings = {
@@ -221,7 +221,7 @@ var warnings = {
   W136: "'{a}' must be in function scope.",
   W137: "Empty destructuring.",
   W138: "Regular parameters should not come after default parameters.",
-  W139: "Function declarations should not be used after the `instanceof` operator."
+  W139: "Function expressions should not be used as the second operand to instanceof."
 };
 
 var info = {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7446,3 +7446,65 @@ exports.parsingCommas = function (test) {
 
   test.done();
 };
+
+exports.instanceOfLiterals = function (test) {
+  var code = [
+    "var x;",
+    "var y = [x];",
+
+    // okay
+    "function Y() {}",
+    "function template() { return Y; }",
+    "var a = x instanceof Y;",
+    "a = new X() instanceof function() { return X; }();",
+    "a = x instanceof template``;",
+    "a = x instanceof /./.constructor;",
+    "a = x instanceof \"\".constructor;",
+    "a = x instanceof [y][0];",
+    "a = x instanceof {}[constructor];",
+    "function Z() {",
+    "  let undefined = function() {};",
+    "  a = x instanceof undefined;",
+    "}",
+
+    // error: literals and unary operators cannot be used
+    "a = x instanceof +x;",
+    "a = x instanceof -x;",
+    "a = x instanceof 0;",
+    "a = x instanceof '';",
+    "a = x instanceof null;",
+    "a = x instanceof undefined;",
+    "a = x instanceof {};",
+    "a = x instanceof [];",
+    "a = x instanceof /./;",
+    "a = x instanceof ``;",
+    "a = x instanceof `${x}`;",
+
+    // warning: functions declarations should not be used
+    "a = x instanceof function() {};",
+    "a = x instanceof function MyUnusableFunction() {};",
+  ];
+
+  var errorMessage = "Literals and unary operators cannot be used after the `instanceof` operator.";
+  var warningMessage = "Function declarations should not be used after the `instanceof` operator.";
+
+  var run = TestRun(test)
+    .addError(13, "Expected an identifier and instead saw 'undefined' (a reserved word).")
+    .addError(16, errorMessage)
+    .addError(17, errorMessage)
+    .addError(18, errorMessage)
+    .addError(19, errorMessage)
+    .addError(20, errorMessage)
+    .addError(21, errorMessage)
+    .addError(22, errorMessage)
+    .addError(23, errorMessage)
+    .addError(24, errorMessage)
+    .addError(25, errorMessage)
+    .addError(26, errorMessage)
+    .addError(27, warningMessage)
+    .addError(28, warningMessage);
+
+  run.test(code, { esversion: 6 });
+
+  test.done();
+};

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7485,8 +7485,8 @@ exports.instanceOfLiterals = function (test) {
     "a = x instanceof function MyUnusableFunction() {};",
   ];
 
-  var errorMessage = "Literals and unary operators cannot be used after the `instanceof` operator.";
-  var warningMessage = "Function declarations should not be used after the `instanceof` operator.";
+  var errorMessage = "Non-callable values cannot be used as the second operand to instanceof.";
+  var warningMessage = "Function expressions should not be used as the second operand to instanceof.";
 
   var run = TestRun(test)
     .addError(13, "Expected an identifier and instead saw 'undefined' (a reserved word).")


### PR DESCRIPTION
This patch adds a new parse error that is used when a literal or function
declaration is found on the right-hand side of the `instanceof` infix operator.
Specifically, it checks for number, string, object, array and regular expression
literals, as well as the null and undefined keywords and function declarations.

The following generate errors:

    x instanceof 0;
    x instanceof '';
    x instanceof null;
    x instanceof undefined;
    x instanceof {};
    x instanceof [];
    x instanceof /./;
    x instanceof function() {};
    x instanceof function MyUnusableFunction() {};

But this is okay:

    /x/ instanceof /x/.constructor;

as per GH-2773

Closes GH-2777