### PR TITLE
[[CHORE]] Upgrade phantom & phantoms to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name":     "jshint",
-  "version":  "2.9.2",
+  "name": "jshint",
+  "version": "2.9.2",
   "homepage": "http://jshint.com/",
   "description": "Static analysis tool for JavaScript",
 
   "author": {
-    "name":  "Anton Kovalyov",
+    "name": "Anton Kovalyov",
     "email": "anton@kovalyov.net",
-    "url":   "http://anton.kovalyov.net/"
+    "url": "http://anton.kovalyov.net/"
   },
 
   "repository": {
@@ -42,31 +42,31 @@
   "main": "./src/jshint.js",
 
   "dependencies": {
-    "cli":                 "0.6.x",
-    "console-browserify":  "1.1.x",
-    "exit":                "0.1.x",
-    "htmlparser2":         "3.8.x",
-    "minimatch":           "2.0.x",
-    "shelljs":             "0.3.x",
+    "cli": "0.6.x",
+    "console-browserify": "1.1.x",
+    "exit": "0.1.x",
+    "htmlparser2": "3.8.x",
+    "minimatch": "2.0.x",
+    "shelljs": "0.3.x",
     "strip-json-comments": "1.0.x",
-    "lodash":              "3.7.x"
+    "lodash": "3.7.x"
   },
 
   "devDependencies": {
-    "browserify":                     "9.x",
-    "conventional-changelog":         "0.4.x",
-    "conventional-github-releaser":   "0.4.x",
-    "coveralls":                      "2.11.x",
-    "istanbul":                       "0.3.x",
-    "jscs":                           "1.11.x",
-    "jshint":                         "2.6.x",
-    "mock-stdin":                     "0.3.x",
-    "nodeunit":                       "0.9.x",
-    "phantom":                        "~0.7.2",
-    "phantomjs":                      "1.9.13",
-    "regenerate":                     "1.2.x",
-    "sinon":                          "1.12.x",
-    "unicode-6.3.0":                  "0.1.x"
+    "browserify": "9.x",
+    "conventional-changelog": "0.4.x",
+    "conventional-github-releaser": "0.4.x",
+    "coveralls": "2.11.x",
+    "istanbul": "0.3.x",
+    "jscs": "1.11.x",
+    "jshint": "2.6.x",
+    "mock-stdin": "0.3.x",
+    "nodeunit": "0.9.x",
+    "phantom": "~2.1.3",
+    "phantomjs-prebuilt": "^2.1.7",
+    "regenerate": "1.2.x",
+    "sinon": "1.12.x",
+    "unicode-6.3.0": "0.1.x"
   },
 
   "license": "(MIT AND JSON)",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "conventional-changelog": "0.4.x",
     "conventional-github-releaser": "0.4.x",
     "coveralls": "2.11.x",
+    "es6-promise": "^3.2.1",
     "istanbul": "0.3.x",
     "jscs": "1.11.x",
     "jshint": "2.6.x",

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -1,5 +1,8 @@
 "use strict";
 
+// Patch the global with a Promise to support node < 0.12
+require('es6-promise').polyfill();
+
 var path = require("path");
 var phantom = require("phantom");
 var createTestServer = require("./helpers/browser/server");

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -3,45 +3,37 @@
 var path = require("path");
 var phantom = require("phantom");
 var createTestServer = require("./helpers/browser/server");
-var options = {
-  /**
-   * The `phantom` module provides a Node.js API for the PhantomJS binary,
-   * while the `phantomjs` module includes the binary itself.
-   */
-  path: path.dirname(require("phantomjs").path) + "/",
 
-  /**
-   * Disable the optional `weak` module due to installation difficulties in
-   * Windows environments.
-   */
-  dnodeOpts: {
-    weak: false
-  }
-};
 var port = process.env.NODE_PORT || 8045;
 
-phantom.create(function(ph) {
-  ph.createPage(function(page) {
-    createTestServer(port, function(server) {
-      page.onConsoleMessage(function(str) {
-        console.log(str);
-      });
+var _ph, _page, _outObj;
+createTestServer(port, function(server) {
+  var shutdown = function() {
+    _page.close();
+    _ph.exit();
+    server.close();
+  };
 
-      page.set("onCallback", function(err) {
-        ph.exit();
-        server.close();
-        if (err) {
-          process.exit(1);
-        }
-      });
-
-      page.set("onError", function(msg, trace) {
-        console.error(msg);
-        console.error(trace);
-        process.exit(1);
-      });
-
-      page.open("http://localhost:" + port, function () {});
+  phantom.create(['--web-security=no']).then(function(ph) {
+    _ph = ph;
+    return _ph.createPage();
+  }).then(function(page) {
+    _page = page;
+    _page.on('onConsoleMessage', function(message) {
+      console.log(message);
     });
-  });
-}, options);
+    _page.on('onCallback', function(message) {
+      console.log(message);
+    });
+    _page.on('onError', function(message, trace) {
+      console.error(message);
+      console.error(trace);
+      throw error;
+    });
+    return _page.open('http://localhost:' + port);
+  }).then(shutdown, function(error) {
+    shutdown();
+    console.error(error);
+    process.exit(1);
+  })
+});


### PR DESCRIPTION
Upgraded phantom to version 2.1.3
Upgraded phantomjs to phantomjs-prebuilt version 2.1.7

Changed tests/browser to use new phantom Promise based API.
Refactored tests/browser to be a bit more DRY.

This removes this deprecation message when installing jshint:
<img width="748" alt="screen shot 2016-06-11 at 23 19 00" src="https://cloud.githubusercontent.com/assets/3070389/15987528/f7d53592-302a-11e6-9816-b16b2b5aa724.png">

---

PS. This is my first contribution to this repo, so if I didn't do everything by the book, please go easy on me. I've tried to read everything I could find on how to contribute correctly.
