### PR TITLE
[[CHORE]] Fix linting error and enable lint in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 after_success: npm run coverage && cat ./coverage/lcov.info | coveralls
 script:
+  - npm run pretest
   - npm run test-node
   - npm run test-262
   - if [[ $(node --version) == v6* ]] ; then npm run test-browser; fi

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3034,10 +3034,6 @@ var JSHINT = (function() {
     return funct;
   }
 
-  function isFunctor(token) {
-    return "(scope)" in token;
-  }
-
   /**
    * Determine if the parser has begun parsing executable code.
    *


### PR DESCRIPTION
A previous commit removed all references to an internal function,
introducing a linting error. This was not reported by the project's
continuous integration system because that system was not configured to
run the project's linting check.

Correct the linting error and enable linting in the continuous
integration environment.