### PR TITLE
[[TEST]] Refactor negative syntax tests for "rest"

### DIFF
--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7667,41 +7667,49 @@ exports.commaAfterRestParameter = function (test) {
 
 
 exports.extraRestOperator = function (test) {
-  var code = [
-    'function fn([a, b, ......c]) { }',
-    'function fn2([......c]) { }',
-    'function fn3(a, b, ......) { }',
-    'function fn4(......) { }',
-    'var [......a] = [1, 2, 3];',
-    'var [a, b, ... ...c] = [1, 2, 3];',
-    'var arrow = (......a) => a;',
-    'var arrow2 = (a, b, ......c) => c;',
-    'var arrow3 = ([......a]) => a;',
-    'var arrow4 = ([a, b, ......c]) => c;',
-    'fn([1, 2, 3]);',
-    'fn2([1, 2, 3]);',
-    'fn3(1, 2, 3);',
-    'fn4(1, 2, 3);',
-    'arrow(1, 2, 3);',
-    'arrow2(1, 2, 3);',
-    'arrow3([1, 2, 3]);',
-    'arrow4([1, 2, 3]);',
-  ];
+  TestRun(test)
+    .addError(1, 23, "Unexpected '...'.")
+    .test('function fn([a, b, ......c]) { }', { esnext: true });
+
+  TestRun(test)
+    .addError(1, 18, "Unexpected '...'.")
+    .test('function fn2([......c]) { }', { esnext: true });
 
   TestRun(test)
     .addError(1, 23, "Unexpected '...'.")
-    .addError(2, 18, "Unexpected '...'.")
-    .addError(3, 23, "Unexpected '...'.")
-    .addError(3, 23, "Unexpected ')'.")
-    .addError(4, 17, "Unexpected '...'.")
-    .addError(4, 17, "Unexpected ')'.")
-    .addError(5, 9, "Unexpected '...'.")
-    .addError(6, 16, "Unexpected '...'.")
-    .addError(7, 17, "Unexpected '...'.")
-    .addError(8, 24, "Unexpected '...'.")
-    .addError(9, 19, "Unexpected '...'.")
-    .addError(10, 25, "Unexpected '...'.")
-    .test(code, { esnext: true });
+    // The reported column number for this parsing error is incorrect.
+    .addError(1, 23, "Unexpected ')'.")
+    .test('function fn3(a, b, ......) { }', { esnext: true });
+
+  TestRun(test)
+    .addError(1, 17, "Unexpected '...'.")
+    // The reported column number for this parsing error is incorrect.
+    .addError(1, 17, "Unexpected ')'.")
+    .test('function fn4(......) { }', { esnext: true });
+
+  TestRun(test)
+    .addError(1, 9, "Unexpected '...'.")
+    .test('var [......a] = [1, 2, 3];', { esnext: true });
+
+  TestRun(test)
+    .addError(1, 16, "Unexpected '...'.")
+    .test('var [a, b, ... ...c] = [1, 2, 3];', { esnext: true });
+
+  TestRun(test)
+    .addError(1, 17, "Unexpected '...'.")
+    .test('var arrow = (......a) => a;', { esnext: true });
+
+  TestRun(test)
+    .addError(1, 24, "Unexpected '...'.")
+    .test('var arrow2 = (a, b, ......c) => c;', { esnext: true });
+
+  TestRun(test)
+    .addError(1, 19, "Unexpected '...'.")
+    .test('var arrow3 = ([......a]) => a;', { esnext: true });
+
+  TestRun(test)
+    .addError(1, 25, "Unexpected '...'.")
+    .test('var arrow4 = ([a, b, ......c]) => c;', { esnext: true });
 
   test.done();
 };


### PR DESCRIPTION
Validate JSHint's behavior for various invalid applications of the
"rest" operator in isolation. In the previous factoring, the independent
syntax tests interacted and caused JSHint to report errors that differ
from those it would report when encountering each form in isolation.
Although JSHint makes a best-effort approach to recovering from invalid
syntax, this behavior is not formalized and should therefor not be
asserted by unit tests.

This factoring avoids the undesirable interaction, allowing the tests to
document JSHint's behavior under more predictable conditions. It also
highlights a previously-existing bug in the errors reported (as
documented via in-line code comments).

---

@rwaldron Mind taking a look? This is pretty minor, but it will help me while rebasing the `v2.10.0` branch (this commit in particular 8b1bbf38cfe4690e810db6c7bbc591575abffbfe).