### PR TITLE
[[CHORE]] Simplify lexing of literal values

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -26,8 +26,6 @@ var Token = {
   StringLiteral: 4,
   Comment: 5,
   Keyword: 6,
-  NullLiteral: 7,
-  BooleanLiteral: 8,
   RegExp: 9,
   TemplateHead: 10,
   TemplateMiddle: 11,
@@ -567,7 +565,7 @@ Lexer.prototype = {
       "super", "return", "typeof", "delete",
       "switch", "export", "import", "default",
       "finally", "extends", "function", "continue",
-      "debugger", "instanceof"
+      "debugger", "instanceof", "true", "false", "null"
     ];
 
     if (result && keywords.indexOf(result[0]) >= 0) {
@@ -582,14 +580,12 @@ Lexer.prototype = {
 
   /*
    * Extract a JavaScript identifier out of the next sequence of
-   * characters or return 'null' if its not possible. In addition,
-   * to Identifier this method can also produce BooleanLiteral
-   * (true/false) and NullLiteral (null).
+   * characters or return 'null' if its not possible.
    */
   scanIdentifier: function() {
     var id = "";
     var index = 0;
-    var type, char;
+    var char;
 
     function isNonAsciiIdentifierStart(code) {
       return nonAsciiIdentifierStartTable.indexOf(code) > -1;
@@ -699,20 +695,8 @@ Lexer.prototype = {
       id += char;
     }
 
-    switch (id) {
-    case "true":
-    case "false":
-      type = Token.BooleanLiteral;
-      break;
-    case "null":
-      type = Token.NullLiteral;
-      break;
-    default:
-      type = Token.Identifier;
-    }
-
     return {
-      type: type,
+      type: Token.Identifier,
       value: removeEscapeSequences(id),
       text: id,
       tokenLength: id.length
@@ -1869,8 +1853,6 @@ Lexer.prototype = {
 
         /* falls through */
       case Token.Keyword:
-      case Token.NullLiteral:
-      case Token.BooleanLiteral:
         return create("(identifier)", token.value, state.tokens.curr.id === ".", token);
 
       case Token.NumericLiteral:


### PR DESCRIPTION
Lex NullLiterals and BooleanLiterals as keywords, not Identifiers. This
simplifies the `scanIdentifier` function and makes its name more
accurately describe its behavior. It also obviates the need for two
token "types" that are internal to the lexer itself (as in either case,
the "type" attribute of the emitted token object is "(identifier)".