### PR TITLE
[[FIX]] Skip undefined env in getHomeDir()

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -109,7 +109,7 @@ function getHomeDir() {
 
   while (paths.length) {
     homePath = paths.shift();
-    if (fs.existsSync(homePath)) {
+    if (homePath && fs.existsSync(homePath)) {
       return homePath;
     }
   }


### PR DESCRIPTION
Skip calling `fs.existsSync()` on an environment variable when it is undefined.

Discovered during the CITGM run of https://github.com/nodejs/node/pull/18308

https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1229/nodes=fedora-latest-x64/testReport/junit/(root)/citgm/bluebird_v3_5_1/

Before this patch, if `fs.existsSync(undefined)` throws, the test would fail like this:

```
▶ PATH=/Users/joyee/projects/node:$PATH ../node/deps/npm/bin/npm-cli.js run test

> jshint@2.9.5 pretest /Users/joyee/projects/jshint
> node ./bin/jshint src && jscs src

fs.js:251
    throw err;
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be one of type string, Buffer, or URL
    at Object.fs.existsSync (fs.js:434:3)
    at getHomeDir (/Users/joyee/projects/jshint/src/cli.js:112:12)
    at findConfig (/Users/joyee/projects/jshint/src/cli.js:83:14)
    at Object.getConfig (/Users/joyee/projects/jshint/src/cli.js:519:52)
    at /Users/joyee/projects/jshint/src/cli.js:643:43
    at Array.forEach (<anonymous>)
    at Object.run (/Users/joyee/projects/jshint/src/cli.js:642:11)
    at Object.interpret (/Users/joyee/projects/jshint/src/cli.js:756:18)
    at Object.<anonymous> (/Users/joyee/projects/jshint/bin/jshint:3:26)
    at Module._compile (module.js:661:30)
```
