### PR TITLE
Fixes a typo and missing space

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,7 @@ var OPTIONS = {
   "reporter": ["reporter", "Custom reporter (<PATH>|jslint|checkstyle|unix)", "string", undefined ],
   "prereq": [
     "prereq",
-    "Comma-separate list of prerequisite (paths). E.g. files which include" +
+    "Comma-separated list of prerequisite (paths). E.g. files which include " +
     "definitions of global variabls used throughout your project",
     "string",
     null

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,7 @@ var OPTIONS = {
   "reporter": ["reporter", "Custom reporter (<PATH>|jslint|checkstyle|unix)", "string", undefined ],
   "prereq": [
     "prereq",
-    "Comma-separated list of prerequisite (paths). E.g. files which include " +
+    "Comma-separated list of prerequisites (paths). E.g. files which include " +
     "definitions of global variabls used throughout your project",
     "string",
     null


### PR DESCRIPTION
I also _think_ that "prerequisite" should be plural, but I may not understand enough what that term means here, so left that as is. I'd be happy to include that though 😄 