### PR TITLE
[[FIX]] Remove `null` value from `errors` array

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -5379,7 +5379,7 @@ var JSHINT = (function() {
           reason    : err.reason,
           line      : err.line || nt.line,
           character : err.character || nt.from
-        }, null);
+        });
       } else {
         throw err;
       }

--- a/tests/helpers/testhelper.js
+++ b/tests/helpers/testhelper.js
@@ -52,9 +52,7 @@ exports.setup.testRun = function (test, name) {
 
     test: function (source, options, globals) {
       var ret = !!JSHINT(source, options, globals);
-      var errors = JSHINT.errors.filter(function (er) {
-        return er;
-      });
+      var errors = JSHINT.errors;
 
       if (errors.length === 0 && definedErrors.length === 0) {
         return;


### PR DESCRIPTION
When reporting unrecoverable errors, JSHint would insert two elements
into the global `errors` array: a descriptor for the error itself, and a
`null` value. Because this behavior is undocumented and inconsistent, it
is most likely the result of a programming error. Ensure that the
`JSHINT.errors` collection contains only error descriptor.

---

@rwaldron This has been around since the first commit!

https://github.com/jshint/jshint/blob/ca120a731db548c0014320fa0c196edc613536ae/fulljslint.js#L5509

Funny how the testing infrastructure was built up to tolerate it.