### PR TITLE
[[FIX]] Avoid crash when peeking past end of prog

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -699,12 +699,23 @@ var JSHINT = (function() {
     }
   }
 
-  // We need a peek function. If it has an argument, it peeks that much farther
-  // ahead. It is used to distinguish
-  //     for ( var i in ...
-  // from
-  //     for ( var i = ...
-
+  /**
+   * Return a token beyond the token available in `state.tokens.next`. If no
+   * such token exists, return the "(end)" token. This function is used to
+   * determine parsing strategies in cases where the value of the next token
+   * does not provide sufficient information, as is the case with `for` loops,
+   * e.g.:
+   *
+   *     for ( var i in ...
+   *
+   * versus:
+   *
+   *     for ( var i = ...
+   *
+   * @param {number} [p] - offset of desired token; defaults to 0
+   *
+   * @returns {token}
+   */
   function peek(p) {
     var i = p || 0, j = lookahead.length, t;
 
@@ -715,10 +726,18 @@ var JSHINT = (function() {
     while (j <= i) {
       t = lex.token();
 
-      // Peeking past the end of the program should produce the "(end)" token
-      // and should not extend the lookahead buffer.
-      if (!t && state.tokens.next.id === "(end)") {
-        return state.tokens.next;
+      // When the lexer is exhausted, this function should produce the "(end)"
+      // token, even in cases where the requested token is beyond the end of
+      // the input stream.
+      if (!t) {
+        // If the lookahead buffer is empty, the expected "(end)" token was
+        // already emitted by the most recent invocation of `advance` and is
+        // available as the next token.
+        if (!lookahead.length) {
+          return state.tokens.next;
+        }
+
+        return lookahead[j - 1];
       }
 
       lookahead[j] = t;

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7944,3 +7944,14 @@ exports.forInExpr = function (test) {
 
   test.done();
 };
+
+// See gh-3004, "Starting jsdoc comment causes 'Unclosed regular expression'
+// error"
+exports.lookaheadBeyondEnd = function (test) {
+  TestRun(test)
+    .addError(1, "Unmatched '{'.")
+    .addError(1, "Unrecoverable syntax error. (100% scanned).")
+    .test("({ a: {");
+
+  test.done();
+};


### PR DESCRIPTION
The internal `peek` function may be used to request tokens beyond the
end of the program. Because multiple call sites expect the function to
consistently return an object value, the "end of program" token is be
returned in these cases.

However, this situation may occur in cases where the "end of program"
token is not the next token. The previous implementation of the function
would produce the `null` value in this event, violating callers'
expectation and resulting in runtime reference errors.

Update the internal `peek` function to consistently return the "end of
program" token when input has been exhausted--even when this is not the
next token.

This should resolve gh-3004. @rwaldron What do you think?