### PR TITLE
[[FIX]] Fixing typos and some dead old code

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -5043,7 +5043,7 @@ var JSHINT = (function() {
         unstack: function() {
           _current.variables.filter(function(v) {
             if (v.unused)
-              warning("W098", v.token, v.raw_text || v.value);
+              warning("W098", v.token, v.token.raw_text || v.value);
             if (v.undef)
               state.funct["(scope)"].block.use(v.value, v.token);
           });

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3549,9 +3549,7 @@ var JSHINT = (function() {
         if (!prefix && value && value.type === "undefined") {
           warning("W080", id, id.value);
         }
-        if (lone) {
-          tokens[0].first = value;
-        } else {
+        if (!lone) {
           destructuringPatternMatch(names, value);
         }
       }
@@ -3661,9 +3659,7 @@ var JSHINT = (function() {
         if (value && !prefix && !state.funct["(loopage)"] && value.type === "undefined") {
           warning("W080", id, id.value);
         }
-        if (lone) {
-          tokens[0].first = value;
-        } else {
+        if (!lone) {
           destructuringPatternMatch(names, value);
         }
       }

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3724,7 +3724,7 @@ var JSHINT = (function() {
     state.inClassBody = true;
     advance("{");
     // ClassBody(opt)
-    c.body = classbody(c);
+    classbody(c);
     advance("}");
     state.inClassBody = wasInClassBody;
   }

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2848,7 +2848,7 @@ var JSHINT = (function() {
       // a possible code smell.
       if (pastDefault) {
         if (state.tokens.next.id !== "=") {
-          error("W138", state.tokens.current);
+          error("W138", state.tokens.curr);
         }
       }
       if (state.tokens.next.id === "=") {

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3737,7 +3737,7 @@ var JSHINT = (function() {
     var props = Object.create(null);
     var staticProps = Object.create(null);
     var computed;
-    for (var i = 0; state.tokens.next.id !== "}"; ++i) {
+    while (state.tokens.next.id !== "}") {
       name = state.tokens.next;
       isStatic = false;
       isGenerator = false;

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -75,11 +75,6 @@ var JSHINT = (function() {
 
     declared, // Globals that were declared using /*global ... */ syntax.
 
-    functionicity = [
-      "closure", "exception", "global", "label",
-      "outer", "unused", "var"
-    ],
-
     functions, // All of the functions
 
     inblock,
@@ -5482,7 +5477,7 @@ var JSHINT = (function() {
       options: state.option
     };
 
-    var fu, f, i, j, n, globals;
+    var fu, f, i, n, globals;
 
     if (itself.errors.length) {
       data.errors = itself.errors;
@@ -5509,16 +5504,6 @@ var JSHINT = (function() {
     for (i = 1; i < functions.length; i += 1) {
       f = functions[i];
       fu = {};
-
-      for (j = 0; j < functionicity.length; j += 1) {
-        fu[functionicity[j]] = [];
-      }
-
-      for (j = 0; j < functionicity.length; j += 1) {
-        if (fu[functionicity[j]].length === 0) {
-          delete fu[functionicity[j]];
-        }
-      }
 
       fu.name = f["(name)"];
       fu.param = f["(params)"];

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2964,21 +2964,21 @@ var JSHINT = (function() {
 
   /**
    * @param {Object} [options]
-   * @param {token} [options.name] The identifier belonging to the function (if
-   *                               any)
-   * @param {boolean} [options.statement] The statement that triggered creation
-   *                                      of the current function.
+   * @param {string} [options.name] The identifier belonging to the function (if
+   *                                any)
+   * @param {token} [options.statement] The statement that triggered creation
+   *                                    of the current function.
    * @param {string} [options.type] If specified, either "generator" or "arrow"
    * @param {token} [options.loneArg] The argument to the function in cases
    *                                  where it was defined using the
    *                                  single-argument shorthand
    * @param {bool} [options.parsedOpening] Whether the opening parenthesis has
    *                                       already been parsed
-   * @param {token} [options.classExprBinding] Define a function with this
-   *                                           identifier in the new function's
-   *                                           scope, mimicking the bahavior of
-   *                                           class expression names within
-   *                                           the body of member functions.
+   * @param {string} [options.classExprBinding] Define a function with this
+   *                                            identifier in the new function's
+   *                                            scope, mimicking the bahavior of
+   *                                            class expression names within
+   *                                            the body of member functions.
    */
   function doFunction(options) {
     var f, token, name, statement, classExprBinding, isGenerator, isArrow, ignoreLoopFunc;

--- a/src/lex.js
+++ b/src/lex.js
@@ -1895,7 +1895,7 @@ Lexer.prototype = {
           from: this.from,
           value: token.value,
           base: token.base,
-          isMalformed: token.malformed
+          isMalformed: token.isMalformed
         });
 
         return create("(number)", token.value);

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1512,7 +1512,7 @@ exports.testDefaultArguments = function (test) {
     .addError(14, 39, "'bar' is not defined.")
     .addError(14, 32, "'num3' was used before it was declared, which is illegal for 'param' variables.")
     .addError(15, 32, "'num4' was used before it was declared, which is illegal for 'param' variables.")
-    .addError(18, 45, "Regular parameters should not come after default parameters.")
+    .addError(18, 41, "Regular parameters should not come after default parameters.")
     .addError(27, 10, "'c' is not defined.")
     .addError(33, 4, "'d' was used before it was defined.")
     .addError(36, 16, "'e' was used before it was declared, which is illegal for 'param' variables.")
@@ -1521,7 +1521,7 @@ exports.testDefaultArguments = function (test) {
   TestRun(test)
     .addError(14, 32, "'num3' was used before it was declared, which is illegal for 'param' variables.")
     .addError(15, 32, "'num4' was used before it was declared, which is illegal for 'param' variables.")
-    .addError(18, 45, "Regular parameters should not come after default parameters.")
+    .addError(18, 41, "Regular parameters should not come after default parameters.")
     .addError(36, 16, "'e' was used before it was declared, which is illegal for 'param' variables.")
     .test(src, { moz: true });
 
@@ -1536,7 +1536,7 @@ exports.testDefaultArguments = function (test) {
     .addError(15, 37, "'default parameters' is only available in ES6 (use 'esversion: 6').")
     .addError(15, 32, "'num4' was used before it was declared, which is illegal for 'param' variables.")
     .addError(18, 37, "'default parameters' is only available in ES6 (use 'esversion: 6').")
-    .addError(18, 45, "Regular parameters should not come after default parameters.")
+    .addError(18, 41, "Regular parameters should not come after default parameters.")
     .addError(26, 18, "'default parameters' is only available in ES6 (use 'esversion: 6').")
     .addError(31, 18, "'default parameters' is only available in ES6 (use 'esversion: 6').")
     .addError(33, 6, "'default parameters' is only available in ES6 (use 'esversion: 6').")

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3690,19 +3690,23 @@ exports["array comprehension unused and undefined"] = function (test) {
   var code = [
     "var range = [1, 2];",
     "var a = [for (i of range) if (i % 2 === 0) i];",
-    "var b = [for (j of range) doesnotexist];"
+    "var b = [for (j of range) doesnotexist];",
+    "var c = [for (\\u0024 of range) 1];"
   ];
   TestRun(test)
     .addError(2, 5, "'a' is defined but never used.")
     .addError(3, 15, "'j' is defined but never used.")
     .addError(3, 27, "'doesnotexist' is not defined.")
     .addError(3, 5, "'b' is defined but never used.")
+    .addError(4, 15, "'\\u0024' is defined but never used.")
+    .addError(4, 5, "'c' is defined but never used.")
     .test(code, { esnext: true, unused: true, undef: true });
 
   var unused = JSHINT.data().unused;
   test.deepEqual([
     { name: 'a', line: 2, character: 5 },
-    { name: 'b', line: 3, character: 5 }
+    { name: 'b', line: 3, character: 5 },
+    { name: 'c', line: 4, character: 5 }
     //{ name: 'j', line: 3, character: 15 } // see gh-2440
   ], unused);
 


### PR DESCRIPTION
Removed old "functionicity" variable, that was used only in useless "for" cycles, which did nothing but adding and removing the same properties to the "fu" object over and over again.

Also, noticed several typing errors like "tokens.current" instead of "tokens.curr"; "v.raw_text" instead of "v.token.raw_text" etc.

Also, property "tokens[0].first" is not used anywhere in the code and can be removed.

And the last thing, function classbody doesn't return anything, so there is no point to assign undefined value to the "c.body" property.
