### PR TITLE
[[FIX]] Avoid infinite loop on invalid `for` stmt

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4208,8 +4208,9 @@ var JSHINT = (function() {
         if (!comma && checkPunctuator(nextop, ",")) comma = nextop;
         else if (!initializer && checkPunctuator(nextop, "=")) initializer = nextop;
       }
-    } while (level > 0 || !_.contains(inof, nextop.value) && nextop.value !== ";" &&
-    nextop.type !== "(end)"); // Is this a JSCS bug? This looks really weird.
+    } while (
+      (level > 0 || !_.contains(inof, nextop.value) && nextop.value !== ";") &&
+      nextop.type !== "(end)");
 
     // if we're in a for (… in|of …) statement
     if (_.contains(inof, nextop.value)) {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -8119,3 +8119,25 @@ exports.lookaheadBeyondEnd = function (test) {
 
   test.done();
 };
+
+// In releases prior to 2.9.6, JSHint would not terminate when given the source
+// code in the following tests.
+exports["regression test for GH-3230"] = function (test) {
+  TestRun(test, "as originally reported")
+    .addError(1, 12, "Expected ';' and instead saw ')'.")
+    .addError(1, 13, "Unmatched '{'.")
+    .addError(1, 13, "Unrecoverable syntax error. (100% scanned).")
+    .test("for(var i=1){");
+
+  TestRun(test, "further simplified (unclosed brace)")
+    .addError(1, 5, "Unmatched '{'.")
+    .addError(1, 5, "Unrecoverable syntax error. (100% scanned).")
+    .test("for({");
+
+  TestRun(test, "further simplified (unclosed bracket)")
+    .addError(1, 5, "Unmatched '['.")
+    .addError(1, 5, "Unrecoverable syntax error. (100% scanned).")
+    .test("for([");
+
+  test.done();
+};


### PR DESCRIPTION
Ensure that the special "end" token cancels parsing of the `for`
statement "head" in all cases.

---

Hey @rwaldon. The modified parsing logic has problems that extend beyond the
issue reported in gh-3230. As you know, we've refactored that code heavily in
the feature branch for the next minor release, so the problem is already fixed
there. But since we don't have a solid plan for 2.10.0 yet, I've implemented
this different solution so we can resolve the bug in our next patch release.
This will cause merge conflicts for the 2.10.0 feature branch, but I'm prepared
to resolve those.