### PR TITLE
[[FIX]] Preserve functionality in "legacy" Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,11 +66,14 @@
     "jscs":                           "1.11.x",
     "mock-stdin":                     "0.3.x",
     "nodeunit":                       "0.9.x",
-    "phantom":                        "~4.0.1",
-    "phantomjs-prebuilt":             "~2.1.7",
     "regenerate":                     "1.2.x",
     "sinon":                          "1.12.x",
     "unicode-6.3.0":                  "0.1.x"
+  },
+
+  "optionalDependencies": {
+    "phantom":                        "~4.0.1",
+    "phantomjs-prebuilt":             "~2.1.7"
   },
 
   "license": "(MIT AND JSON)",

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -1,13 +1,24 @@
 "use strict";
 
-var phantom = require("phantom");
+var phantom, phantomJsPrebuilt;
+try {
+  phantom = require("phantom");
+  phantomJsPrebuilt = require("phantomjs-prebuilt");
+} catch (err) {
+  throw new Error(
+    "Unable to run tests in PhantomJS because the required dependencies are " +
+    "not available. Please note that JSHint does not support development " +
+    "using versions of Node.js which are no longer maintained."
+  );
+}
+
 var createTestServer = require("./helpers/browser/server");
 var options = {
   /**
    * The `phantom` module provides a Node.js API for the PhantomJS binary,
    * while the `phantomjs` module includes the binary itself.
    */
-  phantomPath: require("phantomjs-prebuilt").path
+  phantomPath: phantomJsPrebuilt.path
 };
 var port = process.env.NODE_PORT || 8045;
 var ph;


### PR DESCRIPTION
@rwaldron In gh-3209 and gh-3210, you reported that JSHint is now failing its
own tests when run with the 0.10 and 0.12 releases of Node.js. You were right
that the error originates from a nested dependency: ironically, an npm module
named `boom`. My initial plan was to work with the maintainers of that module
to revert the change in a patch release and re-apply it in a new major version.

That turned out to be unnecessary because `boom` released a new major version
when it dropped support for legacy versions of Node.js. The real issue is how
that module has been consumed elsewhere.

The module `hawk` (which depends on `boom`) likewise incremented its major
version number in recognition of the breaking change. Unfortunately, the
`request` module (which depends on `hawk`) [did not follow
suit](https://github.com/request/request/issues/2772). And since JSHint depends
on `request` only transitively (through the `phantom` module--used to run the
tests in a browser-like environment), we cannot shield ourselves from the
breaking change through this project's `package.json` file.

The simplest solution would be to drop support for Node.js versions 0.10 and
0.12. I'd be open to this, but only after announcing our intention, finalizing
our pending bug fixes and feature additions, publishing one last minor version,
and then publishing a new major version. But in the mean time, we would still
have a responsibility to verify the correctness of the library in those
environments.

This patch fixes the tests in 0.10 and 0.12. We're lucky because we only need
to run PhantomJS for one build, and the version of Node.js we use to do that is
inconsequential. If we move forward with this solution, we will be saying, "We
no longer support contributing to JSHint using legacy versions of Node.js."
This isn't ideal, but it's not a breaking change.

---

A recent minor release of the npm module `request` has introduced
breaking changes for Node.js versions 0.10 and 0.12. Because JSHint
depends on this module transitively through one of its
`devDependencies`, this interferes with the project's ability to verify
its own correctness in the effected environments.

Allow JSHint to be installed in legacy environments by specifying the
effected dependencies as "optional." These dependencies are only
required by tests for the PhantomJS platform, and those tests can be
orchestrated from a single actively-maintained version of Node.js
without effecting coverage.