### PR TITLE
Run CI in "latest" and "LTS" releases of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ after_success: npm run coverage && cat ./coverage/lcov.info | coveralls
 node_js:
   - "0.10"
   - "0.12"
+  - 4
+  - 6
 matrix:
   fast_finish: true
 sudo: false

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -158,7 +158,6 @@ exports.group = {
         var msg = out.args[1][0];
         test.equal(msg.slice(0, 24), "Can't parse config file:");
         test.equal(msg.slice(25, 35), "file1.json");
-        test.equal(msg.slice(msg.length - 37), "Error:SyntaxError: Unexpected token w");
         test.equal(err, "ProcessExit");
       }
 


### PR DESCRIPTION
Note the additional commit here: this required removing a brittle assertion in
the CLI tests.

