### PR TITLE
[[CHORE]] Refactor directive parsing logic

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -809,9 +809,12 @@ var JSHINT = (function() {
     return token.infix || (!token.identifier && !token.template && !!token.led);
   }
 
-  function isEndOfExpr() {
-    var curr = state.tokens.curr;
-    var next = state.tokens.next;
+  function isEndOfExpr(curr, next) {
+    if (arguments.length === 0) {
+      curr = state.tokens.curr;
+      next = state.tokens.next;
+    }
+
     if (next.id === ";" || next.id === "}" || next.id === ":") {
       return true;
     }
@@ -1682,12 +1685,13 @@ var JSHINT = (function() {
    * read all directives
    */
   function directives() {
+    var current = state.tokens.next;
     while (state.tokens.next.id === "(string)") {
-      var p = peekIgnoreEOL();
-      if (p.lbp > 0 && p.lbp !== 150 ||
-          (startLine(p) === state.tokens.next.line && checkPunctuators(p, ["++", "--"]))) {
+      var next = peekIgnoreEOL();
+      if (!isEndOfExpr(current, next)) {
         break;
       }
+      current = next;
 
       advance();
       var directive = state.tokens.curr.value;

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -619,8 +619,9 @@ exports.asi = function (test) {
   TestRun(test, "gh-2714")
     .addError(2, "Unnecessary directive \"code\".")
     .addError(3, "Expected an assignment or function call and instead saw an expression.")
-    .addError(6, "Unnecessary directive \"code\".")
     .addError(6, "Missing semicolon.", { code: "E058" })
+    .addError(6, "Expected an assignment or function call and instead saw an expression.", { character: 16 })
+    .addError(6, "Expected an assignment or function call and instead saw an expression.", { character: 23 })
     .test(code, { asi: true });
 
   test.done();


### PR DESCRIPTION
Extend the recently-improved `isEndOfExpr` function so that it may be
re-used during directive parsing, limiting duplication.

---

@nicolo-ribaudo this refactors some of your work from gh-2716 to re-use the
recent general improvement to ASI interpretation from gh-2977. What do you
think?