### PR TITLE
[[DOCS]] Improve description of `unused` option

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -917,10 +917,10 @@ exports.val = {
    * In addition to that, this option will warn you about unused global
    * variables declared via the `global` directive.
    *
-   * This can be set to `vars` to only check for variables, not function
-   * parameters, or `strict` to check all variables and parameters.  The
-   * default (true) behavior is to allow unused parameters that are followed by
-   * a used parameter.
+   * When set to `true`, unused parameters that are followed by a used
+   * parameter will not produce warnings. This option can be set to `vars` to
+   * only check for variables, not function parameters, or `strict` to check
+   * all variables and parameters.
    */
   unused       : true,
 


### PR DESCRIPTION
As an "enforcing" option, `unused` is not enabled by default. The phrase
"by default" should be avoided because it may be interpreted to describe
JSHint's behavior when the option is not enabled.

This should resolve gh-2358. Wouldn't you agree, @rwaldron?