### PR TITLE
[[FIX]] Tolerate RegExp as `void` operand

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -1703,7 +1703,7 @@ Lexer.prototype = {
 
       if (type === "(identifier)") {
         if (value === "return" || value === "case" || value === "yield" ||
-            value === "typeof" || value === "instanceof") {
+            value === "typeof" || value === "instanceof" || value === "void") {
           this.prereg = true;
         }
 

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -557,6 +557,7 @@ exports.regexp = function (test) {
     "var x = w - /s/;",
     "var y = typeof /[a-z]/;", // GH-657
     "var z = /a/ instanceof /a/.constructor;", // GH-2773
+    "void /./;",
     "var v = /dsdg;"
   ];
 
@@ -576,8 +577,8 @@ exports.regexp = function (test) {
     .addError(17, 9, "Invalid regular expression.")
     .addError(20, 9, "Invalid regular expression.")
     .addError(21, 9, "Invalid regular expression.")
-    .addError(28, 9, "Unclosed regular expression.")
-    .addError(28, 9, "Unrecoverable syntax error. (100% scanned).");
+    .addError(29, 9, "Unclosed regular expression.")
+    .addError(29, 9, "Unrecoverable syntax error. (100% scanned).");
 
   run.test(code, {es3: true});
   run.test(code, {}); // es5


### PR DESCRIPTION
Hey @rwaldron. I imagine that a patch like this would cause you to wonder about my priorities. Rest assured: I'm focused on async functions these days. I just stumbled on this corner case while trying to parse `await` correctly.