### PR TITLE
[[FIX]] Do not create binding for illegal syntax

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3909,14 +3909,16 @@ var JSHINT = (function() {
     }
     var i = optionalidentifier();
 
-    state.funct["(scope)"].addlabel(i, {
-      type: "function",
-      token: state.tokens.curr });
-
     if (i === undefined) {
       warning("W025");
-    } else if (inexport) {
-      state.funct["(scope)"].setExported(i, state.tokens.prev);
+    } else {
+      state.funct["(scope)"].addlabel(i, {
+        type: "function",
+        token: state.tokens.curr });
+
+      if (inexport) {
+        state.funct["(scope)"].setExported(i, state.tokens.prev);
+      }
     }
 
     doFunction({

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1668,6 +1668,10 @@ exports.testUnnamedFuncStatement = function (test) {
     .addError(1, "Missing name in function declaration.")
     .test("function() {}");
 
+  TestRun(test, "with 'unused' option")
+    .addError(1, "Missing name in function declaration.")
+    .test("function() {}", { unused: true });
+
   test.done();
 };
 


### PR DESCRIPTION
When a function declaration without an identifier is encountered, JSHint
issues a warning and attempts to continue parsing the declaration.

Previously, JSHint created a new binding for the "function" keyword, and
because such a binding can never be referenced, this would generate
spurious warnings when the "unused" option was enabled.

Do not create a faulty binding in the presence of this syntax error.