### PR TITLE
[[FIX]] Close synthetic scope for labeled blocks

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1625,6 +1625,11 @@ var JSHINT = (function() {
       //  }
       var iscase = (state.funct["(verb)"] === "case" && state.tokens.curr.value === ":");
       block(true, true, false, false, iscase);
+
+      if (hasOwnScope) {
+        state.funct["(scope)"].unstack();
+      }
+
       return;
     }
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -867,6 +867,14 @@ exports.testES6Modules = function (test) {
   TestRun(test)
     .test(src2, {});
 
+  // See gh-3055 "Labels Break JSHint"
+  TestRun(test, "following labeled block")
+    .test([
+      "label: {}",
+      "export function afterLabelExported() {}",
+      "import afterLabelImported from 'elsewhere';"
+    ], { esversion: 6 });
+
   test.done();
 };
 
@@ -1756,6 +1764,14 @@ exports.labelsOutOfScope = function (test) {
     .addError(22, "'bar' is not a statement label.")
     .addError(24, "'baz' is not a statement label.")
     .test(src);
+
+  // See gh-3055 "Labels Break JSHint"
+  TestRun(test, "following labeled block")
+    .addError(2, "'x' is not a statement label.")
+    .test([
+      "x: {}",
+      "break x;"
+    ]);
 
   test.done();
 };

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -787,6 +787,16 @@ exports.undef = function (test) {
 
   test.strictEqual(JSHINT.data().implieds, undefined);
 
+  // See gh-3055 "Labels Break JSHint"
+  TestRun(test, "following labeled block")
+    .addError(4, "'x' is not defined.")
+    .test([
+      "label: {",
+      "  let x;",
+      "}",
+      "void x;"
+    ], { esversion: 6, undef: true });
+
   test.done();
 };
 


### PR DESCRIPTION
@rwaldron Honestly, I'm not such a big fan of the way labeled statements have
been implemented here. Creating a synthetic scope is just asking for bugs
exactly like gh-3055.

That said, it seems kind of onerous to implement more accurate semantics. I
think we'd need to extend the `expression` function to accept an optional label
identifier. When it encountered block-creating statements, it would assign the
label correctly.

The approach I'm proposing here is much simpler, and it is probably "safer" for
it. Maybe we can address the synthetic scope in some future patch. What do you
think?

Commit message:

> [[FIX]] Close synthetic scope for labeled blocks
> 
> JSHint creates a synthetic block scope in order to track labeled
> statements prior to parsing the statements themselves. Previously, this
> scope was not closed (or "unstacked") for labeled Block statements.
> 
> Ensure that the synthetic scope is closed in these cases as well. Assert
> correct behavior via various parsing/linting mechanisms that are aware
> of scope.

Resolves gh-3055.
