### PR TITLE
[[FIX]] recognize Jasmine global `spyOnProperty`

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -738,5 +738,7 @@ exports.jasmine = {
   fail        : false,
   fdescribe   : false,
   fit         : false,
-  pending     : false
+  pending     : false,
+  // Jasmine 2.6
+  spyOnProperty: false
 };

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -538,6 +538,7 @@ exports.jasmine = function (test) {
     "setFixtures",
     "loadFixtures",
     "spyOn",
+    "spyOnProperty",
     "expect",
     "runs",
     "waitsFor",


### PR DESCRIPTION
Added `spyOnProperty` (introduced in Jasmine 2.6) to the list of known globals.

Fixes #3183