### PR TITLE
[[DOCS]] Fix incorrect information about scopes in JavaScript

### DIFF
--- a/dist/jshint-rhino.js
+++ b/dist/jshint-rhino.js
@@ -16287,13 +16287,12 @@ exports.bool = {
     evil        : true,
 
     /**
-     * This option suppresses warnings about declaring variables inside of
-     * control
-     * structures while accessing them later from the outside. Even though
-     * JavaScript has only two real scopes—global and function—such practice
-     * leads to confusion among people new to the language and hard-to-debug
-     * bugs. This is why, by default, JSHint warns about variables that are
-     * used outside of their intended scope.
+     * This option suppresses warnings about declaring variables inside
+     * of control structures while accessing them later from the outside.
+     * Even though identifiers declared with `var` have two real scopes—global
+     * and function—such practice leads to confusion among people new to
+     * the language and hard-to-debug bugs. This is why, by default, JSHint
+     * warns about variables that are used outside of their intended scope.
      *
      *     function test() {
      *       if (true) {

--- a/dist/jshint.js
+++ b/dist/jshint.js
@@ -16285,13 +16285,12 @@ exports.bool = {
     evil        : true,
 
     /**
-     * This option suppresses warnings about declaring variables inside of
-     * control
-     * structures while accessing them later from the outside. Even though
-     * JavaScript has only two real scopes—global and function—such practice
-     * leads to confusion among people new to the language and hard-to-debug
-     * bugs. This is why, by default, JSHint warns about variables that are
-     * used outside of their intended scope.
+     * This option suppresses warnings about declaring variables inside
+     * of control structures while accessing them later from the outside.
+     * Even though identifiers declared with `var` have two real scopes—global
+     * and function—such practice leads to confusion among people new to
+     * the language and hard-to-debug bugs. This is why, by default, JSHint
+     * warns about variables that are used outside of their intended scope.
      *
      *     function test() {
      *       if (true) {

--- a/src/options.js
+++ b/src/options.js
@@ -356,13 +356,12 @@ exports.bool = {
     evil        : true,
 
     /**
-     * This option suppresses warnings about declaring variables inside of
-     * control
-     * structures while accessing them later from the outside. Even though
-     * JavaScript has only two real scopes—global and function—such practice
-     * leads to confusion among people new to the language and hard-to-debug
-     * bugs. This is why, by default, JSHint warns about variables that are
-     * used outside of their intended scope.
+     * This option suppresses warnings about declaring variables inside
+     * of control structures while accessing them later from the outside.
+     * Even though identifiers declared with `var` have two real scopes—global
+     * and function—such practice leads to confusion among people new to
+     * the language and hard-to-debug bugs. This is why, by default, JSHint
+     * warns about variables that are used outside of their intended scope.
      *
      *     function test() {
      *       if (true) {


### PR DESCRIPTION
Comment stated that JavaScript has only two real scopes.
This is incorrect as identifiers declared with let and const do have
block scope.

Maybe a little nitpicky but I think that as long as the information is there, it should be correct. It's also wrong on http://jshint.com/docs/options/ 