### PR TITLE
Correct parsing of YieldExpression

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4467,27 +4467,19 @@ var JSHINT = (function() {
       advance("*");
     }
 
-    if (this.line === startLine(state.tokens.next) || !state.inMoz()) {
-      if (delegatingYield ||
-          (state.tokens.next.id !== ";" && !state.option.asi &&
-           !state.tokens.next.reach && state.tokens.next.nud)) {
+    if (delegatingYield ||
+        (state.tokens.next.id !== ";" && !state.option.asi &&
+         !state.tokens.next.reach && state.tokens.next.nud)) {
 
-        nobreaknonadjacent(state.tokens.curr, state.tokens.next);
-        this.first = expression(10);
+      nobreaknonadjacent(state.tokens.curr, state.tokens.next);
+      this.first = expression(10);
 
-        if (this.first.type === "(punctuator)" && this.first.value === "=" &&
-            !this.first.paren && !state.option.boss) {
-          warningAt("W093", this.first.line, this.first.character);
-        }
+      if (this.first.type === "(punctuator)" && this.first.value === "=" &&
+          !this.first.paren && !state.option.boss) {
+        warningAt("W093", this.first.line, this.first.character);
       }
-
-      if (state.inMoz() && state.tokens.next.id !== ")" &&
-          (prev.lbp > 30 || (!prev.assign && !isEndOfExpr()) || prev.id === "yield")) {
-        error("E050", this);
-      }
-    } else if (!state.option.asi) {
-      nolinebreak(this); // always warn (Line breaking error)
     }
+
     return this;
   })));
 
@@ -4513,7 +4505,7 @@ var JSHINT = (function() {
       advance("*");
     }
 
-    if (this.line === startLine(state.tokens.next) || !state.inMoz()) {
+    if (this.line === startLine(state.tokens.next)) {
       if (delegatingYield ||
           (state.tokens.next.id !== ";" && !state.option.asi &&
            !state.tokens.next.reach && state.tokens.next.nud)) {
@@ -4527,7 +4519,7 @@ var JSHINT = (function() {
         }
       }
 
-      if (state.inMoz() && state.tokens.next.id !== ")" &&
+      if (state.tokens.next.id !== ")" &&
           (prev.lbp > 30 || (!prev.assign && !isEndOfExpr()) || prev.id === "yield")) {
         error("E050", this);
       }

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4507,8 +4507,6 @@ var JSHINT = (function() {
       if (!("(catch)" === state.funct["(name)"] && state.funct["(context)"]["(generator)"])) {
         error("E046", state.tokens.curr, "yield");
       }
-    } else if (!state.inES6()) {
-      warning("W104", state.tokens.curr, "yield", "6");
     }
     state.funct["(generator)"] = "yielded";
     var delegatingYield = false;

--- a/src/messages.js
+++ b/src/messages.js
@@ -75,7 +75,8 @@ var errors = {
   E057: "Invalid meta property: '{a}.{b}'.",
   E058: "Missing semicolon.",
   E059: "Incompatible values for the '{a}' and '{b}' linting options.",
-  E060: "Non-callable values cannot be used as the second operand to instanceof."
+  E060: "Non-callable values cannot be used as the second operand to instanceof.",
+  E061: "Invalid position for 'yield' expression (consider wrapping in parenthesis)."
 };
 
 var warnings = {

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2901,6 +2901,111 @@ singleGroups.generatorExpression = function (test) {
   test.done();
 };
 
+singleGroups.yield = function (test) {
+  TestRun(test, "otherwise-invalid position")
+    .test([
+      "function* g() {",
+      "  var x;",
+      "  x = 0 || (yield);",
+      "  x = 0 || (yield 0);",
+      "  x = 0 && (yield);",
+      "  x = 0 && (yield 0);",
+      "  x = !(yield);",
+      "  x = !(yield 0);",
+      "  x = !!(yield);",
+      "  x = !!(yield 0);",
+      "  x = 0 + (yield);",
+      "  x = 0 + (yield 0);",
+      "  x = 0 - (yield);",
+      "  x = 0 - (yield 0);",
+      "}"
+    ], { singleGroups: true, esversion: 6 });
+
+  TestRun(test, "operand delineation")
+    .test([
+      "function* g() {",
+      "  (yield).x = 0;",
+      "  x = (yield) ? 0 : 0;",
+      "  x = (yield 0) ? 0 : 0;",
+      "  x = (yield) / 0;",
+      "}"
+    ], { singleGroups: true, esversion: 6 });
+
+  TestRun(test)
+    .addError(2, "Unnecessary grouping operator.")
+    .addError(3, "Unnecessary grouping operator.")
+    .addError(4, "Unnecessary grouping operator.")
+    .addError(5, "Unnecessary grouping operator.")
+    .addError(6, "Unnecessary grouping operator.")
+    .addError(7, "Unnecessary grouping operator.")
+    .addError(8, "Unnecessary grouping operator.")
+    .addError(9, "Unnecessary grouping operator.")
+    .addError(10, "Unnecessary grouping operator.")
+    .addError(11, "Unnecessary grouping operator.")
+    .addError(12, "Unnecessary grouping operator.")
+    .addError(13, "Unnecessary grouping operator.")
+    .addError(14, "Unnecessary grouping operator.")
+    .addError(15, "Unnecessary grouping operator.")
+    .addError(16, "Unnecessary grouping operator.")
+    .addError(17, "Unnecessary grouping operator.")
+    .addError(18, "Unnecessary grouping operator.")
+    .addError(19, "Unnecessary grouping operator.")
+    .addError(20, "Unnecessary grouping operator.")
+    .addError(21, "Unnecessary grouping operator.")
+    .addError(22, "Unnecessary grouping operator.")
+    .addError(23, "Unnecessary grouping operator.")
+    .addError(24, "Unnecessary grouping operator.")
+    .addError(25, "Unnecessary grouping operator.")
+    .addError(26, "Unnecessary grouping operator.")
+    .addError(27, "Unnecessary grouping operator.")
+    .addError(28, "Unnecessary grouping operator.")
+    .addError(29, "Unnecessary grouping operator.")
+    .addError(30, "Unnecessary grouping operator.")
+    .addError(31, "Unnecessary grouping operator.")
+    .addError(32, "Unnecessary grouping operator.")
+    .addError(33, "Unnecessary grouping operator.")
+    .addError(34, "Unnecessary grouping operator.")
+    .test([
+      "function* g() {",
+      "  (yield);",
+      "  (yield 0);",
+      "  var x = (yield);",
+      "  var y = (yield 0);",
+      "  x = (yield);",
+      "  x = (yield 0);",
+      "  x += (yield);",
+      "  x += (yield 0);",
+      "  x -= (yield);",
+      "  x -= (yield 0);",
+      "  x *= (yield);",
+      "  x *= (yield 0);",
+      "  x /= (yield);",
+      "  x /= (yield 0);",
+      "  x %= (yield);",
+      "  x %= (yield 0);",
+      "  x <<= (yield 0);",
+      "  x <<= (yield);",
+      "  x >>= (yield);",
+      "  x >>= (yield 0);",
+      "  x >>>= (yield);",
+      "  x >>>= (yield 0);",
+      "  x &= (yield);",
+      "  x &= (yield 0);",
+      "  x ^= (yield);",
+      "  x ^= (yield 0);",
+      "  x |= (yield);",
+      "  x |= (yield 0);",
+      "  x = 0 ? (yield) : 0;",
+      "  x = 0 ? (yield 0) : 0;",
+      "  x = 0 ? 0 : (yield);",
+      "  x = 0 ? 0 : (yield 0);",
+      "  yield (yield);",
+      "}"
+    ], { singleGroups: true, esversion: 6 });
+
+  test.done();
+};
+
 singleGroups.arrowFunctions = function (test) {
   var code = [
     "var a = () => ({});",

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -6264,11 +6264,46 @@ exports["test for crash with invalid condition"] = function (test) {
 exports["test 'yield' in compound expressions."] = function (test) {
   var code = fs.readFileSync(path.join(__dirname, "./fixtures/yield-expressions.js"), "utf8");
 
-  var run = TestRun(test)
+  var run = TestRun(test);
+
+  run
+    .addError(22, "Did you mean to return a conditional instead of an assignment?")
+    .addError(23, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 22 })
+    .addError(31, "Did you mean to return a conditional instead of an assignment?")
+    .addError(32, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 20 })
+    .addError(32, "Bad operand.", { character: 17 })
+    .addError(51, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 10 })
+    .addError(53, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 10 })
+    .addError(54, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 16 })
+    .addError(57, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 10 })
+    .addError(58, "Bad operand.", { character: 11 })
+    .addError(59, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 10 })
+    .addError(59, "Bad operand.", { character: 16 })
+    .addError(60, "Bad operand.", { character: 11 })
+    .addError(60, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 14 })
+    .addError(64, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 6 })
+    .addError(65, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 7 })
+    .addError(66, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 6 })
+    .addError(67, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 7 })
+    .addError(70, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 6 })
+    .addError(71, "Invalid position for 'yield' expression (consider wrapping in parenthesis).", { character: 7 })
+    .addError(77, "Bad operand.", { character: 11 })
+    .addError(78, "Bad operand.", { character: 11 })
+    .addError(78, "Bad operand.", { character: 19 })
+    .addError(79, "Bad operand.", { character: 11 })
+    .addError(79, "Bad operand.", { character: 19 })
+    .addError(79, "Bad operand.", { character: 47 })
+    .addError(82, "Bad operand.", { character: 11 })
+    .addError(83, "Bad operand.", { character: 11 })
+    .addError(83, "Bad operand.", { character: 19 })
+    .addError(84, "Bad operand.", { character: 11 })
+    .addError(84, "Bad operand.", { character: 19 })
+    .addError(84, "Bad operand.", { character: 43 })
+    .test(code, {maxerr: 1000, expr: true, esnext: true});
+
+  run = TestRun(test)
     .addError(22, "Did you mean to return a conditional instead of an assignment?")
     .addError(31, "Did you mean to return a conditional instead of an assignment?");
-
-  run.test(code, {maxerr: 1000, expr: true, esnext: true});
 
   // These are line-column pairs for the Mozilla paren errors.
   var needparen = [
@@ -6297,6 +6332,106 @@ exports["test 'yield' in compound expressions."] = function (test) {
     .addError(74, "'function*' is only available in ES6 (use 'esversion: 6').");
 
   run.test(code, {maxerr: 1000, expr: true, moz: true});
+
+  test.done();
+};
+
+exports["test 'yield' in invalid positions"] = function (test) {
+  var testRun = TestRun(test, "as an invalid operand")
+    .addError(1, "Invalid position for 'yield' expression (consider wrapping in parenthesis).");
+
+  testRun.test("function* g() { null || yield; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { null || yield null; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { null || yield* g(); }", { esversion: 6, expr: true });
+  testRun.test("function* g() { null && yield; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { null && yield null; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { null && yield* g(); }", { esversion: 6, expr: true });
+  testRun.test("function* g() { !yield; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { !yield null; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { !yield* g(); }", { esversion: 6, expr: true });
+  testRun.test("function* g() { !!yield; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { !!yield null; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { !!yield* g(); }", { esversion: 6, expr: true });
+  testRun.test("function* g() { 1 + yield; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { 1 + yield null; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { 1 + yield* g(); }", { esversion: 6, expr: true });
+  testRun.test("function* g() { 1 - yield; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { 1 - yield null; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { 1 - yield* g(); }", { esversion: 6, expr: true });
+
+  testRun = TestRun(test, "with an invalid operand")
+    .addError(1, "Bad operand.");
+
+  testRun.test("function* g() { yield.x; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { yield*.x; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { yield ? null : null; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { yield* ? null : null; }", { esversion: 6, expr: true });
+  testRun.test("function* g() { (yield ? 1 : 1); }", { esversion: 6, expr: true });
+  testRun.test("function* g() { (yield* ? 1 : 1); }", { esversion: 6, expr: true });
+  testRun.test("function* g() { yield / 1; }", { esversion: 6, expr: true });
+  TestRun(test)
+    .addError(1, "Unclosed regular expression.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test("function* g() { yield* / 1; }", { esversion: 6, expr: true });
+
+  TestRun(test, 'as a valid operand')
+    .test([
+      "function* g() {",
+      "  (yield);",
+      "  var x = yield;",
+      "  x = yield;",
+      "  x = (yield, null);",
+      "  x = (null, yield);",
+      "  x = (null, yield, null);",
+      "  x += yield;",
+      "  x -= yield;",
+      "  x *= yield;",
+      "  x /= yield;",
+      "  x %= yield;",
+      "  x <<= yield;",
+      "  x >>= yield;",
+      "  x >>>= yield;",
+      "  x &= yield;",
+      "  x ^= yield;",
+      "  x |= yield;",
+      "  x = (yield) ? 0 : 0;",
+      "  x = yield 0 ? 0 : 0;",
+      "  x = 0 ? yield : 0;",
+      "  x = 0 ? 0 : yield;",
+      "  x = 0 ? yield : yield;",
+      "  yield yield;",
+      "}"
+    ], { esversion: 6 });
+
+  TestRun(test, "with a valid operand")
+    .test([
+      "function *g() {",
+      "  yield g;",
+      "  yield{};",
+      // Misleading cases; potential future warning.
+      "  yield + 1;",
+      "  yield - 1;",
+      "  yield[0];",
+      "}"
+    ], { esversion: 6 });
+
+  var code = [
+    "function* g() {",
+    "  var x;",
+    "  x++",
+    "  yield;",
+    "  x--",
+    "  yield;",
+    "}"
+  ];
+
+  TestRun(test, "asi")
+    .addError(3, "Missing semicolon.")
+    .addError(5, "Missing semicolon.")
+    .test(code, { esversion: 6, expr: true });
+
+  TestRun(test, "asi (ignoring warnings)")
+    .test(code, { esversion: 6, expr: true, asi: true });
 
   test.done();
 };
@@ -6335,17 +6470,22 @@ exports["test for line breaks with 'yield'"] = function (test) {
   ];
 
   var run = TestRun(test)
-    .addError(3, "Bad line breaking before 'c'.")
-    .addError(6, "Bad line breaking before '+'.")
-    .addError(8, "Comma warnings can be turned off with 'laxcomma'.")
+    .addError(3, "Expected ')' to match '(' from line 2 and instead saw 'c'.")
+    .addError(3, "Missing semicolon.")
+    .addError(4, "Expected an identifier and instead saw ')'.")
+    .addError(4, "Expected an assignment or function call and instead saw an expression.")
+    .addError(5, "Missing semicolon.")
+    .addError(6, "Expected an assignment or function call and instead saw an expression.")
     .addError(7, "Bad line breaking before ','.")
-    .addError(9,  "Missing semicolon.")
+    .addError(8, "Comma warnings can be turned off with 'laxcomma'.")
+    .addError(9, "Missing semicolon.")
     .addError(10, "Expected an identifier and instead saw '?'.")
     .addError(10, "Expected an assignment or function call and instead saw an expression.")
     .addError(10, "Missing semicolon.")
     .addError(10, "Label 'i' on j statement.")
     .addError(10, "Expected an assignment or function call and instead saw an expression.")
-    .addError(14, "Bad line breaking before '+'.");
+    .addError(13, "Missing semicolon.")
+    .addError(14, "Expected an assignment or function call and instead saw an expression.");
 
   run.test(code, {esnext: true});
 
@@ -6398,12 +6538,12 @@ exports["test for line breaks with 'yield'"] = function (test) {
     "}"
   ];
 
-  TestRun(test, "gh-2530")
+  TestRun(test, "gh-2530 (asi: true)")
     .addError(5, "Bad line breaking before 'fn'.")
     .test(code2, { esnext: true, undef: false, asi: true });
 
-  TestRun(test, "gh-2530")
-    .addError(3, "Bad line breaking before 'fn'.")
+  TestRun(test, "gh-2530 (asi: false)")
+    .addError(2, "Missing semicolon.")
     .addError(5, "Bad line breaking before 'fn'.")
     .test(code2, { esnext: true, undef: false });
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3426,6 +3426,7 @@ exports["esnext generator with yield delegation, gh-1544"] = function(test) {
 
 
   TestRun(test).test(code, {esnext: true, noyield: true});
+  TestRun(test).test(code, {esnext: true, noyield: true, moz: true});
 
   test.done();
 };
@@ -3468,6 +3469,11 @@ exports["mozilla generator as esnext"] = function (test) {
     .addError(4,
      "A yield statement shall be within a generator function (with syntax: `function*`)")
     .test(code, {esnext: true, unused: true, undef: true, predef: ["print", "Iterator"]});
+
+  TestRun(test)
+    .addError(4,
+     "A yield statement shall be within a generator function (with syntax: `function*`)")
+    .test(code, {esnext: true, moz: true});
 
   test.done();
 };
@@ -3720,6 +3726,11 @@ exports["moz-style array comprehension as esnext"] = function (test) {
     .addError(7, "Expected 'for' and instead saw 'i'.")
     .addError(7, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
     .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+
+  TestRun(test)
+    .addError(3, "A yield statement shall be within a generator function (with syntax: " +
+      "`function*`)")
+    .test(code, {esnext: true, moz: true});
 
   test.done();
 };


### PR DESCRIPTION
At long last, here is a fix for gh-2923! You'll note the very first thing this
patch does is factor out the Mozilla-JavaScript-1.7-specific logic into a
standalone function. I think we 'd all like to remove `moz` one day, but until
then, this seems like the safest/most readable way to change the ECMAScript
standard version. (Since we we have no means to verify conformance with the
Mozilla-specific extension and no bug reports for that implementation, I've
elected to maintain behavior there.)

@rwaldron Would you mind reviewing this for me?