### PR TITLE
[[FIX]] Correct interpretation of ASI

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -815,7 +815,8 @@ var JSHINT = (function() {
     if (next.id === ";" || next.id === "}" || next.id === ":") {
       return true;
     }
-    if (isInfix(next) === isInfix(curr) || (curr.id === "yield" && state.inMoz())) {
+    if (isInfix(next) === isInfix(curr) || curr.ltBoundary === "after" ||
+      next.ltBoundary === "before") {
       return curr.line !== startLine(next);
     }
     return false;
@@ -2208,10 +2209,13 @@ var JSHINT = (function() {
   suffix("++");
   prefix("++", "preinc");
   state.syntax["++"].exps = true;
+  state.syntax["++"].ltBoundary = "before";
 
   suffix("--");
   prefix("--", "predec");
   state.syntax["--"].exps = true;
+  state.syntax["--"].ltBoundary = "before";
+
   prefix("delete", function() {
     var p = expression(10);
     if (!p) {
@@ -4440,6 +4444,7 @@ var JSHINT = (function() {
   (function(x) {
     x.exps = true;
     x.lbp = 25;
+    x.ltBoundary = "after";
   }(prefix("yield", function() {
     var prev = state.tokens.prev;
     if (state.inES6(true) && !state.funct["(generator)"]) {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5153,6 +5153,13 @@ exports["automatic comma insertion GH-950"] = function (test) {
     "  return",
     "      { a: 1 }",
     "}",
+
+    "a",
+    "++",
+    "a",
+    "a",
+    "--",
+    "a",
   ];
 
   var run = TestRun(test)
@@ -5160,7 +5167,9 @@ exports["automatic comma insertion GH-950"] = function (test) {
     .addError(6, "Bad line breaking before '&&'.")
     .addError(8, "Line breaking error 'return'.")
     .addError(9, "Label 'a' on 1 statement.")
-    .addError(9, "Expected an assignment or function call and instead saw an expression.");
+    .addError(9, "Expected an assignment or function call and instead saw an expression.")
+    .addError(11, "Expected an assignment or function call and instead saw an expression.")
+    .addError(14, "Expected an assignment or function call and instead saw an expression.");
 
   run.test(code, {es3: true, asi: true});
   run.test(code, {asi: true}); // es5
@@ -5176,7 +5185,13 @@ exports["automatic comma insertion GH-950"] = function (test) {
     .addError(8, "Missing semicolon.")
     .addError(9, "Label 'a' on 1 statement.")
     .addError(9, "Expected an assignment or function call and instead saw an expression.")
-    .addError(9, "Missing semicolon.");
+    .addError(9, "Missing semicolon.")
+    .addError(11, "Expected an assignment or function call and instead saw an expression.")
+    .addError(11, "Missing semicolon.")
+    .addError(13, "Missing semicolon.")
+    .addError(14, "Expected an assignment or function call and instead saw an expression.")
+    .addError(14, "Missing semicolon.")
+    .addError(16, "Missing semicolon.");
 
   run.test(code, {es3: true, asi: false});
   run.test(code, {asi: false}); // es5
@@ -6324,7 +6339,12 @@ exports["test for line breaks with 'yield'"] = function (test) {
     .addError(6, "Bad line breaking before '+'.")
     .addError(8, "Comma warnings can be turned off with 'laxcomma'.")
     .addError(7, "Bad line breaking before ','.")
-    .addError(10, "Bad line breaking before '?'.")
+    .addError(9,  "Missing semicolon.")
+    .addError(10, "Expected an identifier and instead saw '?'.")
+    .addError(10, "Expected an assignment or function call and instead saw an expression.")
+    .addError(10, "Missing semicolon.")
+    .addError(10, "Label 'i' on j statement.")
+    .addError(10, "Expected an assignment or function call and instead saw an expression.")
     .addError(14, "Bad line breaking before '+'.");
 
   run.test(code, {esnext: true});


### PR DESCRIPTION
@rwaldron this is the latest installment of the ongoing saga to resolve gh-2923. It's the last one, though--I have already written the follow-up patch that will finish this up.

Commit message:

> Ensure JSHint observes correct automatic semicolon insertion semantics.
> This change also modifies parsing logic for the Mozilla "JavaScript 1.7"
> implementation of YieldExpression. There is no formal specificaion for
> that version of the language feature, so the validity of this change was
> experimentally confirmed.