### PR TITLE
[[TEST]] Fixing copy-paste bugs in tests

### DIFF
--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -16,7 +16,7 @@ function globalsKnown(test, globals, options) {
   JSHINT(wrap(globals), options || {});
   var report = JSHINT.data();
 
-  test.ok(report.implied === undefined);
+  test.ok(report.implieds === undefined);
   test.equal(report.globals.length, globals.length);
 
   for (var i = 0, g; g = report.globals[i]; i += 1)

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1602,7 +1602,7 @@ exports.debug = function (test) {
 
   // By default disallow debugger statements.
   TestRun(test)
-    .addError(1, 23232323, "Forgotten 'debugger' statement?")
+    .addError(1, 20, "Forgotten 'debugger' statement?")
     .test(code, {es3: true});
 
   // But allow them if debug is true.

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -387,7 +387,6 @@ exports["implied and unused should respect hoisting"] = function (test) {
     .addError(14, 5, "'fun4' is not defined.")
     .test(src, { undef: true }); // es5
 
-  JSHINT.flag = true;
   JSHINT(src, { undef: true });
   var report = JSHINT.data();
 
@@ -1515,8 +1514,8 @@ exports.eqnull = function (test) {
 
   // By default, warn about `== null` comparison
   /**
-   * This test previously asserted the issuance of warning W041. 
-   * W041 has since been removed, but the test is maintained in 
+   * This test previously asserted the issuance of warning W041.
+   * W041 has since been removed, but the test is maintained in
    * order to discourage regressions.
    */
   TestRun(test)
@@ -1613,7 +1612,7 @@ exports.debug = function (test) {
 };
 
 /** `debugger` statements without semicolons are found on the correct line */
-exports.debug = function (test) {
+exports.debuggerWithoutSemicolons = function (test) {
   var src = [
     "function test () {",
     "debugger",
@@ -1633,8 +1632,8 @@ exports.eqeqeq = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/eqeqeq.js', 'utf8');
 
   /**
-   * This test previously asserted the issuance of warning W041. 
-   * W041 has since been removed, but the test is maintained in 
+   * This test previously asserted the issuance of warning W041.
+   * W041 has since been removed, but the test is maintained in
    * order to discourage regressions.
    */
   TestRun(test)

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -4444,7 +4444,7 @@ exports["for of as legacy JS"] = function (test) {
     .addError(17, 17, "Invalid for-of loop left-hand-side: initializer is forbidden.")
     .addError(17, 17, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(17, 6, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, undef: true, predef: ["print"]}); // es5
+    .test(code, {es3: true, undef: true, predef: ["print"]});
 
   test.done();
 };

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -600,10 +600,10 @@ exports.regexp = function (test) {
   TestRun(test).test("var y = Math.sqrt(16) / 180;", {moz: true});
 
   // "~"
-  TestRun(test).test("var y = Math.sqrt(16) / 180;", {es3: true});
-  TestRun(test).test("var y = Math.sqrt(16) / 180;", {}); // es5
-  TestRun(test).test("var y = Math.sqrt(16) / 180;", {esnext: true});
-  TestRun(test).test("var y = Math.sqrt(16) / 180;", {moz: true});
+  TestRun(test).test("var y = ~16 / 180;", {es3: true});
+  TestRun(test).test("var y = ~16 / 180;", {}); // es5
+  TestRun(test).test("var y = ~16 / 180;", {esnext: true});
+  TestRun(test).test("var y = ~16 / 180;", {moz: true});
 
 
   // "]" (GH-803)
@@ -4444,7 +4444,7 @@ exports["for of as legacy JS"] = function (test) {
     .addError(17, 17, "Invalid for-of loop left-hand-side: initializer is forbidden.")
     .addError(17, 17, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(17, 6, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {undef: true, predef: ["print"]}); // es5
+    .test(code, {es3: true, undef: true, predef: ["print"]}); // es5
 
   test.done();
 };
@@ -5553,7 +5553,7 @@ conciseMethods.getWithoutSet = function (test) {
   test.done();
 };
 
-conciseMethods.getWithoutSet = function (test) {
+conciseMethods.setWithoutGet = function (test) {
   var code = [
     "var a = [1, 2, 3, 4, 5];",
     "var strange = {",
@@ -6925,8 +6925,8 @@ exports.ignoreDirective["should allow the linter to skip blocked-out lines to co
   var code = fs.readFileSync(__dirname + "/fixtures/gh826.js", "utf8");
 
   /**
-   * This test previously asserted the issuance of warning W041. 
-   * W041 has since been removed, but the test is maintained in 
+   * This test previously asserted the issuance of warning W041.
+   * W041 has since been removed, but the test is maintained in
    * order to discourage regressions.
    */
   TestRun(test)


### PR DESCRIPTION
Noticed several copy-paste errors in test scripts. Modified names of some functions and restored, what was intended.