### PR TITLE
[[CHORE]] Improve reporting in project test suite

### DIFF
--- a/tests/helpers/testhelper.js
+++ b/tests/helpers/testhelper.js
@@ -103,6 +103,7 @@ exports.setup.testRun = function (test, name) {
         if (lines.length) {
           return {
             line: er.line,
+            character: er.character,
             message: er.reason,
             definedIn: lines
           };
@@ -130,29 +131,39 @@ exports.setup.testRun = function (test, name) {
         });
       });
 
-      test.ok(
-        undefinedErrors.length === 0 &&
-          unthrownErrors.length === 0 &&
-          wrongLineNumbers.length === 0 &&
-          duplicateErrors.length === 0,
+      var errorDetails = "";
 
-        (name === null ? "" : "\n  TestRun: [bold]{" + name + "}") +
-        unthrownErrors.map(function (el, idx) {
-          return (idx === 0 ? "\n  [yellow]{Errors defined, but not thrown by JSHINT}\n" : "") +
-            " [bold]{Line " + el.line + ", Char " + el.character + "} " + el.message;
-        }).join("\n") +
-        undefinedErrors.map(function (el, idx) {
-          return (idx === 0 ? "\n  [yellow]{Errors thrown by JSHINT, but not defined in test run}\n" : "") +
-            "  [bold]{Line " + el.line + ", Char " + el.character + "} " + el.reason;
-        }).join("\n") +
-        wrongLineNumbers.map(function (el, idx) {
-          return (idx === 0 ? "\n  [yellow]{Errors with wrong line number}\n" : "") +
-            "  [bold]{Line " + el.line + "} " + el.message + " [red]{not in line(s)} [bold]{" + el.definedIn.join(", ") + "}";
-        }).join("\n") +
-        duplicateErrors.map(function (el, idx) {
-          return (idx === 0 ? "\n  [yellow]{Duplicated errors}\n": "") +
-            "  [bold]{Line " + el.line + ", Char " + el.character + "} " + el.reason;
-        }).join("\n") + "\n"
+      if (unthrownErrors.length > 0) {
+        errorDetails += "\n  Errors defined, but not thrown by JSHint:\n" +
+          unthrownErrors.map(function (el) {
+            return "    {Line " + el.line + ", Char " + el.character + "} " + el.message;
+          }).join("\n");
+      }
+
+      if (undefinedErrors.length > 0) {
+        errorDetails += "\n  Errors thrown by JSHint, but not defined in test run:\n" +
+          undefinedErrors.map(function (el) {
+            return "    {Line " + el.line + ", Char " + el.character + "} " + el.reason;
+          }).join("\n");
+      }
+
+      if (wrongLineNumbers.length > 0) {
+        errorDetails += "\n  Errors with wrong line number:\n" +
+          wrongLineNumbers.map(function (el) {
+            return "    {Line " + el.line + ", Char " + el.character + "} " + el.message + " {not in line(s)} {" + el.definedIn.join(", ") + "}";
+          }).join("\n");
+      }
+
+      if (duplicateErrors.length > 0) {
+        errorDetails += "\n  Duplicated errors:\n" +
+          duplicateErrors.map(function (el) {
+            return "    {Line " + el.line + ", Char " + el.character + "} " + el.reason;
+          }).join("\n");
+      }
+
+      test.ok(
+        errorDetails === "",
+        (name ? "\n  TestRun: '" + name + "'" : "") + errorDetails
       );
     }
   };


### PR DESCRIPTION
Previously, the project's test suite generated error messages which
included formatting directives related to text rendering. These
directives no longer modify the style of the text rendered to the
terminal; instead, they only introduce additional noise in the failure
reports.

- Remove the formatting directives to improve the readability of error
  reports
- Expand the logic that generates error messages to improve the
  readability of the test suite's source code
- Suppress test title in cases where it is not specified
- Consistently report expected character position

---

This has bugged me for years. For the longest time, I assumed that the noise in
the test suite's error reports was due to a misconfiguration in my system. I
imagine that contributors either made the same assumption or simply did not
want to dig in to the problem here.

I've previously bisected the project history, and I can't find any point where
the formatting directives produced the intended effect. My best guess is that
the functionality was built around some chance interaction between modules that
overrode built-in functions.

In any event, the noise is very distracting. Here's an example of what test
suite ouput looks like for a failure, prior to applying this patch:

    ✖ instanceOfLiterals

    Assertion Message: 
      TestRun: [bold]{undefined}
      [yellow]{Errors defined, but not thrown by JSHINT}
     [bold]{Line 1, Char undefined} A made up error.
      [yellow]{Errors thrown by JSHINT, but not defined in test run}
      [bold]{Line 1, Char 13} Expected an assignment or function call and instead saw an expression.
      [yellow]{Errors with wrong line number}
      [bold]{Line 1} Expected an identifier and instead saw ';'. [red]{not in line(s)} [bold]{2}
      [yellow]{Duplicated errors}
      [bold]{Line 1, Char 14} Missing semicolon.
      [bold]{Line 1, Char 14} Missing semicolon.


And here is the report as generated with this patch applied:

    ✖ instanceOfLiterals

    Assertion Message: 
      Errors defined, but not thrown by JSHint:
        {Line 1, Char undefined} A made up error.
      Errors thrown by JSHint, but not defined in test run:
        {Line 1, Char 13} Expected an assignment or function call and instead saw an expression.
      Errors with wrong line number:
        {Line 1, Char 13} Expected an identifier and instead saw ';'. {not in line(s)} {2}
      Duplicated errors:
        {Line 1, Char 14} Missing semicolon.
        {Line 1, Char 14} Missing semicolon.