### PR TITLE
[[DOCS]] Expand warning message

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -222,10 +222,12 @@ var warnings = {
   W134: "The '{a}' option is only available when linting ECMAScript {b} code.",
   W135: "{a} may not be supported by non-browser environments.",
   W136: "'{a}' must be in function scope.",
-  W137: "Empty {a}: this is unnecessary and can be removed.",
+  W137: "Empty destructuring: this is unnecessary and can be removed.",
   W138: "Regular parameters should not come after default parameters.",
   W139: "Function expressions should not be used as the second operand to instanceof.",
-  W140: "Missing comma."
+  W140: "Missing comma.",
+  W141: "Empty {a}: this is unnecessary and can be removed.",
+  W142: "Empty {a}: consider replacing with `import '{b}';`."
 };
 
 var info = {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -828,7 +828,8 @@ exports.testES6Modules = function (test) {
   ];
 
   var testRun = TestRun(test)
-    .addError(74, 9, "Empty export: this is unnecessary and can be removed.");
+    .addError(74, 1, "Empty export: this is unnecessary and can be removed.")
+    .addError(75, 1, "Empty export: consider replacing with `import 'source';`.");
   importConstErrors.forEach(function(error) { testRun.addError.apply(testRun, error); });
   testRun.test(src, {esnext: true});
 
@@ -867,7 +868,8 @@ exports.testES6Modules = function (test) {
     .addError(70, 1, "'export' is only available in ES6 (use 'esversion: 6').")
     .addError(71, 1, "'import' is only available in ES6 (use 'esversion: 6').")
     .addError(74, 1, "'export' is only available in ES6 (use 'esversion: 6').")
-    .addError(75, 1, "'import' is only available in ES6 (use 'esversion: 6').")
+    .addError(75, 1, "'export' is only available in ES6 (use 'esversion: 6').")
+    .addError(76, 1, "'import' is only available in ES6 (use 'esversion: 6').")
     .test(src);
 
   var src2 = [

--- a/tests/unit/fixtures/es6-import-export.js
+++ b/tests/unit/fixtures/es6-import-export.js
@@ -72,4 +72,5 @@ import { x, } from "source";
 
 // Empty
 export {};
+export {} from "source";
 import {} from "source";


### PR DESCRIPTION
`export` declarations with empty export export clauses are not
necessarily superfluous: if they also specify a "from" clause, they will
cause the referenced module to be evaluated. Because of this, the
warning produced in these cases should be contextual--it should
recommend removal only if no "from" clause is present. In the presence
of such a clause, the warning should instead suggest use of a
binding-free `import` declaration (as this clearly communicates the
intention to evaluate a module without requesting any bindings).

Notes on compatibility:

- The previous warning behavior had not yet been published in a stable
  release (it was implemented at the same time as the parser was
  corrected to support `export` declarations without bindings). This
  makes this change in warning behavior backward-compatible with prior
  releases.
- This warning is relevant for `import` declarations as well. However,
  because prior releases of JSHint included correct parsing support for
  binding-free `import` declarations, introducing an equivalent warning
  would constitute a backwards-breaking change.

@rwaldron This is a follow-up to gh-2569 which I just landed today.