### PR TITLE
[[FEAT]] Remove fdescribe and fit from Jasmine's globals

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -730,7 +730,5 @@ exports.jasmine = {
   beforeAll   : false,
   afterAll    : false,
   fail        : false,
-  fdescribe   : false,
-  fit         : false,
   pending     : false
 };


### PR DESCRIPTION
Remove Jasmine 2.1 focused spec globals to be consistent with the Jasmine 1.3 globals

Fixes #3022 