### PR TITLE
[[FIX]] Avoid crash when peeking past end of prog

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -716,16 +716,16 @@ var JSHINT = (function() {
     }
 
     while (j <= i) {
-      t = lookahead[j];
-      if (!t) {
-        t = lookahead[j] = lex.token();
-      }
-      j += 1;
-    }
+      t = lex.token();
 
-    // Peeking past the end of the program should produce the "(end)" token.
-    if (!t && state.tokens.next.id === "(end)") {
-      return state.tokens.next;
+      // Peeking past the end of the program should produce the "(end)" token
+      // and should not extend the lookahead buffer.
+      if (!t && state.tokens.next.id === "(end)") {
+        return state.tokens.next;
+      }
+
+      lookahead[j] = t;
+      j += 1;
     }
 
     return t;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -458,6 +458,11 @@ exports.comments = function (test) {
   TestRun(test).test(src);
   TestRun(test).test(fs.readFileSync(__dirname + "/fixtures/gruntComment.js", "utf8"));
 
+  TestRun(test)
+    .addError(1, "Unmatched '{'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test("({");
+
   test.done();
 };
 


### PR DESCRIPTION
The lexer returns `null` values when tokens are requested after all
input has been consumed. Previously, the `peek` function would correctly
produce the special "(end)" token in situations where the parser
attempted to look beyond the end of the program. In such cases, however,
it would also pollute the lookahead buffer with an invalid entry--the
`null` value returned by the lexer. Future calls to `peek` could receive
this buffered value.

Because JSHint's internals are written with the assumption that `peek`
always returns a token object, the `null` value would trigger a
TypeError and subsequent program crash.

Re-factor the `peek` function to only insert valid token objects into
the lookahead buffer.