### PR TITLE
[[DOCS]] Document inconsistent behavior

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2454,9 +2454,16 @@ var JSHINT = (function() {
             left.value === "execScript") {
           warning("W061", left);
 
-          if (p[0] && [0].id === "(string)") {
-            addInternalSrc(left, p[0].value);
-          }
+          // This conditional expression was initially implemented with a typo
+          // which prevented the branch's execution in all cases. While
+          // enabling the code will produce behavior that is consistent with
+          // the other forms of code evaluation that follow, such a change is
+          // also technically incompatable with prior versions of JSHint (due
+          // to the fact that the behavior was never formally documented). This
+          // branch should be enabled as part of a major release.
+          //if (p[0] && p[0].id === "(string)") {
+          //  addInternalSrc(left, p[0].value);
+          //}
         } else if (p[0] && p[0].id === "(string)" &&
              (left.value === "setTimeout" ||
             left.value === "setInterval")) {


### PR DESCRIPTION
As noted in the in-line comment, the current behavior is a result of a
programming error. It may not be resolved outside of a major release
because the project documentation does not describe the more desirable
consistent behavior.

---

@rwaldron We may not be able to fix it today, but we can at least same
some cycles (and confusion) by commenting this out.