### PR TITLE
Rephrase message for W014

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -93,7 +93,7 @@ var warnings = {
   W011: null,
   W012: null,
   W013: null,
-  W014: "Bad line breaking before '{a}'.",
+  W014: "Misleading line break before '{a}'; readers may interpret this as an expression boundary.",
   W015: null,
   W016: "Unexpected use of '{a}'.",
   W017: "Bad operand.",

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -634,7 +634,7 @@ exports.safeasi = function (test) {
   TestRun(test, 1)
     // TOOD consider setting an option to suppress these errors so that
     // the tests don't become tightly interdependent
-    .addError(10, "Bad line breaking before '/'.")
+    .addError(10, "Misleading line break before '/'; readers may interpret this as an expression boundary.")
     .addError(10, "Expected an identifier and instead saw '.'.")
     .addError(10, "Expected an assignment or function call and instead saw an expression.")
     .addError(10, "Missing semicolon.")
@@ -644,10 +644,10 @@ exports.safeasi = function (test) {
     .test(src, {});
 
   TestRun(test, 2)
-    .addError(5, "Bad line breaking before '('.")
-    .addError(8, "Bad line breaking before '('.")
-    .addError(10, "Bad line breaking before '/'.")
-    .addError(10, "Bad line breaking before '/'.")
+    .addError(5, "Misleading line break before '('; readers may interpret this as an expression boundary.")
+    .addError(8, "Misleading line break before '('; readers may interpret this as an expression boundary.")
+    .addError(10, "Misleading line break before '/'; readers may interpret this as an expression boundary.")
+    .addError(10, "Misleading line break before '/'; readers may interpret this as an expression boundary.")
     .addError(10, "Expected an identifier and instead saw '.'.")
     .addError(10, "Expected an assignment or function call and instead saw an expression.")
     .addError(10, "Missing semicolon.")
@@ -1962,9 +1962,9 @@ exports.laxbreak = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/laxbreak.js', 'utf8');
 
   TestRun(test)
-    .addError(2, "Bad line breaking before ','.")
+    .addError(2, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(3, "Comma warnings can be turned off with 'laxcomma'.")
-    .addError(12, "Bad line breaking before ','.")
+    .addError(12, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .test(src, { es3: true });
 
   var ops = [ '||', '&&', '*', '/', '%', '+', '-', '>=',
@@ -1973,7 +1973,7 @@ exports.laxbreak = function (test) {
   for (var i = 0, op, code; op = ops[i]; i += 1) {
     code = ['var a = b ', op + ' c;'];
     TestRun(test)
-      .addError(2, "Bad line breaking before '" + op + "'.")
+      .addError(2, "Misleading line break before '" + op + "'; readers may interpret this as an expression boundary.")
       .test(code, { es3: true });
 
     TestRun(test).test(code, { es3: true, laxbreak: true });
@@ -1981,7 +1981,7 @@ exports.laxbreak = function (test) {
 
   code = [ 'var a = b ', '? c : d;' ];
   TestRun(test)
-    .addError(2, "Bad line breaking before '?'.")
+    .addError(2, "Misleading line break before '?'; readers may interpret this as an expression boundary.")
     .test(code, { es3: true });
 
   TestRun(test).test(code, { es3: true, laxbreak: true });
@@ -2240,26 +2240,26 @@ exports.laxcomma = function (test) {
 
   // All errors.
   TestRun(test)
-    .addError(1, "Bad line breaking before ','.")
+    .addError(1, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(2, "Comma warnings can be turned off with 'laxcomma'.")
-    .addError(2, "Bad line breaking before ','.")
-    .addError(6, "Bad line breaking before ','.")
-    .addError(10, "Bad line breaking before '&&'.")
-    .addError(15, "Bad line breaking before '?'.")
+    .addError(2, "Misleading line break before ','; readers may interpret this as an expression boundary.")
+    .addError(6, "Misleading line break before ','; readers may interpret this as an expression boundary.")
+    .addError(10, "Misleading line break before '&&'; readers may interpret this as an expression boundary.")
+    .addError(15, "Misleading line break before '?'; readers may interpret this as an expression boundary.")
     .test(src, {es3: true});
 
   // Allows bad line breaking, but not on commas.
   TestRun(test)
-    .addError(1, "Bad line breaking before ','.")
+    .addError(1, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(2, "Comma warnings can be turned off with 'laxcomma'.")
-    .addError(2, "Bad line breaking before ','.")
-    .addError(6, "Bad line breaking before ','.")
+    .addError(2, "Misleading line break before ','; readers may interpret this as an expression boundary.")
+    .addError(6, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .test(src, {es3: true, laxbreak: true });
 
   // Allows comma-first style but warns on bad line breaking
   TestRun(test)
-    .addError(10, "Bad line breaking before '&&'.")
-    .addError(15, "Bad line breaking before '?'.")
+    .addError(10, "Misleading line break before '&&'; readers may interpret this as an expression boundary.")
+    .addError(15, "Misleading line break before '?'; readers may interpret this as an expression boundary.")
     .test(src, {es3: true, laxcomma: true });
 
   // No errors if both laxbreak and laxcomma are turned on

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -5207,8 +5207,8 @@ exports["automatic comma insertion GH-950"] = function (test) {
   ];
 
   var run = TestRun(test)
-    .addError(2, "Bad line breaking before 'instanceof'.")
-    .addError(6, "Bad line breaking before '&&'.")
+    .addError(2, "Misleading line break before 'instanceof'; readers may interpret this as an expression boundary.")
+    .addError(6, "Misleading line break before '&&'; readers may interpret this as an expression boundary.")
     .addError(8, "Line breaking error 'return'.")
     .addError(9, "Label 'a' on 1 statement.")
     .addError(9, "Expected an assignment or function call and instead saw an expression.")
@@ -5221,10 +5221,10 @@ exports["automatic comma insertion GH-950"] = function (test) {
   run.test(code, {moz: true, asi: true});
 
   run = TestRun(test)
-    .addError(2, "Bad line breaking before 'instanceof'.")
+    .addError(2, "Misleading line break before 'instanceof'; readers may interpret this as an expression boundary.")
     .addError(3, "Missing semicolon.")
     .addError(4, "Missing semicolon.")
-    .addError(6, "Bad line breaking before '&&'.")
+    .addError(6, "Misleading line break before '&&'; readers may interpret this as an expression boundary.")
     .addError(8, "Line breaking error 'return'.")
     .addError(8, "Missing semicolon.")
     .addError(9, "Label 'a' on 1 statement.")
@@ -6529,7 +6529,7 @@ exports["test for line breaks with 'yield'"] = function (test) {
     .addError(4, "Expected an assignment or function call and instead saw an expression.")
     .addError(5, "Missing semicolon.")
     .addError(6, "Expected an assignment or function call and instead saw an expression.")
-    .addError(7, "Bad line breaking before ','.")
+    .addError(7, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(8, "Comma warnings can be turned off with 'laxcomma'.")
     .addError(9, "Missing semicolon.")
     .addError(10, "Expected an identifier and instead saw '?'.")
@@ -6558,7 +6558,7 @@ exports["test for line breaks with 'yield'"] = function (test) {
     .addError(4, "Expected an assignment or function call and instead saw an expression.")
     .addError(6, "Expected an assignment or function call and instead saw an expression.")
     .addError(8, "Comma warnings can be turned off with 'laxcomma'.")
-    .addError(7, "Bad line breaking before ','.")
+    .addError(7, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(10, "Expected an identifier and instead saw '?'.")
     .addError(10, "Missing semicolon.")
     .addError(10, "Expected an assignment or function call and instead saw an expression.")
@@ -6592,12 +6592,12 @@ exports["test for line breaks with 'yield'"] = function (test) {
   ];
 
   TestRun(test, "gh-2530 (asi: true)")
-    .addError(5, "Bad line breaking before 'fn'.")
+    .addError(5, "Misleading line break before 'fn'; readers may interpret this as an expression boundary.")
     .test(code2, { esnext: true, undef: false, asi: true });
 
   TestRun(test, "gh-2530 (asi: false)")
     .addError(2, "Missing semicolon.")
-    .addError(5, "Bad line breaking before 'fn'.")
+    .addError(5, "Misleading line break before 'fn'; readers may interpret this as an expression boundary.")
     .test(code2, { esnext: true, undef: false });
 
   test.done();
@@ -7273,7 +7273,7 @@ exports.testStrictDirectiveASI = function (test) {
     .test("'use strict'\n!x;", options);
 
   TestRun(test, 12)
-    .addError(2, "Bad line breaking before '+'.")
+    .addError(2, "Misleading line break before '+'; readers may interpret this as an expression boundary.")
     .addError(2, "Missing \"use strict\" statement.")
     .addError(2, "Expected an assignment or function call and instead saw an expression.")
     .test("'use strict'\n+x;", options);
@@ -7698,7 +7698,7 @@ exports.parsingCommas = function (test) {
   TestRun(test)
     .addError(2, "Unexpected ','.")
     .addError(2, "Comma warnings can be turned off with 'laxcomma'.")
-    .addError(1, "Bad line breaking before ','.")
+    .addError(1, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(2, "Expected an identifier and instead saw ';'.")
     .addError(2, "Expected an identifier and instead saw ')'.")
     .addError(2, "Expected ';' and instead saw '{'.")


### PR DESCRIPTION
W014 was previously implemented with the following message:

> Bad line breaking before '{ token }'.

This message does little to explain the rationale for the warning or the
means to correct it. Re-phrase the message to better reflect the
intention.