### PR TITLE
Add onmessage to vars.worker

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -405,6 +405,7 @@ exports.devel = {
 
 exports.worker = {
   importScripts  : true,
+  onmessage      : true,
   postMessage    : true,
   self           : true,
   FileReaderSync : true


### PR DESCRIPTION
Using `onmessage`, without referencing the `self` global object inside of a worker, is valid. This PR adds it for the worker environment.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/onmessage)

> Notice how in the main script, onmessage has to be called on myWorker, whereas inside the worker script you just need onmessage because the worker is effectively the global scope (the DedicatedWorkerGlobalScope, in this case).

and [their example](https://github.com/mdn/simple-web-worker/blob/gh-pages/worker.js)
```js
onmessage = function(e) {
  console.log('Message received from main script');
  var workerResult = 'Result: ' + (e.data[0] * e.data[1]);
  console.log('Posting message back to main script');
  postMessage(workerResult);
}
```