### PR TITLE
Improve the license information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "unicode-6.3.0":                  "0.1.x"
   },
 
-  "license": "(MIT AND JSON)",
+  "licenses": ["MIT", "JSON"],
 
   "preferGlobal": true,
 


### PR DESCRIPTION
I separated the license information into an Array. That way it's easier to handle for [VersionEye](https://www.versioneye.com) and other tools which are dealing with license information.