### PR TITLE
[[CHORE]] Ignore vim temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ demo.js
 .idea
 
 coverage/
+
+# Vim
+*.swp


### PR DESCRIPTION
Ignore files with .swp extension so that contributers using Vim can safely run

    git add --all