### PR TITLE
[[FIX]] Avoid crashing on invalid input

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2128,6 +2128,12 @@ var JSHINT = (function() {
     token.left = left;
     token.right = right = expression(120);
 
+    // This condition reflects a syntax error which will be reported by the
+    // `expression` function.
+    if (!right) {
+      return token;
+    }
+
     if (right.id === "(number)" ||
         right.id === "(string)" ||
         right.value === "null" ||

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7875,6 +7875,12 @@ exports.instanceOfLiterals = function (test) {
 
   run.test(code, { esversion: 6 });
 
+  TestRun(test)
+    .addError(1, "Expected an identifier and instead saw ';'.")
+    .addError(1, "Expected an assignment or function call and instead saw an expression.")
+    .addError(1, "Missing semicolon.")
+    .test('0 instanceof;');
+
   test.done();
 };
 


### PR DESCRIPTION
A recent extension to the `instanceof` operator introduced logic that
performed property access on the result of parsing the operator's
right-hand expression operand. Because invalid code may not specify such
an expression, this logic led to program crashes in response to the
invalid syntax.

Ensure that when the `instanceof` operator appears without a right-hand
expression operand, JSHint reports a syntax error and exits gracefully.

This should resolve gh-3039. @rwaldron mind taking a look?