### PR TITLE
[[FIX]] Restrict "name" of strict mode functions

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1750,6 +1750,8 @@ var JSHINT = (function() {
           }
           directives();
 
+          state.funct["(isStrict)"] = state.isStrict();
+
           if (state.option.strict && state.funct["(context)"]["(global)"]) {
             if (!m["use strict"] && !state.isStrict()) {
               warning("E007");
@@ -2864,6 +2866,12 @@ var JSHINT = (function() {
       "(name)"      : name,
       "(breakage)"  : 0,
       "(loopage)"   : 0,
+      // The strictness of the function body is tracked via a dedicated
+      // property (as opposed to via the global `state` object) so that the
+      // value can be referenced after the body has been fully parsed (i.e.
+      // when validating the identifier used in function declarations and
+      // function expressions).
+      "(isStrict)"  : "unknown",
 
       "(global)"    : false,
 
@@ -3045,6 +3053,11 @@ var JSHINT = (function() {
     if (!state.option.noyield && isGenerator &&
         state.funct["(generator)"] !== "yielded") {
       warning("W124", state.tokens.curr);
+    }
+
+    if (state.funct["(isStrict)"] === true &&
+      (name === "arguments" || name === "eval")) {
+      error('E008', token);
     }
 
     state.funct["(metrics)"].verifyMaxStatementsPerFunction();

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3666,6 +3666,38 @@ exports["strict violation - use of arguments and eval"] = function (test) {
       "function f2(eval) { 'use strict'; }"
     ]);
 
+  TestRun(test, "as function binding (valid)")
+    .test([
+      "function arguments() {}",
+      "function eval() {}",
+      "void function arguments() {};",
+      "void function eval() {};"
+    ]);
+
+  TestRun(test, "as function bindings for expressions with inferred names (valid)")
+    .test([
+      "var arguments = function() {};",
+      "(function() {",
+      "  var eval = function() {};",
+      "}());"
+    ]);
+
+  TestRun(test, "as function declaration binding (invalid)")
+    .addError(1, 10, "Strict violation.")
+    .addError(2, 10, "Strict violation.")
+    .test([
+      "function arguments() { 'use strict'; }",
+      "function eval() { 'use strict'; }"
+    ]);
+
+  TestRun(test, "as function expression binding (invalid)")
+    .addError(1, 15, "Strict violation.")
+    .addError(2, 15, "Strict violation.")
+    .test([
+      "void function arguments() { 'use strict'; };",
+      "void function eval() { 'use strict'; };"
+    ]);
+
   test.done();
 };
 


### PR DESCRIPTION
@rwaldron this is another fix in support of gh-2604