### PR TITLE
allow custom devel's functions

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -263,7 +263,12 @@ var JSHINT = (function() {
     }
 
     if (state.option.devel) {
-      combine(predefined, vars.devel);
+      // allow custom devel's functions
+      if (typeof state.option.devel == 'object') {
+        combine(predefined, state.option.devel);
+      } else {
+        combine(predefined, vars.devel);
+      }
     }
 
     if (state.option.dojo) {


### PR DESCRIPTION
Sometimes we need `alert`, but not `console`, and now we have no idea.