### PR TITLE
[[FIX]] Consistently ignore dot-prefixed dirs

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -230,7 +230,7 @@ function loadIgnores(params) {
  */
 function isIgnored(fp, patterns) {
   return patterns.some(function(ip) {
-    if (minimatch(path.resolve(fp), ip, { nocase: true })) {
+    if (minimatch(path.resolve(fp), ip, { nocase: true, dot: true })) {
       return true;
     }
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -658,6 +658,30 @@ exports.group = {
     test.done();
   },
 
+  // See gh-3187
+  testIgnoreWithDot: function (test) {
+    var dir = __dirname + "/../examples/";
+    this.sinon.stub(process, "cwd").returns(dir);
+
+    this.sinon.stub(shjs, "cat")
+      .withArgs(sinon.match(/file\.js$/)).returns("This is not Javascript.")
+      .withArgs(sinon.match(/\.jshintignore$/)).returns("**/ignored-dir/**");
+    this.sinon.stub(shjs, "test")
+      .withArgs("-e", sinon.match(/file\.js$/)).returns(true)
+      .withArgs("-e", sinon.match(/\.jshintignore$/)).returns(true);
+
+    cli.interpret([
+      "node", "jshint", "ignored-dir/.dot-prefixed/file.js",
+      "ignored-dir/not-dot-prefixed/file.js"
+    ]);
+
+    process.cwd.returns(__dirname + "/../");
+
+    test.equal(cli.exit.args[0][0], 0, "All matching files are ignored, regardless of dot-prefixed directories.");
+
+    test.done();
+  },
+
   testExcludePath: function (test) {
     var run = this.sinon.stub(cli, "run");
     var dir = __dirname + "/../examples/";


### PR DESCRIPTION
When the Node.js CLI is invoked with a path to an input file, that file
should not be linted if it matches any pattern in a "ignore list"
configuration file.

Prior to this patch, JSHint failed to ignore such files if one of their
parent directories was prefixed with a period character.

Update the CLI's usage of the `minimatch` Node.js library to also
consider such "dot-prefixed" directories when interpreting ignore lists.

Note that this change is backwards-compatible because it limits the
situations in which the CLI reports an error.