### PR TITLE
[[CHORE]] Correct bug in test harness

### DIFF
--- a/tests/helpers/testhelper.js
+++ b/tests/helpers/testhelper.js
@@ -94,6 +94,7 @@ exports.setup.testRun = function (test, name) {
       var undefinedErrors = errors.filter(function (er) {
         return !definedErrors.some(function (def) {
           var result = def.line === er.line &&
+            def.character === er.character &&
             def.message === er.reason;
 
           if (!result) {


### PR DESCRIPTION
Today, when a test expects an error to occur on a line that is
incorrect, the harness reports the situation in those terms. For
example, for the following test:

    exports.foo = function (test) {
      TestRun(test)
        .addError(9999, 1, "Expected an assignment or function call and instead saw an expression.")
        .test("0;");
      test.done();
    };

The test harness reports:

>     Errors with wrong location:
>       {Line 1, Char 1} Expected an assignment or function call and instead saw an expression. - Not in line(s) {Line 9999, Char 1}

The requirement for tests to specify the character column for every
error is a recent addition to the test harness [1]. It was introduced
with only partial support in the test harness. That flaw did not impact
the harness's ability to identify test failures, but it did produce
confusing output in the event of failure.

When an error was reported with a character column that differed from
what was expected, the harness would simply report that the error was
defined but not thrown and omit details about the error that was
actually produced. For example, for the following test:

    exports.foo = function (test) {
      TestRun(test)
        .addError(1, 9999, "Expected an assignment or function call and instead saw an expression.")
        .test("0;");
      test.done();
    };

...the harness would report the following error:

>       Errors defined, but not thrown by JSHint:
>         {Line 1, Char 9999} Expected an assignment or function call and instead saw an expression.

This patch corrects the harness's behavior so it instead reports:

>       Errors with wrong location:
>         {Line 1, Char 1} Expected an assignment or function call and instead saw an expression. - Not in line(s) {Line 1, Char 9999}

[1] e0d575f2803ff9d5891007f2c22c3953df4a21fe