### PR TITLE
Remove preferGlobal.  Fixes #2642

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,6 @@
 
   "license": "(MIT AND JSON)",
 
-  "preferGlobal": true,
-
   "files": [
     "bin",
     "data",


### PR DESCRIPTION
npm still emits a warning because of the preferGlobal flag.  i.e.: `npm WARN prefer global jshint@2.5.11 should be installed with -g`.  See for example npm/npm#8517 and npm/npm#11652.

An easy way to repro is `npm i swagger-js-codegen`, which includes jshint as a dependency.
