### PR TITLE
[[FIX]] Only allow Import statemnets in ES6 to be at top level of scope

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4478,7 +4478,7 @@ var JSHINT = (function() {
 
   stmt("import", function() {
     if (!state.funct["(scope)"].block.isGlobal()) {
-      error("E053", state.tokens.curr, state.tokens.curr.value);
+      error("E053", state.tokens.curr, "Import");
     }
 
     if (!state.inES6()) {
@@ -4579,7 +4579,7 @@ var JSHINT = (function() {
     }
 
     if (!state.funct["(scope)"].block.isGlobal()) {
-      error("E053", state.tokens.curr, state.tokens.curr.value);
+      error("E053", state.tokens.curr, "Export");
       ok = false;
     }
 

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4477,6 +4477,10 @@ var JSHINT = (function() {
   }).exps = true;
 
   stmt("import", function() {
+    if (!state.funct["(scope)"].block.isGlobal()) {
+      error("E061", state.tokens.curr);
+    }
+
     if (!state.inES6()) {
       warning("W119", state.tokens.curr, "import", "6");
     }

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4478,7 +4478,7 @@ var JSHINT = (function() {
 
   stmt("import", function() {
     if (!state.funct["(scope)"].block.isGlobal()) {
-      error("E061", state.tokens.curr);
+      error("E053", state.tokens.curr, state.tokens.curr.value);
     }
 
     if (!state.inES6()) {
@@ -4579,7 +4579,7 @@ var JSHINT = (function() {
     }
 
     if (!state.funct["(scope)"].block.isGlobal()) {
-      error("E053", state.tokens.curr);
+      error("E053", state.tokens.curr, state.tokens.curr.value);
       ok = false;
     }
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -75,7 +75,8 @@ var errors = {
   E057: "Invalid meta property: '{a}.{b}'.",
   E058: "Missing semicolon.",
   E059: "Incompatible values for the '{a}' and '{b}' linting options.",
-  E060: "Non-callable values cannot be used as the second operand to instanceof."
+  E060: "Non-callable values cannot be used as the second operand to instanceof.",
+  E061: "Import declarations are only allowed at the top level of module scope."
 };
 
 var warnings = {

--- a/src/messages.js
+++ b/src/messages.js
@@ -68,15 +68,14 @@ var errors = {
   E050: "Mozilla requires the yield expression to be parenthesized here.",
   E051: null,
   E052: "Unclosed template literal.",
-  E053: "Export declaration must be in global scope.",
+  E053: "{a} declarations are only allowed at the top level of module scope.",
   E054: "Class properties must be methods. Expected '(' but instead saw '{a}'.",
   E055: "The '{a}' option cannot be set after any executable code.",
   E056: "'{a}' was used before it was declared, which is illegal for '{b}' variables.",
   E057: "Invalid meta property: '{a}.{b}'.",
   E058: "Missing semicolon.",
   E059: "Incompatible values for the '{a}' and '{b}' linting options.",
-  E060: "Non-callable values cannot be used as the second operand to instanceof.",
-  E061: "Import declarations are only allowed at the top level of module scope."
+  E060: "Non-callable values cannot be used as the second operand to instanceof."
 };
 
 var warnings = {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -6988,17 +6988,17 @@ exports.testES6BlockExports = function (test) {
   TestRun(test)
     .addError(1, "'broken' is defined but never used.")
     .addError(2, "'broken2' is defined but never used.")
-    .addError(4, "export declarations are only allowed at the top level of module scope.")
-    .addError(5, "export declarations are only allowed at the top level of module scope.")
-    .addError(6, "export declarations are only allowed at the top level of module scope.")
-    .addError(7, "export declarations are only allowed at the top level of module scope.")
-    .addError(8, "export declarations are only allowed at the top level of module scope.")
-    .addError(14, "export declarations are only allowed at the top level of module scope.")
-    .addError(15, "export declarations are only allowed at the top level of module scope.")
-    .addError(16, "export declarations are only allowed at the top level of module scope.")
-    .addError(17, "export declarations are only allowed at the top level of module scope.")
+    .addError(4, "Export declarations are only allowed at the top level of module scope.")
+    .addError(5, "Export declarations are only allowed at the top level of module scope.")
+    .addError(6, "Export declarations are only allowed at the top level of module scope.")
+    .addError(7, "Export declarations are only allowed at the top level of module scope.")
+    .addError(8, "Export declarations are only allowed at the top level of module scope.")
+    .addError(14, "Export declarations are only allowed at the top level of module scope.")
+    .addError(15, "Export declarations are only allowed at the top level of module scope.")
+    .addError(16, "Export declarations are only allowed at the top level of module scope.")
+    .addError(17, "Export declarations are only allowed at the top level of module scope.")
     .addError(17, "Function declarations should not be placed in blocks. Use a function expression or move the statement to the top of the outer function.")
-    .addError(18, "export declarations are only allowed at the top level of module scope.")
+    .addError(18, "Export declarations are only allowed at the top level of module scope.")
     .test(code, { esnext: true, unused: true });
 
   test.done();
@@ -7022,10 +7022,10 @@ exports.testES6BlockImports = function (test) {
   ];
 
   TestRun(test)
-    .addError(2, "import declarations are only allowed at the top level of module scope.")
-    .addError(5, "import declarations are only allowed at the top level of module scope.")
-    .addError(8, "import declarations are only allowed at the top level of module scope.")
-    .addError(11, "import declarations are only allowed at the top level of module scope.")
+    .addError(2, "Import declarations are only allowed at the top level of module scope.")
+    .addError(5, "Import declarations are only allowed at the top level of module scope.")
+    .addError(8, "Import declarations are only allowed at the top level of module scope.")
+    .addError(11, "Import declarations are only allowed at the top level of module scope.")
     .test(code, { esversion: 6, module: true });
 
   test.done();

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7004,6 +7004,20 @@ exports.testES6BlockExports = function (test) {
   test.done();
 };
 
+exports.testES6BlockImports = function (test) {
+  var code = [
+    "{",
+    " import x from './m.js';",
+    "}"
+  ];
+
+  TestRun(test)
+    .addError(2, "Import declarations are only allowed at the top level of module scope.")
+    .test(code, { esversion: 6, module: true });
+
+  test.done();
+};
+
 exports.testStrictDirectiveASI = function (test) {
   var options = { strict: true, asi: true, globalstrict: true, predef: ["x"] };
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -6988,17 +6988,17 @@ exports.testES6BlockExports = function (test) {
   TestRun(test)
     .addError(1, "'broken' is defined but never used.")
     .addError(2, "'broken2' is defined but never used.")
-    .addError(4, "Export declaration must be in global scope.")
-    .addError(5, "Export declaration must be in global scope.")
-    .addError(6, "Export declaration must be in global scope.")
-    .addError(7, "Export declaration must be in global scope.")
-    .addError(8, "Export declaration must be in global scope.")
-    .addError(14, "Export declaration must be in global scope.")
-    .addError(15, "Export declaration must be in global scope.")
-    .addError(16, "Export declaration must be in global scope.")
-    .addError(17, "Export declaration must be in global scope.")
+    .addError(4, "export declarations are only allowed at the top level of module scope.")
+    .addError(5, "export declarations are only allowed at the top level of module scope.")
+    .addError(6, "export declarations are only allowed at the top level of module scope.")
+    .addError(7, "export declarations are only allowed at the top level of module scope.")
+    .addError(8, "export declarations are only allowed at the top level of module scope.")
+    .addError(14, "export declarations are only allowed at the top level of module scope.")
+    .addError(15, "export declarations are only allowed at the top level of module scope.")
+    .addError(16, "export declarations are only allowed at the top level of module scope.")
+    .addError(17, "export declarations are only allowed at the top level of module scope.")
     .addError(17, "Function declarations should not be placed in blocks. Use a function expression or move the statement to the top of the outer function.")
-    .addError(18, "Export declaration must be in global scope.")
+    .addError(18, "export declarations are only allowed at the top level of module scope.")
     .test(code, { esnext: true, unused: true });
 
   test.done();
@@ -7008,11 +7008,24 @@ exports.testES6BlockImports = function (test) {
   var code = [
     "{",
     " import x from './m.js';",
-    "}"
+    "}",
+    "function limitScope(){",
+    " import {x} from './m.js';",
+    "}",
+    "(function(){",
+    " import './m.js';",
+    "}());",
+    "{",
+    " import {x as y} from './m.js';",
+    "}",
+    "limitScope();"
   ];
 
   TestRun(test)
-    .addError(2, "Import declarations are only allowed at the top level of module scope.")
+    .addError(2, "import declarations are only allowed at the top level of module scope.")
+    .addError(5, "import declarations are only allowed at the top level of module scope.")
+    .addError(8, "import declarations are only allowed at the top level of module scope.")
+    .addError(11, "import declarations are only allowed at the top level of module scope.")
     .test(code, { esversion: 6, module: true });
 
   test.done();


### PR DESCRIPTION
Added a conditional within stmt("import" that checks if the scope of the import statement is not global using the isGlobal function call.  If it is not global I created an error message in messages.js named E061 that lets the user know that their import statement needs to be at the top level of the module scope.

This issue fixes https://github.com/jshint/jshint/issues/2975.