### PR TITLE
[[FEAT]] Allow HTML-like comments

### DIFF
--- a/examples/.jshintrc
+++ b/examples/.jshintrc
@@ -11,6 +11,7 @@
     "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
     "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
     "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
+    "htmlcomments"  : true,     // true: Prohibit use of HTML-like comments (`<!--`)
     "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
     "latedef"       : false,    // true: Require variables/functions to be defined before being used
     "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`

--- a/src/lex.js
+++ b/src/lex.js
@@ -490,7 +490,26 @@ Lexer.prototype = {
       return null;
     }
 
-    // Comments must start either with // or /*
+    // HTML-like comments start with <!-- and cause the line to be ignored upto the EOL
+    if (!state.option.htmlcomments && ch1 === "<" && ch2 === "!" &&
+      this.peek(2) === "-" && this.peek(3) === "-") {
+      // Warn if HTML-like comments are used before ES5, where they were
+      // standardised, but still widely implemented.
+      if (!state.inES5()) {
+        this.triggerAsync("warning", {
+            code: "W119",
+            line: this.line,
+            character: this.char,
+            data: ["<!--", "5"]
+          }, checks, function() { return true; }
+        );
+      }
+      this.skip(this.input.length);  // Skip to the EOL
+      // Remove the two -- characters in rest
+      return commentToken("<!--", rest.substr(2));
+    }
+
+    // Comments must start with either // or /* if they aren't HTML-like
     if (ch1 !== "/" || (ch2 !== "*" && ch2 !== "/")) {
       return null;
     }
@@ -1613,7 +1632,8 @@ Lexer.prototype = {
       state.option.maxlen < this.input.length) {
       var inComment = this.inComment ||
         startsWith.call(inputTrimmed, "//") ||
-        startsWith.call(inputTrimmed, "/*");
+        startsWith.call(inputTrimmed, "/*") ||
+        (!state.option.htmlcomments && startsWith.call(inputTrimmed, "<!--"));
 
       var shouldTriggerError = !inComment || !reg.maxlenException.test(inputTrimmed);
 

--- a/src/options.js
+++ b/src/options.js
@@ -110,6 +110,13 @@ exports.bool = {
     forin       : true,
 
     /**
+     * This option prohibits the use of HTML-like comments (`<!--`) and
+     * forces the characters to be lexed as other symbols and not start a
+     * comment.
+     */
+    htmlcomments: true,
+
+    /**
      * This option prohibits the use of immediate function invocations without
      * wrapping them in parentheses. Wrapping parentheses assists readers of
      * your code in understanding that the expression is the result of a

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2191,3 +2191,19 @@ exports["TDZ within for in/of head"] = function(test) {
 
   test.done();
 };
+
+exports["HTML-like comments (<!--)"] = function(test) {
+  var code = [
+    "<!--global c",
+    // --> does not end a HTML-like comment
+    "<!--c-->c",
+    "c.c = 1;"
+  ];
+
+  TestRun(test).test(code, { esversion: 5, htmlcomments: false });
+  TestRun(test)
+    .addError(2, "'<!--' is only available in ES5 (use 'esversion: 5').")
+    .test(code, { esversion: 3, htmlcomments: false });
+
+  test.done();
+};


### PR DESCRIPTION
HTML-like comments were standardised in ECMAScript 2015 (ES5),
so this raises a warning when esversion < 5.

The HTML-like comments will also allow `globals` and the (deprecated) `members` directive where
regular single line comments can't. They also allow the regular `js[hl]int` directives.

A test was added and a new warning.
W140: "HTML-like comments (`<!--`) may not be supported before ES5."

BREAKING CHANGE:

`<!--` will no longer be interpreted as "less than not pre-decrement", for example in:

    for(var i = 1; 0<!--i;) { /* This will run once */ }

This can be fixed by putting a space between the `<` and the `!`.

Closes #3082
Closes #1256