### PR TITLE
[[CHORE]] Update to latest version of Lodash

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -888,8 +888,8 @@ var JSHINT = (function() {
     var isDangerous =
       state.option.asi &&
       state.tokens.prev.line !== startLine(state.tokens.curr) &&
-      _.contains(["]", ")"], state.tokens.prev.id) &&
-      _.contains(["[", "("], state.tokens.curr.id);
+      _.includes(["]", ")"], state.tokens.prev.id) &&
+      _.includes(["[", "("], state.tokens.curr.id);
 
     if (isDangerous)
       warning("W014", state.tokens.curr, state.tokens.curr.id);
@@ -1253,7 +1253,7 @@ var JSHINT = (function() {
     values = state.inES6() ? typeofValues.es6 : typeofValues.es3;
 
     if (right.type === "(identifier)" && right.value === "typeof" && left.type === "(string)")
-      return !_.contains(values, left.value);
+      return !_.includes(values, left.value);
 
     return false;
   }
@@ -2623,7 +2623,7 @@ var JSHINT = (function() {
     advance("(");
     state.funct["(comparray)"].setState("define");
     res.left = expression(130);
-    if (_.contains(["in", "of"], state.tokens.next.value)) {
+    if (_.includes(["in", "of"], state.tokens.next.value)) {
       advance();
     } else {
       error("E045", state.tokens.curr);
@@ -2803,7 +2803,7 @@ var JSHINT = (function() {
       // are added to the param scope
       var currentParams = [];
 
-      if (_.contains(["{", "["], state.tokens.next.id)) {
+      if (_.includes(["{", "["], state.tokens.next.id)) {
         tokens = destructuringPattern();
         for (t in tokens) {
           t = tokens[t];
@@ -3521,7 +3521,7 @@ var JSHINT = (function() {
     statement.first = [];
     for (;;) {
       var names = [];
-      if (_.contains(["{", "["], state.tokens.next.value)) {
+      if (_.includes(["{", "["], state.tokens.next.value)) {
         tokens = destructuringPattern();
         lone = false;
       } else {
@@ -3614,7 +3614,7 @@ var JSHINT = (function() {
     this.first = [];
     for (;;) {
       var names = [];
-      if (_.contains(["{", "["], state.tokens.next.value)) {
+      if (_.includes(["{", "["], state.tokens.next.value)) {
         tokens = destructuringPattern();
         lone = false;
       } else {
@@ -4240,11 +4240,11 @@ var JSHINT = (function() {
         else if (!initializer && checkPunctuator(nextop, "=")) initializer = nextop;
       }
     } while (
-      (level > 0 || !_.contains(inof, nextop.value) && nextop.value !== ";") &&
+      (level > 0 || !_.includes(inof, nextop.value) && nextop.value !== ";") &&
       nextop.type !== "(end)");
 
     // if we're in a for (… in|of …) statement
-    if (_.contains(inof, nextop.value)) {
+    if (_.includes(inof, nextop.value)) {
       if (nextop.value === "of") {
         bindingPower = 20;
         if (!state.inES6()) {
@@ -5028,7 +5028,7 @@ var JSHINT = (function() {
    */
   function checkPunctuators(token, values) {
     if (token.type === "(punctuator)") {
-      return _.contains(values, token.value);
+      return _.includes(values, token.value);
     }
     return false;
   }
@@ -5116,7 +5116,7 @@ var JSHINT = (function() {
           _current = _carrays[_carrays.length - 1];
         },
         setState: function(s) {
-          if (_.contains(["use", "define", "generate", "filter"], s))
+          if (_.includes(["use", "define", "generate", "filter"], s))
             _current.mode = s;
         },
         check: function(v) {


### PR DESCRIPTION
Version 3 of the Lodash module contains a security vulnerability. That
vulnerability was patched in the 4.17.5 release.

Note that version 4 of Lodash removes support for Internet Explorer 6,
7, and 8. The JSHint project does not formally document compatibility
with web browsers, but the source is currently dependent on Array
prototype methods introduced in ES5. This means that updating Lodash
does not effect the set of browsers supported by this project.

[1] https://hackerone.com/reports/310443
[2] https://github.com/lodash/lodash/wiki/Changelog#v400

Signed-off-by: Mike Pennisi <mike@mikepennisi.com>