### PR TITLE
[[FIX]] Support semicolons within arrow fn params

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2498,7 +2498,7 @@ var JSHINT = (function() {
       i += 1;
       pn1 = pn;
       pn = peek(i);
-    } while (!(parens === 0 && pn1.value === ")") && pn.value !== ";" && pn.type !== "(end)");
+    } while (!(parens === 0 && pn1.value === ")") && pn.type !== "(end)");
 
     if (state.tokens.next.id === "function") {
       triggerFnExpr = state.tokens.next.immed = true;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5371,6 +5371,15 @@ exports["expressions in place of arrow function parameters"] = function (test) {
   test.done();
 };
 
+exports["arrow function parameter containing semicolon (gh-3002)"] = function (test) {
+  TestRun(test)
+    .addError(1, "Unnecessary semicolon.", { character: 19 })
+    .addError(1, "Expected an assignment or function call and instead saw an expression.", { character: 27 })
+    .test("(x = function() { ; }) => 0;", { esversion: 6 });
+
+  test.done();
+};
+
 var conciseMethods = exports.conciseMethods = {};
 
 conciseMethods.basicSupport = function (test) {


### PR DESCRIPTION
When JSHint encounters an "open parenthesis" token, it must determine if
the token marks the beginning of an arrow function or a grouping
operator before parsing can proceed.

To make this determination, it inspects the token stream to find the
corresponding "close parenthesis" character.

Previously, this lookahead behavior halted whenever a semicolon token
was encountered. This was presumably an optimization to allow the
algorithm to exit early in the event of an unmatched "open parenthesis"
token.

Because a semicolon token may appear in the parameter list of an arrow
function (e.g. within a default parameter value that is a function
expression), the presence of such a token does *not* necessarily
indicate that the "open parenthesis" is unmatched.

Remove the condition concerning the semicolon character from the
lookahead algorithm.

Resolves gh-3002.