### PR TITLE
[[FIX]] Correct behavior of singleGroups

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2929,12 +2929,17 @@ var JSHINT = (function() {
     return funct["(global)"] && !funct["(verb)"];
   }
 
-  function doTemplateLiteral(left) {
+  /**
+   * This function is used as both a null-denotation method *and* a
+   * left-denotation method, meaning the first parameter is overloaded.
+   */
+  function doTemplateLiteral(leftOrRbp) {
     // ASSERT: this.type === "(template)"
     // jshint validthis: true
     var ctx = this.context;
     var noSubst = this.noSubst;
     var depth = this.depth;
+    var left = typeof leftOrRbp === "number" ? null : leftOrRbp;
 
     if (!noSubst) {
       while (!end()) {

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2710,6 +2710,7 @@ singleGroups.bindingPower.singleExpr = function (test) {
     "var v = a % (b / c);",
     "var w = a * (b * c);",
     "var x = z === (b === c);",
+    "x = typeof (a + b);",
     // Invalid forms:
     "var j = 2 * ((3 - 4) - 5) * 6;",
     "var l = 2 * ((3 - 4 - 5)) * 6;",
@@ -2731,7 +2732,6 @@ singleGroups.bindingPower.singleExpr = function (test) {
   ];
 
   TestRun(test)
-    .addError(18, "Unnecessary grouping operator.")
     .addError(19, "Unnecessary grouping operator.")
     .addError(20, "Unnecessary grouping operator.")
     .addError(21, "Unnecessary grouping operator.")
@@ -2748,6 +2748,7 @@ singleGroups.bindingPower.singleExpr = function (test) {
     .addError(32, "Unnecessary grouping operator.")
     .addError(33, "Unnecessary grouping operator.")
     .addError(34, "Unnecessary grouping operator.")
+    .addError(35, "Unnecessary grouping operator.")
     .test(code, { singleGroups: true });
 
   code = [
@@ -2810,7 +2811,6 @@ singleGroups.multiExpr = function (test) {
   ];
 
   TestRun(test)
-    .addError(5, "Unnecessary grouping operator.")
     .test(code, { singleGroups: true });
 
   test.done();


### PR DESCRIPTION
The extension to `nud` is a fairly low-level change for such a fringe feature
as "singleGroups", but I believe it is technically necessary to expose correct
behavior. It doesn't seem too dirty--the change is functional and does not rely
on additional global state.

And believe it or not, this is actually blocking my patch for gh-2923 (`yield`'s
binding power is a little tricky).

I'm curious to hear what others think! Especially @caitp and @rwaldron :)

---

The grouping operator may be necessary if the right-binding power of the
operator preceeding the "(" token is greater than the left-binding power
of the operator immediately following it.

The initial implementation approximated this behavior by using the
readily-accessible left-binding power of both operators. This heuristic
is not always accurate, however as in the following case:

    typeof (a + b);

Here, the necessity of the grouping operator is determined by the
right-binding power of the `typeof` operator.

Extend the Pratt parser to make the right-binding power available to all
null denotation ("nud") functions. Remove an invalid unit test exposed
by this improvement.