### PR TITLE
[[CHORE]] Update dependency: cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "main": "./src/jshint.js",
 
   "dependencies": {
-    "cli":                 "0.11.x",
+    "cli":                 "~1.0.0",
     "console-browserify":  "1.1.x",
     "exit":                "0.1.x",
     "htmlparser2":         "3.8.x",


### PR DESCRIPTION
The `cli` module at this version range was recently found to have a
security vulnerability in a feature that is not used in JSHint. Update
to the latest version which resolves the vulnerability by removing the
affected functionality.