### PR TITLE
[[FIX]] Consistently lint evaluated code

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2454,7 +2454,7 @@ var JSHINT = (function() {
             left.value === "execScript") {
           warning("W061", left);
 
-          if (p[0] && [0].id === "(string)") {
+          if (p[0] && p[0].id === "(string)") {
             addInternalSrc(left, p[0].value);
           }
         } else if (p[0] && p[0].id === "(string)" &&

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -452,7 +452,23 @@ exports.escapedEvil = function (test) {
 
   TestRun(test)
     .addError(1, "eval can be harmful.")
+    .addError(1, "Expected an assignment or function call and instead saw an expression.")
+    .addError(1, "Missing semicolon.")
     .test(code, { evil: false });
+
+  test.done();
+};
+
+exports.lintEval = function (test) {
+  TestRun(test, "Via direct eval")
+    .addError(1, "eval can be harmful.")
+    .addError(1, "Expected an assignment or function call and instead saw an expression.")
+    .test("void eval('0;');");
+
+  TestRun(test, "Via Function constructor")
+    .addError(1, "eval can be harmful.")
+    .addError(1, "Expected an assignment or function call and instead saw an expression.")
+    .test("void Function('0;');");
 
   test.done();
 };


### PR DESCRIPTION
Previously, upon encountering certain forms of dynamic code evaluation
(namely the browser's `setTimeout` and `setInterval` functions), JSHint
would attempt to lint the code being evaluated. Due to what appears to
to be an unintentional typo on the JSHint source code, this behavior did
not extend to code evaluated via the `Function` and `eval` functions.

Extend this behavior to all forms of evaluated code.

---

@rwaldron: This is about 3 bugs separated from a more important issue, but I
want to tackle each part on its own. What do you think about this? It's
backwards-breaking, but the current behavior is clearly inconsistent and clearly
the result of a typo.