### PR TITLE
[REFACTOR]: Warn instead of quitting when invalid options specified

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -230,7 +230,8 @@ var warnings = {
   W139: "Function expressions should not be used as the second operand to instanceof.",
   W140: "Missing comma.",
   W141: "Empty {a}: this is unnecessary and can be removed.",
-  W142: "Empty {a}: consider replacing with `import '{b}';`."
+  W142: "Empty {a}: consider replacing with `import '{b}';`.",
+  W143: "Option '{a}' is deprecated. {b}.",
 };
 
 var info = {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -36,7 +36,7 @@ exports.testCustomGlobals = function (test) {
   TestRun(test)
     .addError(2, 1, "Read only.")
     .addError(3, 1, "Read only.")
-    .test(code, { es3: true, unused: true, predef: { foo: false }});
+    .test(code, { esversion: 6, unused: true, predef: { foo: false }});
 
   test.done();
 };
@@ -46,7 +46,7 @@ exports.testUnusedDefinedGlobals = function (test) {
 
   TestRun(test)
     .addError(2, 1, "'bar' is defined but never used.")
-    .test(src, { es3: true, unused: true });
+    .test(src, { esversion: 6, unused: true });
 
   test.done();
 };
@@ -87,7 +87,7 @@ exports.testExportedDefinedGlobals = function (test) {
     "export { bar, foo };"];
 
   // Test should pass
-  TestRun(test).test(src, { esnext: true, unused: true }, {});
+  TestRun(test).test(src, { esversion: 6, unused: true }, {});
 
   var report = JSHINT.data();
   test.deepEqual(report.globals, ['bar', 'foo']);
@@ -98,12 +98,12 @@ exports.testExportedDefinedGlobals = function (test) {
 exports.testGlobalVarDeclarations = function (test) {
   var src = "var a;";
 
-  TestRun(test).test(src, { es3: true }, {});
+  TestRun(test).test(src, { esversion: 6 }, {});
 
   var report = JSHINT.data();
   test.deepEqual(report.globals, ['a']);
 
-  TestRun(test).test(src, { es3: true, node: true }, {});
+  TestRun(test).test(src, { esversion: 6, node: true }, {});
 
   report = JSHINT.data();
   test.strictEqual(report.globals, undefined);
@@ -119,7 +119,7 @@ exports.globalDeclarations = function (test) {
   var src = "exports = module.exports = function (test) {};";
 
   // Test should pass
-  TestRun(test).test(src, { es3: true, node: true }, { exports: true });
+  TestRun(test).test(src, { esversion: 6, node: true }, { exports: true });
 
   // Test should pass as well
   src = [
@@ -369,7 +369,7 @@ exports.returnStatement = function (test) {
     .addError(38, 5, "Line breaking error 'return'.")
     .addError(38, 11, "Missing semicolon.")
     .addError(39, 7, "Unnecessary semicolon.")
-    .test(src, { es3: true });
+    .test(src, { esversion: 6 });
 
   test.done();
 };
@@ -381,7 +381,7 @@ exports.argsInCatchReused = function (test) {
     .addError(12, 9, "Do not assign to the exception parameter.")
     .addError(13, 9, "Do not assign to the exception parameter.")
     .addError(24, 9, "'e' is not defined.")
-    .test(src, { es3: true, undef: true });
+    .test(src, { esversion: 6, undef: true });
 
   test.done();
 };
@@ -403,13 +403,13 @@ exports.yesEmptyStmt = function (test) {
     .addError(6, 1, "Expected an assignment or function call and instead saw an expression.")
     .addError(10, 2, "Unnecessary semicolon.")
     .addError(17, 11, "Unnecessary semicolon.")
-    .test(src, { es3: true, curly: false });
+    .test(src, { esversion: 6, curly: false });
 
   TestRun(test)
     .addError(1, 4, "Expected an identifier and instead saw ';'.")
     .addError(10, 2, "Unnecessary semicolon.")
     .addError(17, 11, "Unnecessary semicolon.")
-    .test(src, { es3: true, curly: false, expr: true });
+    .test(src, { esversion: 6, curly: false, expr: true });
 
   test.done();
 };
@@ -435,7 +435,7 @@ exports.insideEval = function (test) {
     .addError(17, 17, "Unexpected early end of program.")
     .addError(17, 17, "Unrecoverable syntax error. (100% scanned).")
 
-    .test(src, { es3: true, evil: false });
+    .test(src, { esversion: 6, evil: false });
 
   // Regression test for bug GH-714.
   JSHINT(src, { evil: false, maxerr: 1 });
@@ -471,7 +471,7 @@ exports.noExcOnTooManyUndefined = function (test) {
   TestRun(test)
     .addError(1, 1, "'a' is not defined.")
     .addError(1, 6, "'b' is not defined.")
-    .test(code, { es3: true, undef: true });
+    .test(code, { esversion: 6, undef: true });
 
   test.done();
 };
@@ -482,7 +482,7 @@ exports.defensiveSemicolon = function (test) {
   TestRun(test)
     .addError(16, 1, "Unnecessary semicolon.")
     .addError(17, 2, "Unnecessary semicolon.")
-    .test(src, { es3: true, expr: true, laxbreak: true });
+    .test(src, { esversion: 6, expr: true, laxbreak: true });
 
   test.done();
 };
@@ -504,7 +504,7 @@ exports.iife = function (test) {
 exports.invalidOptions = function (test) {
   TestRun(test)
     .addError(0, 0, "Bad option: 'invalid'.")
-    .test("function test() {}", { es3: true, devel: true, invalid: true });
+    .test("function test() {}", { esversion: 6, devel: true, invalid: true });
 
   test.done();
 };
@@ -528,13 +528,13 @@ exports.testInvalidSource = function (test) {
 
   TestRun(test)
     .addError(0, undefined, "Input is neither a string nor an array of strings.")
-    .test({}, {es3: true});
+    .test({}, {esversion: 6});
 
   TestRun(test)
-    .test("", {es3: true});
+    .test("", {esversion: 6});
 
   TestRun(test)
-    .test([], {es3: true});
+    .test([], {esversion: 6});
 
   test.done();
 };
@@ -544,7 +544,7 @@ exports.testConstructor = function (test) {
 
   TestRun(test)
     .addError(1, 1, "Do not use Number as a constructor.")
-    .test(code, {es3: true});
+    .test(code, {esversion: 6});
 
   test.done();
 };
@@ -554,7 +554,7 @@ exports.missingRadix = function (test) {
 
   TestRun(test)
     .addError(1, 12, "Missing radix parameter.")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   TestRun(test).test(code);
 
@@ -563,15 +563,15 @@ exports.missingRadix = function (test) {
 
 exports.NumberNaN = function (test) {
   var code = "(function (test) { return Number.NaN; })();";
-  TestRun(test).test(code, {es3: true});
+  TestRun(test).test(code, {esversion: 6});
 
   test.done();
 };
 
 exports.htmlEscapement = function (test) {
-  TestRun(test).test("var a = '<\\!--';", {es3: true});
+  TestRun(test).test("var a = '<\\!--';", {esversion: 6});
   TestRun(test)
-    .test("var a = '\\!';", {es3: true});
+    .test("var a = '\\!';", {esversion: 6});
 
   test.done();
 };
@@ -585,7 +585,7 @@ exports.testSparseArrays = function (test) {
     .addError(1, 23, "Extra comma. (it breaks older versions of IE)")
     .addError(1, 28, "Extra comma. (it breaks older versions of IE)")
     .addError(1, 40, "Extra comma. (it breaks older versions of IE)")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   TestRun(test)
     .test(src, { elision: true }); // es5
@@ -603,7 +603,7 @@ exports.testReserved = function (test) {
     .addError(13, 13, "Expected an identifier and instead saw 'class' (a reserved word).")
     .addError(14, 5, "Expected an identifier and instead saw 'else' (a reserved word).")
     .addError(15, 5, "Expected an identifier and instead saw 'protected' (a reserved word).")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   TestRun(test)
     .addError(5, 5, "Expected an identifier and instead saw 'let' (a reserved word).")
@@ -628,7 +628,7 @@ exports.testES5Reserved = function (test) {
     .addError(9, 3, "Expected an identifier and instead saw 'default' (a reserved word).")
     .addError(10, 3, "Expected an identifier and instead saw 'in' (a reserved word).")
     .addError(11, 10, "Expected an identifier and instead saw 'in' (a reserved word).")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   TestRun(test)
     .addError(6, 5, "Expected an identifier and instead saw 'default' (a reserved word).")
@@ -647,22 +647,22 @@ exports.testCatchBlocks = function (test) {
     .addError(19, 13, "'w' is already defined.")
     .addError(35, 19, "'u2' used out of scope.")
     .addError(36, 19, "'w2' used out of scope.")
-    .test(src, { es3: true, undef: true, devel: true });
+    .test(src, { esversion: 6, undef: true, devel: true });
 
   src = fs.readFileSync(__dirname + '/fixtures/gh618.js', 'utf8');
 
   TestRun(test)
     .addError(5, 11, "Value of 'x' may be overwritten in IE 8 and earlier.")
     .addError(15, 11, "Value of 'y' may be overwritten in IE 8 and earlier.")
-    .test(src, { es3: true, undef: true, devel: true });
+    .test(src, { esversion: 6, undef: true, devel: true });
 
   TestRun(test)
-    .test(src, { es3: true, undef: true, devel: true, node: true });
+    .test(src, { esversion: 6, undef: true, devel: true, node: true });
 
   var code = "try {} catch ({ message }) {}";
 
   TestRun(test, "destructuring in catch blocks' parameter")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -686,7 +686,7 @@ exports.testForIn = function (test) {
   ];
 
   TestRun(test)
-    .test(src, {es3: true});
+    .test(src, {esversion: 6});
 
   src = [
     "(function (o) {",
@@ -696,7 +696,7 @@ exports.testForIn = function (test) {
 
   TestRun(test)
     .addError(2, 6, "Creating global 'for' variable. Should be 'for (var i ...'.")
-    .test(src, {es3: true});
+    .test(src, {esversion: 6});
 
   src = [
     "(function (o) {",
@@ -738,7 +738,7 @@ exports.testForIn = function (test) {
     .addError(3, 13, "Invalid for-in loop left-hand-side: more than one ForBinding.")
     .addError(4, 6, "Invalid for-in loop left-hand-side: initializer is forbidden.")
     .addError(5, 6, "Invalid for-in loop left-hand-side: initializer is forbidden.")
-    .test(src, { esnext: true });
+    .test(src, { esversion: 6 });
 
   TestRun(test, "Left-hand side as MemberExpression")
     .test([
@@ -761,7 +761,7 @@ exports.testRegexArray = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/regex_array.js", "utf8");
 
   TestRun(test)
-    .test(src, {es3: true});
+    .test(src, {esversion: 6});
 
   test.done();
 };
@@ -806,7 +806,7 @@ exports.testUndefinedAssignment = function (test) {
     .addError(9, 9, "It's not necessary to initialize 'f' to 'undefined'.")
     .addError(10, 11, "It's not necessary to initialize 'g' to 'undefined'.")
     .addError(11, 9, "It's not necessary to initialize 'h' to 'undefined'.")
-    .test(src, {esnext: true});
+    .test(src, {esversion: 6});
 
   test.done();
 };
@@ -831,7 +831,7 @@ exports.testES6Modules = function (test) {
     .addError(74, 1, "Empty export: this is unnecessary and can be removed.")
     .addError(75, 1, "Empty export: consider replacing with `import 'source';`.");
   importConstErrors.forEach(function(error) { testRun.addError.apply(testRun, error); });
-  testRun.test(src, {esnext: true});
+  testRun.test(src, {esversion: 6});
 
   testRun
     .addError(3, 1, "'import' is only available in ES6 (use 'esversion: 6').")
@@ -922,7 +922,7 @@ exports.testES6ModulesNamedExportsAffectUnused = function (test) {
     .addError(19, 14, "const 'c1u' is initialized to 'undefined'.")
     .addError(19, 19, "const 'c2u' is initialized to 'undefined'.")
     .test(src1, {
-      esnext: true,
+      esversion: 6,
       unused: true
     });
 
@@ -954,7 +954,7 @@ exports.testConstRedeclaration = function (test) {
     .addError(9, 10, "'a' has already been declared.")
     .addError(13, 7, "'b' has already been declared.")
     .test(src, {
-      esnext: true
+      esversion: 6
     });
 
   test.done();
@@ -975,7 +975,7 @@ exports["test typeof in TDZ"] = function (test) {
   TestRun(test)
     .addError(2, 5, "'b' was used before it was declared, which is illegal for 'let' variables.")
     .test(src, {
-      esnext: true
+      esversion: 6
     });
 
   test.done();
@@ -1057,7 +1057,7 @@ exports.testConstModification = function (test) {
       .addError(53, 5, "Missing '()' invoking a constructor.")
       .addError(55, 3, "Attempting to override 'f' which is a constant.")
       .test(src, {
-        esnext: true
+        esversion: 6
       });
 
   test.done();
@@ -1067,7 +1067,7 @@ exports["class declaration export"] = function (test) {
   var source = fs.readFileSync(__dirname + "/fixtures/class-declaration.js", "utf8");
 
   TestRun(test).test(source, {
-    esnext: true,
+    esversion: 6,
     undef: true
   });
 
@@ -1078,7 +1078,7 @@ exports["function declaration export"] = function (test) {
   var source = fs.readFileSync(__dirname + "/fixtures/function-declaration.js", "utf8");
 
   TestRun(test).test(source, {
-    esnext: true,
+    esversion: 6,
     undef: true
   });
 
@@ -1109,7 +1109,7 @@ exports.classIsBlockScoped = function (test) {
     .addError(5, 5, "'D' is not defined.")
     .addError(9, 5, "'D' is not defined.")
     .addError(13, 5, "'F' is not defined.")
-    .test(code, { esnext: true, undef: true });
+    .test(code, { esversion: 6, undef: true });
 
   test.done();
 };
@@ -1129,7 +1129,7 @@ exports.testES6ModulesNamedExportsAffectUndef = function (test) {
   TestRun(test)
     .addError(1, 10, "'foo' is not defined.")
     .test(src1, {
-      esnext: true,
+      esversion: 6,
       undef: true
     });
 
@@ -1153,7 +1153,7 @@ exports.testES6ModulesThroughExportDoNotAffectUnused = function (test) {
   TestRun(test)
     .addError(1, 5, "'foo' is defined but never used.")
     .test(src1, {
-      esnext: true,
+      esversion: 6,
       unused: true
     });
 
@@ -1177,7 +1177,7 @@ exports.testES6ModulesThroughExportDoNotAffectUndef = function (test) {
   TestRun(test)
     .addError(2, 11, "'foo' is not defined.")
     .test(src1, {
-      esnext: true,
+      esversion: 6,
       undef: true
     });
 
@@ -1200,7 +1200,7 @@ exports.testES6ModulesDefaultExportsAffectUnused = function (test) {
 
   TestRun(test)
     .test(src1, {
-      esnext: true,
+      esversion: 6,
       unused: true
     });
 
@@ -1216,7 +1216,7 @@ exports.testES6ModulesDefaultExportAssignmentExpr = function (test) {
   ];
 
   TestRun(test)
-    .test(src, { unused: true, esnext: true });
+    .test(src, { unused: true, esversion: 6 });
 
   test.done();
 };
@@ -1229,7 +1229,7 @@ exports.testES6ModulesNameSpaceImportsAffectUnused = function (test) {
   TestRun(test)
     .addError(1, 13, "'angular' is defined but never used.")
     .test(src, {
-      esnext: true,
+      esversion: 6,
       unused: true
     });
 
@@ -1241,8 +1241,8 @@ exports.testES6TemplateLiterals = function (test) {
   var run = TestRun(test)
     .addError(14, 16, "Octal literals are not allowed in strict mode.")
     .addError(21, 20, "Unclosed template literal.");
-  run.test(src, { esnext: true });
-  run.test("/* jshint esnext: true */" + src);
+  run.test(src, { esversion: 6 });
+  run.test("/* jshint esversion: 6 */" + src);
 
   test.done();
 };
@@ -1252,7 +1252,7 @@ exports.testES6TaggedTemplateLiterals = function (test) {
   TestRun(test)
     .addError(16, 19, "Octal literals are not allowed in strict mode.")
     .addError(23, 23, "Unclosed template literal.")
-    .test(src, { esnext: true });
+    .test(src, { esversion: 6 });
   test.done();
 };
 
@@ -1262,7 +1262,7 @@ exports.testES6TemplateLiteralsUnused = function (test) {
     "alert(`${a} world`);"
   ];
   TestRun(test)
-    .test(src, { esnext: true, unused: true });
+    .test(src, { esversion: 6, unused: true });
 
   test.done();
 };
@@ -1274,7 +1274,7 @@ exports.testES6TaggedTemplateLiteralsUnused = function (test) {
     "alert(tag`${a} world`);"
   ];
   TestRun(test)
-    .test(src, { esnext: true, unused: true });
+    .test(src, { esversion: 6, unused: true });
 
   test.done();
 };
@@ -1287,7 +1287,7 @@ exports.testES6TemplateLiteralsUndef = function (test) {
   ];
   TestRun(test)
     .addError(2, 10, "'a' is not defined.")
-    .test(src, { esnext: true, undef: true });
+    .test(src, { esversion: 6, undef: true });
 
   test.done();
 };
@@ -1301,7 +1301,7 @@ exports.testES6TaggedTemplateLiteralsUndef = function (test) {
   TestRun(test)
     .addError(2, 7, "'tag' is not defined.")
     .addError(2, 13, "'a' is not defined.")
-    .test(src, { esnext: true, undef: true });
+    .test(src, { esversion: 6, undef: true });
 
   test.done();
 };
@@ -1315,7 +1315,7 @@ exports.testES6TemplateLiteralMultiline = function (test) {
     '`;'
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   test.done();
 };
@@ -1330,7 +1330,7 @@ exports.testES6TemplateLiteralsAreNotDirectives = function (test) {
 
   TestRun(test)
     .addError(2, 1, "Expected an assignment or function call and instead saw an expression.")
-    .test(src, { esnext: true });
+    .test(src, { esversion: 6 });
 
   var src2 = [
     "function fn() {",
@@ -1341,7 +1341,7 @@ exports.testES6TemplateLiteralsAreNotDirectives = function (test) {
 
   TestRun(test)
     .addError(2, 16, "Expected an assignment or function call and instead saw an expression.")
-    .test(src2, { esnext: true });
+    .test(src2, { esversion: 6 });
 
   test.done();
 };
@@ -1354,7 +1354,7 @@ exports.testES6TemplateLiteralReturnValue = function (test) {
     'print(sayHello("George"));'
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   var src = [
     'function* sayHello(to) {',
@@ -1363,7 +1363,7 @@ exports.testES6TemplateLiteralReturnValue = function (test) {
     'print(sayHello("George"));'
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   test.done();
 };
@@ -1377,7 +1377,7 @@ exports.testES6TemplateLiteralMultilineReturnValue = function (test) {
     'print(sayHello("George"));'
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   var src = [
     'function* sayHello(to) {',
@@ -1387,7 +1387,7 @@ exports.testES6TemplateLiteralMultilineReturnValue = function (test) {
     'print(sayHello("George"));'
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   test.done();
 };
@@ -1403,7 +1403,7 @@ exports.testES6TaggedTemplateLiteralMultilineReturnValue = function (test) {
     'print(sayHello("George"));'
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   var src = [
     'function tag() {}',
@@ -1414,7 +1414,7 @@ exports.testES6TaggedTemplateLiteralMultilineReturnValue = function (test) {
     'print(sayHello("George"));'
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   test.done();
 };
@@ -1430,7 +1430,7 @@ exports.testES6TemplateLiteralMultilineReturnValueWithFunctionCall = function (t
     'print(sayHello());',
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   test.done();
 };
@@ -1447,7 +1447,7 @@ exports.testES6TaggedTemplateLiteralMultilineReturnValueWithFunctionCall = funct
     'print(sayHello());',
   ];
 
-  TestRun(test).test(src, { esnext: true });
+  TestRun(test).test(src, { esversion: 6 });
 
   test.done();
 };
@@ -1472,7 +1472,7 @@ exports.testMultilineReturnValueStringLiteral = function (test) {
     'print(sayHello("George"));'
   ];
 
-  TestRun(test).test(src, { esnext: true, multistr: true });
+  TestRun(test).test(src, { esversion: 6, multistr: true });
 
   test.done();
 };
@@ -1484,7 +1484,7 @@ exports.testES6ExportStarFrom = function (test) {
     .addError(2, 13, "Expected '(string)' and instead saw ';'.")
     .addError(2, 14, "Missing semicolon.")
     .addError(3, 15, "Expected '(string)' and instead saw '78'.")
-    .test(src, { esnext: true });
+    .test(src, { esversion: 6 });
   test.done();
 };
 
@@ -1497,7 +1497,7 @@ exports.testPotentialVariableLeak = function (test) {
     .addError(2, 11, "You might be leaking a variable (b) here.")
     .addError(3, 13, "You might be leaking a variable (d) here.")
     .addError(4, 11, "You might be leaking a variable (f) here.")
-    .test(a, { esnext: true });
+    .test(a, { esversion: 6 });
 
   // False Positive
   TestRun(test)
@@ -1516,7 +1516,7 @@ exports.testDefaultArguments = function (test) {
     .addError(27, 10, "'c' is not defined.")
     .addError(33, 4, "'d' was used before it was defined.")
     .addError(36, 16, "'e' was used before it was declared, which is illegal for 'param' variables.")
-    .test(src, { esnext: true, undef: true, latedef: true });
+    .test(src, { esversion: 6, undef: true, latedef: true });
 
   TestRun(test)
     .addError(14, 32, "'num3' was used before it was declared, which is illegal for 'param' variables.")
@@ -2010,7 +2010,7 @@ exports.duplicateProto = function (test) {
 
   TestRun(test, "Duplicate `let`s")
     .addError(3, 7, "'__proto__' has already been declared.")
-    .test(src, { proto: true, esnext: true });
+    .test(src, { proto: true, esversion: 6 });
 
   src = [
     "(function() {",
@@ -2021,7 +2021,7 @@ exports.duplicateProto = function (test) {
 
   TestRun(test, "Duplicate `const`s")
     .addError(3, 9, "'__proto__' has already been declared.")
-    .test(src, { proto: true, esnext: true });
+    .test(src, { proto: true, esversion: 6 });
 
   src = [
     "void {",

--- a/tests/unit/envs.js
+++ b/tests/unit/envs.js
@@ -55,20 +55,20 @@ exports.node = function (test) {
 
   TestRun(test)
     .addError(1, 1, 'Use the function form of "use strict".')
-    .test(globalStrict, { es3: true, strict: true });
+    .test(globalStrict, { esversion: 3, strict: true });
 
   TestRun(test)
-    .test(globalStrict, { es3: true, node: true, strict: true });
+    .test(globalStrict, { esversion: 3, node: true, strict: true });
 
   TestRun(test)
-    .test(globalStrict, { es3: true, browserify: true, strict: true });
+    .test(globalStrict, { esversion: 3, browserify: true, strict: true });
 
   // Don't assume strict:true for Node environments. See bug GH-721.
   TestRun(test)
-    .test("function test() { return; }", { es3: true, node: true });
+    .test("function test() { return; }", { esversion: 3, node: true });
 
   TestRun(test)
-    .test("function test() { return; }", { es3: true, browserify: true });
+    .test("function test() { return; }", { esversion: 3, browserify: true });
 
   // Make sure that we can do fancy Node export
 
@@ -80,11 +80,11 @@ exports.node = function (test) {
 
   TestRun(test)
     .addError(1, 1, "Read only.")
-    .test(overwrites, { es3: true, node: true });
+    .test(overwrites, { esversion: 3, node: true });
 
   TestRun(test)
     .addError(1, 1, "Read only.")
-    .test(overwrites, { es3: true, browserify: true });
+    .test(overwrites, { esversion: 3, browserify: true });
 
   TestRun(test, "gh-2657")
     .test("'use strict';var a;", { node: true });
@@ -160,7 +160,7 @@ exports.es5 = function (test) {
     .addError(75, 13, "get/set are ES5 features.")
     .addError(76, 13, "get/set are ES5 features.")
     .addError(80, 13, "get/set are ES5 features.")
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   TestRun(test)
     .addError(36, 13, "Setter is defined without getter.")
@@ -177,7 +177,7 @@ exports.es5 = function (test) {
     .test(src, {  }); // es5
 
   // JSHint should not throw "Missing property name" error on nameless getters/setters
-  // using Method Definition Shorthand if esnext flag is enabled.
+  // using Method Definition Shorthand if esversion flag >= 6.
   TestRun(test)
     .addError(36, 13, "Setter is defined without getter.")
     .addError(43, 10, "Duplicate key 'x'.")
@@ -188,7 +188,7 @@ exports.es5 = function (test) {
     .addError(62, 14, "Expected a single parameter in set x function.")
     .addError(64, 14, "Expected a single parameter in set z function.")
     .addError(80, 13, "Setter is defined without getter.")
-    .test(src, { esnext: true });
+    .test(src, { esversion: 6 });
 
   // Make sure that JSHint parses getters/setters as function expressions
   // (https://github.com/jshint/jshint/issues/96)
@@ -207,10 +207,10 @@ exports.phantom = function (test) {
 
   TestRun(test)
     .addError(1, 1, 'Use the function form of "use strict".')
-    .test(globalStrict, { es3: true, strict: true });
+    .test(globalStrict, { esversion: 3, strict: true });
 
   TestRun(test)
-    .test(globalStrict, { es3: true, phantom: true, strict: true });
+    .test(globalStrict, { esversion: 3, phantom: true, strict: true });
 
 
   test.done();
@@ -360,9 +360,9 @@ exports.browser = function (test) {
     .addError(31, 15, "'document' is not defined.")
     .addError(32, 1, "'fetch' is not defined.")
     .addError(35, 19, "'URL' is not defined.")
-    .test(src, {es3: true, undef: true });
+    .test(src, {esversion: 3, undef: true });
 
-  TestRun(test).test(src, {es3: true, browser: true, undef: true });
+  TestRun(test).test(src, {esversion: 3, browser: true, undef: true });
 
   test.done();
 };

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -28,21 +28,21 @@ exports.shadow = function (test) {
   TestRun(test)
     .addError(5, 13, "'a' is already defined.")
     .addError(10, 9, "'foo' is already defined.")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   TestRun(test)
     .addError(5, 13, "'a' is already defined.")
     .addError(10, 9, "'foo' is already defined.")
-    .test(src, {es3: true, shadow: false });
+    .test(src, {esversion: 3, shadow: false });
 
   TestRun(test)
     .addError(5, 13, "'a' is already defined.")
     .addError(10, 9, "'foo' is already defined.")
-    .test(src, {es3: true, shadow: "inner" });
+    .test(src, {esversion: 3, shadow: "inner" });
 
   // Allow variable shadowing when shadow is true
   TestRun(test)
-    .test(src, { es3: true, shadow: true });
+    .test(src, { esversion: 3, shadow: true });
 
   src = [
     "function f() {",
@@ -77,7 +77,7 @@ exports.shadowouter = function (test) {
     .addError(12, 18, "'b' is already defined in outer scope.")
     .addError(20, 18, "'bar' is already defined in outer scope.")
     .addError(26, 14, "'foo' is already defined.")
-    .test(src, { es3: true, shadow: "outer" });
+    .test(src, { esversion: 3, shadow: "outer" });
 
   test.done();
 };
@@ -192,15 +192,15 @@ exports.shadowEs6 = function (test) {
 
   var testRun = TestRun(test);
   commonErrors.forEach(function(error) { testRun.addError.apply(testRun, error); });
-  testRun.test(src, {esnext: true, shadow: true});
+  testRun.test(src, {esversion: 6, shadow: true});
 
   var testRun = TestRun(test);
   commonErrors.concat(innerErrors).forEach(function(error) { testRun.addError.apply(testRun, error); });
-  testRun.test(src, {esnext: true, shadow: "inner", maxerr: 100 });
+  testRun.test(src, {esversion: 6, shadow: "inner", maxerr: 100 });
 
   var testRun = TestRun(test);
   commonErrors.concat(innerErrors, outerErrors).forEach(function(error) { testRun.addError.apply(testRun, error); });
-  testRun.test(src, {esnext: true, shadow: "outer", maxerr: 100});
+  testRun.test(src, {esversion: 6, shadow: "outer", maxerr: 100});
 
   test.done();
 };
@@ -224,34 +224,34 @@ exports.latedef = function (test) {
 
   // By default, tolerate the use of variable before its definition
   TestRun(test)
-    .test(src, {es3: true, funcscope: true});
+    .test(src, {esversion: 3, funcscope: true});
 
   TestRun(test)
       .addError(10, 5, "'i' was used before it was declared, which is illegal for 'let' variables.")
-      .test(esnextSrc, {esnext: true});
+      .test(esnextSrc, {esversion: 6});
 
   // However, JSHint must complain if variable is actually missing
   TestRun(test)
     .addError(1, 1, "'fn' is not defined.")
-    .test('fn();', { es3: true, undef: true });
+    .test('fn();', { esversion: 3, undef: true });
 
   // And it also must complain about the redefinition (see option `shadow`)
   TestRun(test)
     .addError(5, 13, "'a' is already defined.")
     .addError(10, 9, "'foo' is already defined.")
-    .test(src1, { es3: true });
+    .test(src1, { esversion: 3 });
 
   // When latedef is true, JSHint must not tolerate the use before definition
   TestRun(test)
     .addError(10, 9, "'vr' was used before it was defined.")
-    .test(src, { es3: true, latedef: "nofunc" });
+    .test(src, { esversion: 3, latedef: "nofunc" });
 
   // when latedef is true, jshint must not warn if variable is defined.
   TestRun(test)
     .test([
       "if(true) { var a; }",
       "if (a) { a(); }",
-      "var a;"], { es3: true, latedef: true});
+      "var a;"], { esversion: 3, latedef: true});
 
   // When latedef_func is true, JSHint must not tolerate the use before definition for functions
   TestRun(test)
@@ -260,7 +260,7 @@ exports.latedef = function (test) {
     .addError(10, 9, "'vr' was used before it was defined.")
     .addError(18, 12, "'bar' was used before it was defined.")
     .addError(18, 3, "Inner functions should be listed at the top of the outer function.")
-    .test(src, { es3: true, latedef: true });
+    .test(src, { esversion: 3, latedef: true });
 
   var es2015Errors = TestRun(test)
       .addError(4, 5, "'c' was used before it was defined.")
@@ -318,13 +318,13 @@ exports.notypeof = function (test) {
     .addError(2, 14, "Invalid typeof value 'double'")
     .addError(3, 17, "Invalid typeof value 'bool'")
     .addError(4, 11, "Invalid typeof value 'obj'")
-    .test(src, { esnext: true });
+    .test(src, { esversion: 6 });
 
   TestRun(test)
     .test(src, { notypeof: true });
 
   TestRun(test)
-    .test(src, { notypeof: true, esnext: true });
+    .test(src, { notypeof: true, esversion: 6 });
 
   test.done();
 }
@@ -337,11 +337,11 @@ exports['combination of latedef and undef'] = function (test) {
   TestRun(test)
     .addError(29, 1, "'hello' is not defined.")
     .addError(35, 5, "'world' is not defined.")
-    .test(src, { es3: true, latedef: false, undef: true });
+    .test(src, { esversion: 3, latedef: false, undef: true });
 
   // When we suppress `latedef` and `undef` then we get no warnings.
   TestRun(test)
-    .test(src, { es3: true, latedef: false, undef: false });
+    .test(src, { esversion: 3, latedef: false, undef: false });
 
   // If we warn on `latedef` but suppress `undef` we only get the
   // late definition warnings.
@@ -353,13 +353,13 @@ exports['combination of latedef and undef'] = function (test) {
     .addError(34, 14, "'fn' was used before it was defined.")
     .addError(41, 9, "'q' was used before it was defined.")
     .addError(46, 5, "'h' was used before it was defined.")
-    .test(src, { es3: true, latedef: true, undef: false });
+    .test(src, { esversion: 3, latedef: true, undef: false });
 
   // But we get all the functions warning if we disable latedef func
   TestRun(test)
     .addError(41, 9, "'q' was used before it was defined.")
     .addError(46, 5, "'h' was used before it was defined.")
-    .test(src, { es3: true, latedef: "nofunc", undef: false });
+    .test(src, { esversion: 3, latedef: "nofunc", undef: false });
 
   // If we warn on both options we get all the warnings.
   TestRun(test)
@@ -372,7 +372,7 @@ exports['combination of latedef and undef'] = function (test) {
     .addError(35, 5, "'world' is not defined.")
     .addError(41, 9, "'q' was used before it was defined.")
     .addError(46, 5, "'h' was used before it was defined.")
-    .test(src, { es3: true, latedef: true, undef: true });
+    .test(src, { esversion: 3, latedef: true, undef: true });
 
   // If we remove latedef_func, we don't get the functions warning
   TestRun(test)
@@ -380,14 +380,14 @@ exports['combination of latedef and undef'] = function (test) {
     .addError(35, 5, "'world' is not defined.")
     .addError(41, 9, "'q' was used before it was defined.")
     .addError(46, 5, "'h' was used before it was defined.")
-    .test(src, { es3: true, latedef: "nofunc", undef: true });
+    .test(src, { esversion: 3, latedef: "nofunc", undef: true });
 
   test.done();
 };
 
 exports.undefwstrict = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/undefstrict.js', 'utf8');
-  TestRun(test).test(src, { es3: true, undef: false });
+  TestRun(test).test(src, { esversion: 3, undef: false });
 
   test.done();
 };
@@ -429,17 +429,17 @@ exports.testProtoAndIterator = function (test) {
     .addError(27, 53, "The '__iterator__' property is deprecated.")
     .addError(33, 19, "The '__proto__' property is deprecated.")
     .addError(37, 29, "The '__proto__' property is deprecated.")
-    .test(source, {es3: true});
+    .test(source, {esversion: 3});
 
   TestRun(test)
     .addError(1, 2, "The '__proto__' key may produce unexpected results.")
     .addError(1, 21, "The '__iterator__' key may produce unexpected results.")
-    .test(json, {es3: true});
+    .test(json, {esversion: 3});
 
   // Should not report any errors when proto and iterator
   // options are on
-  TestRun("source").test(source, { es3: true, proto: true, iterator: true });
-  TestRun("json").test(json, { es3: true, proto: true, iterator: true });
+  TestRun("source").test(source, { esversion: 3, proto: true, iterator: true });
+  TestRun("json").test(json, { esversion: 3, proto: true, iterator: true });
 
   test.done();
 };
@@ -452,7 +452,7 @@ exports.testCamelcase = function (test) {
 
   // By default, tolerate arbitrary identifiers
   TestRun(test)
-    .test(source, {es3: true});
+    .test(source, {esversion: 3});
 
   // Require identifiers in camel case if camelcase is true
   TestRun(test)
@@ -461,7 +461,7 @@ exports.testCamelcase = function (test) {
     .addError(6, 15, "Identifier 'test_me' is not in camel case.")
     .addError(6, 25, "Identifier 'test_me' is not in camel case.")
     .addError(13, 26, "Identifier 'test_1' is not in camel case.")
-    .test(source, { es3: true, camelcase: true });
+    .test(source, { esversion: 3, camelcase: true });
 
 
   test.done();
@@ -483,8 +483,8 @@ exports.curly = function (test) {
     src1 = fs.readFileSync(__dirname + '/fixtures/curly2.js', 'utf8');
 
   // By default, tolerate one-line blocks since they are valid JavaScript
-  TestRun(test).test(src, {es3: true});
-  TestRun(test).test(src1, {es3: true});
+  TestRun(test).test(src, {esversion: 3});
+  TestRun(test).test(src1, {esversion: 3});
 
   // Require all blocks to be wrapped with curly braces if curly is true
   TestRun(test)
@@ -492,9 +492,9 @@ exports.curly = function (test) {
     .addError(5, 5, "Expected '{' and instead saw 'doSomething'.")
     .addError(8, 5, "Expected '{' and instead saw 'doSomething'.")
     .addError(11, 5, "Expected '{' and instead saw 'doSomething'.")
-    .test(src, { es3: true, curly: true });
+    .test(src, { esversion: 3, curly: true });
 
-  TestRun(test).test(src1, { es3: true, curly: true });
+  TestRun(test).test(src1, { esversion: 3, curly: true });
 
   test.done();
 };
@@ -509,13 +509,13 @@ exports.noempty = function (test) {
   ];
 
   // By default, tolerate empty blocks since they are valid JavaScript
-  TestRun(test).test(code, { es3: true });
+  TestRun(test).test(code, { esversion: 3 });
 
   // Do not tolerate, when noempty is true
   TestRun(test)
     .addError(1, 10, "Empty block.")
     .addError(2, 11, "Empty block.")
-    .test(code, { es3: true, noempty: true });
+    .test(code, { esversion: 3, noempty: true });
 
   test.done();
 };
@@ -531,13 +531,13 @@ exports.noarg = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/noarg.js', 'utf8');
 
   // By default, tolerate both arguments.callee and arguments.caller
-  TestRun(test).test(src, { es3: true });
+  TestRun(test).test(src, { esversion: 3 });
 
   // Do not tolerate both .callee and .caller when noarg is true
   TestRun(test)
     .addError(2, 12, 'Avoid arguments.callee.')
     .addError(6, 12, 'Avoid arguments.caller.')
-    .test(src, { es3: true, noarg: true });
+    .test(src, { esversion: 3, noarg: true });
 
   test.done();
 };
@@ -547,12 +547,12 @@ exports.nonew = function (test) {
   var code  = "new Thing();",
     code1 = "var obj = new Thing();";
 
-  TestRun(test).test(code, { es3: true });
-  TestRun(test).test(code1, { es3: true });
+  TestRun(test).test(code, { esversion: 3 });
+  TestRun(test).test(code1, { esversion: 3 });
 
   TestRun(test)
     .addError(1, 1, "Do not use 'new' for side effects.")
-    .test(code, { es3: true, nonew: true });
+    .test(code, { esversion: 3, nonew: true });
 
   test.done();
 };
@@ -581,10 +581,10 @@ exports.asi = function (test) {
     .addError(26, 10, "Missing semicolon.")
     .addError(27, 12, "Missing semicolon.")
     .addError(28, 12, "Missing semicolon.")
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   TestRun(test, 2)
-    .test(src, { es3: true, asi: true });
+    .test(src, { esversion: 3, asi: true });
 
   var code = [
     "function a() { 'code' }",
@@ -689,13 +689,13 @@ exports.lastsemic = function (test) {
     .addError(2, 11, "Missing semicolon.") // missing semicolon in the middle of a block
     .addError(4, 45, "Missing semicolon.") // missing semicolon in a one-liner function
     .addError(5, 12, "Missing semicolon.") // missing semicolon at the end of a block
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   // with lastsemic
   TestRun(test)
     .addError(2, 11, "Missing semicolon.")
     .addError(5, 12, "Missing semicolon.")
-    .test(src, { es3: true, lastsemic: true });
+    .test(src, { esversion: 3, lastsemic: true });
   // this line is valid now: [1, 2, 3].forEach(function(i) { print(i) });
   // line 5 isn't, because the block doesn't close on the same line
 
@@ -722,11 +722,11 @@ exports.expr = function (test) {
   for (var i = 0, exp; exp = exps[i]; i += 1) {
     TestRun(test)
       .addError(1, exp.character, 'Expected an assignment or function call and instead saw an expression.')
-      .test(exp.src, { es3: true });
+      .test(exp.src, { esversion: 3 });
   }
 
   for (i = 0, exp = null; exp = exps[i]; i += 1) {
-    TestRun(test).test(exp.src, { es3: true, expr: true });
+    TestRun(test).test(exp.src, { esversion: 3, expr: true });
   }
 
   test.done();
@@ -737,7 +737,7 @@ exports.undef = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/undef.js', 'utf8');
 
   // Make sure there are no other errors
-  TestRun(test).test(src, { es3: true });
+  TestRun(test).test(src, { esversion: 3 });
 
   // Make sure it fails when undef is true
   TestRun(test)
@@ -754,7 +754,7 @@ exports.undef = function (test) {
     .addError(32, 12, "'undef' is not defined.")
     .addError(33, 13, "'undef' is not defined.")
     .addError(34, 12, "'undef' is not defined.")
-    .test(src, { es3: true, undef: true });
+    .test(src, { esversion: 3, undef: true });
 
   // block scope cannot use themselves in the declaration
   TestRun(test)
@@ -770,7 +770,7 @@ exports.undef = function (test) {
       '  e = e || 2;',
       '  return e;',
       '}'
-    ], { esnext: true, undef: true });
+    ], { esversion: 6, undef: true });
 
   // Regression test for GH-668.
   src = fs.readFileSync(__dirname + "/fixtures/gh668.js", "utf8");
@@ -920,7 +920,7 @@ exports.unused.basic = function (test) {
   allErrors.forEach(function (e) {
     testRun.addError.apply(testRun, e);
   });
-  testRun.test(src, { esnext: true });
+  testRun.test(src, { esversion: 6 });
 
   var var_errors = allErrors.concat([
     [1, 5, "'a' is defined but never used."],
@@ -954,14 +954,14 @@ exports.unused.basic = function (test) {
     [71, 6, "'y' is defined but never used."]
   ];
 
-  var true_run = TestRun(test, {esnext: true});
+  var true_run = TestRun(test, {esversion: 6});
 
   var_errors.slice().concat(last_param_errors).forEach(function (e) {
     true_run.addError.apply(true_run, e);
   });
 
-  true_run.test(src, { esnext: true, unused: true });
-  test.ok(!JSHINT(src, { esnext: true, unused: true }));
+  true_run.test(src, { esversion: 6, unused: true });
+  test.ok(!JSHINT(src, { esversion: 6, unused: true }));
 
   // Test checking all function params via unused="strict"
   var all_run = TestRun(test);
@@ -969,12 +969,12 @@ exports.unused.basic = function (test) {
     all_run.addError.apply(true_run, e);
   });
 
-  all_run.test(src, { esnext: true, unused: "strict"});
+  all_run.test(src, { esversion: 6, unused: "strict"});
 
   // Test checking everything except function params
   var vars_run = TestRun(test);
   var_errors.forEach(function (e) { vars_run.addError.apply(vars_run, e); });
-  vars_run.test(src, { esnext: true, unused: "vars"});
+  vars_run.test(src, { esversion: 6, unused: "vars"});
 
   var unused = JSHINT.data().unused;
   test.equal(24, unused.length);
@@ -1096,7 +1096,7 @@ exports['let can re-use function and class name'] = function (test) {
       "A();",
       "var D = class E { constructor(F) { let E = F; return E; }};",
       "D();"
-    ], { undef: true, unused: "strict", esnext: true });
+    ], { undef: true, unused: "strict", esversion: 6 });
 
   test.done();
 };
@@ -1115,7 +1115,7 @@ exports['unused with param destructuring'] = function(test) {
 
   TestRun(test)
     .addError(2, 5, "'args' is defined but never used.")
-    .test(code, { esnext: true, unused: true });
+    .test(code, { esversion: 6, unused: true });
 
   TestRun(test)
     .addError(1, 14, "'args' is defined but never used.")
@@ -1126,7 +1126,7 @@ exports['unused with param destructuring'] = function(test) {
     .addError(6, 19, "'args' is defined but never used.")
     .addError(7, 20, "'args' is defined but never used.")
     .addError(8, 20, "'args' is defined but never used.")
-    .test(code, { esnext: true, unused: "strict" });
+    .test(code, { esversion: 6, unused: "strict" });
 
 
   test.done();
@@ -1207,33 +1207,33 @@ exports['unused overrides'] = function (test) {
   var code;
 
   code = ['function foo(a) {', '/*jshint unused:false */', '}', 'foo();'];
-  TestRun(test).test(code, {es3: true, unused: true});
+  TestRun(test).test(code, {esversion: 3, unused: true});
 
   code = ['function foo(a, b, c) {', '/*jshint unused:vars */', 'var i = b;', '}', 'foo();'];
   TestRun(test)
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {es3: true, unused: true});
+    .test(code, {esversion: 3, unused: true});
 
   code = ['function foo(a, b, c) {', '/*jshint unused:true */', 'var i = b;', '}', 'foo();'];
   TestRun(test)
     .addError(1, 20, "'c' is defined but never used.")
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {es3: true, unused: "strict"});
+    .test(code, {esversion: 3, unused: "strict"});
 
   code = ['function foo(a, b, c) {', '/*jshint unused:strict */', 'var i = b;', '}', 'foo();'];
   TestRun(test)
     .addError(1, 14, "'a' is defined but never used.")
     .addError(1, 20, "'c' is defined but never used.")
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {es3: true, unused: true});
+    .test(code, {esversion: 3, unused: true});
 
   code = ['/*jshint unused:vars */', 'function foo(a, b) {}', 'foo();'];
-  TestRun(test).test(code, {es3: true, unused: "strict"});
+  TestRun(test).test(code, {esversion: 3, unused: "strict"});
 
   code = ['/*jshint unused:vars */', 'function foo(a, b) {', 'var i = 3;', '}', 'foo();'];
   TestRun(test)
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {es3: true, unused: "strict"});
+    .test(code, {esversion: 3, unused: "strict"});
 
   code = ['/*jshint unused:badoption */', 'function foo(a, b) {', 'var i = 3;', '}', 'foo();'];
   TestRun(test)
@@ -1241,39 +1241,39 @@ exports['unused overrides'] = function (test) {
     .addError(2, 17, "'b' is defined but never used.")
     .addError(2, 14, "'a' is defined but never used.")
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {es3: true, unused: "strict"});
+    .test(code, {esversion: 3, unused: "strict"});
 
   test.done();
 };
 
-exports['unused overrides esnext'] = function (test) {
+exports['unused overrides esversion=6'] = function (test) {
   var code;
 
   code = ['function foo(a) {', '/*jshint unused:false */', '}', 'foo();'];
-  TestRun(test).test(code, {esnext: true, unused: true});
+  TestRun(test).test(code, {esversion: 6, unused: true});
 
   code = ['function foo(a, b, c) {', '/*jshint unused:vars */', 'let i = b;', '}', 'foo();'];
   TestRun(test)
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {esnext: true, unused: true});
+    .test(code, {esversion: 6, unused: true});
 
   code = ['function foo(a, b, c) {', '/*jshint unused:true */', 'let i = b;', '}', 'foo();'];
   TestRun(test)
     .addError(1, 20, "'c' is defined but never used.")
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {esnext: true, unused: "strict"});
+    .test(code, {esversion: 6, unused: "strict"});
 
   code = ['function foo(a, b, c) {', '/*jshint unused:strict */', 'let i = b;', '}', 'foo();'];
   TestRun(test)
     .addError(1, 14, "'a' is defined but never used.")
     .addError(1, 20, "'c' is defined but never used.")
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {esnext: true, unused: true});
+    .test(code, {esversion: 6, unused: true});
 
   code = ['/*jshint unused:vars */', 'function foo(a, b) {', 'let i = 3;', '}', 'foo();'];
   TestRun(test)
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {esnext: true, unused: "strict"});
+    .test(code, {esversion: 6, unused: "strict"});
 
   code = ['/*jshint unused:badoption */', 'function foo(a, b) {', 'let i = 3;', '}', 'foo();'];
   TestRun(test)
@@ -1281,7 +1281,7 @@ exports['unused overrides esnext'] = function (test) {
     .addError(2, 17, "'b' is defined but never used.")
     .addError(2, 14, "'a' is defined but never used.")
     .addError(3, 5, "'i' is defined but never used.")
-    .test(code, {esnext: true, unused: "strict"});
+    .test(code, {esversion: 6, unused: "strict"});
 
   test.done();
 };
@@ -1318,8 +1318,8 @@ exports['undef in a function scope'] = function (test) {
   var src = fixture('undef_func.js');
 
   // Make sure that the lint is clean with and without undef.
-  TestRun(test).test(src, {es3: true});
-  TestRun(test).test(src, {es3: true, undef: true });
+  TestRun(test).test(src, {esversion: 3});
+  TestRun(test).test(src, {esversion: 3, undef: true });
 
   test.done();
 };
@@ -1337,14 +1337,14 @@ exports.scripturl = function (test) {
     .addError(1, 47, "Script URL.")
     .addError(2, 20, "Script URL.") // 2 times?
     .addError(2, 7, "JavaScript URL.")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   // Make sure the error goes away when javascript URLs are tolerated
-  TestRun(test).test(code, { es3: true, scripturl: true });
+  TestRun(test).test(code, { esversion: 3, scripturl: true });
 
   // Make sure an error does not exist for labels that look like URLs (GH-1013)
   TestRun(test)
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   test.done();
 };
@@ -1363,7 +1363,7 @@ exports.forin = function (test) {
         'properties from the prototype.';
 
   // Make sure there are no other errors
-  TestRun(test).test(src, {es3: true});
+  TestRun(test).test(src, {esversion: 3});
 
   // Make sure it fails when forin is true
   TestRun(test)
@@ -1372,7 +1372,7 @@ exports.forin = function (test) {
     .addError(37, 3, msg)
     .addError(43, 9, msg)
     .addError(73, 1, msg)
-    .test(src, { es3: true, forin: true });
+    .test(src, { esversion: 3, forin: true });
 
   test.done();
 };
@@ -1397,14 +1397,14 @@ exports.loopfunc = function (test) {
     .addError(12, 5, "Function declarations should not be placed in blocks. Use a function " +
             "expression or move the statement to the top of the outer function.")
     .addError(42, 7, "Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (i)")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   // When loopfunc is true, only function declaration should fail.
   // Expressions are okay.
   TestRun(test)
     .addError(12, 5, "Function declarations should not be placed in blocks. Use a function " +
             "expression or move the statement to the top of the outer function.")
-    .test(src, { es3: true, loopfunc: true });
+    .test(src, { esversion: 3, loopfunc: true });
 
   var es6LoopFuncSrc = [
     "for (var i = 0; i < 5; i++) {",
@@ -1432,7 +1432,7 @@ exports.loopfunc = function (test) {
     .addError(11, 9, "Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (i)")
     .addError(14, 15, "Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (i)")
     .addError(17, 9, "Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (i)")
-    .test(es6LoopFuncSrc, {esnext: true});
+    .test(es6LoopFuncSrc, {esversion: 6});
 
   // functions declared in the expressions that loop should warn
   var src2 = [
@@ -1444,7 +1444,7 @@ exports.loopfunc = function (test) {
   TestRun(test)
     .addError(1, 25, "Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (i)")
     .addError(3, 16, "Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (j)")
-    .test(src2, { es3: true, loopfunc: false, boss: true });
+    .test(src2, { esversion: 3, loopfunc: false, boss: true });
 
   TestRun(test, "Allows closing over immutable bindings (ES5)")
     .addError(6, 8, "Functions declared within loops referencing an outer scoped variable may lead to confusing semantics. (outerVar)")
@@ -1548,10 +1548,10 @@ exports.boss = function (test) {
     // GH-670
     .addError(28, 13, "Did you mean to return a conditional instead of an assignment?")
     .addError(32, 15, "Did you mean to return a conditional instead of an assignment?")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   // But if you are the boss, all is good
-  TestRun(test).test(src, { es3: true, boss: true });
+  TestRun(test).test(src, { esversion: 3, boss: true });
 
   test.done();
 };
@@ -1575,13 +1575,13 @@ exports.eqnull = function (test) {
    * order to discourage regressions.
    */
   TestRun(test)
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   // But when `eqnull` is true, no questions asked
-  TestRun(test).test(code, { es3: true, eqnull: true });
+  TestRun(test).test(code, { esversion: 3, eqnull: true });
 
   // Make sure that `eqnull` has precedence over `eqeqeq`
-  TestRun(test).test(code, { es3: true, eqeqeq: true, eqnull: true });
+  TestRun(test).test(code, { esversion: 3, eqeqeq: true, eqnull: true });
 
   test.done();
 };
@@ -1601,9 +1601,9 @@ exports.supernew = function (test) {
     .addError(1, 9, "Weird construction. Is 'new' necessary?")
     .addError(9, 1, "Missing '()' invoking a constructor.")
     .addError(11, 13, "Missing '()' invoking a constructor.")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
-  TestRun(test).test(src, { es3: true, supernew: true });
+  TestRun(test).test(src, { esversion: 3, supernew: true });
 
   test.done();
 };
@@ -1620,33 +1620,33 @@ exports.bitwise = function (test) {
     op = unOps[i];
 
     TestRun(test)
-      .test("var b = " + op + "a;", {es3: true});
+      .test("var b = " + op + "a;", {esversion: 3});
 
     TestRun(test)
       .addError(1, 9, "Unexpected use of '" + op + "'.")
-      .test("var b = " + op + "a;", {es3: true, bitwise: true});
+      .test("var b = " + op + "a;", {esversion: 3, bitwise: true});
   }
 
   for (i = 0; i < binOps.length; i += 1) {
     op = binOps[i];
 
     TestRun(test)
-      .test("var c = a " + op + " b;", {es3: true});
+      .test("var c = a " + op + " b;", {esversion: 3});
 
     TestRun(test)
       .addError(1, 11, "Unexpected use of '" + op + "'.")
-      .test("var c = a " + op + " b;", {es3: true, bitwise: true});
+      .test("var c = a " + op + " b;", {esversion: 3, bitwise: true});
   }
 
   for (i = 0; i < modOps.length; i += 1) {
     op = modOps[i];
 
     TestRun(test)
-      .test("b " + op + " a;", {es3: true});
+      .test("b " + op + " a;", {esversion: 3});
 
     TestRun(test)
       .addError(1, 3, "Unexpected use of '" + op + "'.")
-      .test("b " + op + " a;", {es3: true, bitwise: true});
+      .test("b " + op + " a;", {esversion: 3, bitwise: true});
   }
 
   test.done();
@@ -1659,10 +1659,10 @@ exports.debug = function (test) {
   // By default disallow debugger statements.
   TestRun(test)
     .addError(1, 20, "Forgotten 'debugger' statement?")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   // But allow them if debug is true.
-  TestRun(test).test(code, { es3: true, debug: true });
+  TestRun(test).test(code, { esversion: 3, debug: true });
 
   test.done();
 };
@@ -1678,7 +1678,7 @@ exports.debuggerWithoutSemicolons = function (test) {
   // Ensure we mark the correct line when finding debugger statements
   TestRun(test)
     .addError(2, 1, "Forgotten 'debugger' statement?")
-    .test(src, {es3: true, asi: true});
+    .test(src, {esversion: 3, asi: true});
 
   test.done();
 };
@@ -1693,13 +1693,13 @@ exports.eqeqeq = function (test) {
    * order to discourage regressions.
    */
   TestRun(test)
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   TestRun(test)
     .addError(2, 13, "Expected '===' and instead saw '=='.")
     .addError(5, 13, "Expected '!==' and instead saw '!='.")
     .addError(8, 13, "Expected '===' and instead saw '=='.")
-    .test(src, { es3: true, eqeqeq: true });
+    .test(src, { esversion: 3, eqeqeq: true });
 
   test.done();
 };
@@ -1726,9 +1726,9 @@ exports.evil = function (test) {
     .addError(6, 1, "Implied eval. Consider passing a function instead of a string.")
     .addError(7, 1, "Implied eval. Consider passing a function instead of a string.")
     .addError(8, 24, "eval can be harmful.")
-    .test(src, { es3: true, browser: true });
+    .test(src, { esversion: 3, browser: true });
 
-  TestRun(test).test(src, { es3: true, evil: true, browser: true });
+  TestRun(test).test(src, { esversion: 3, evil: true, browser: true });
 
   test.done();
 };
@@ -1749,14 +1749,14 @@ exports.evil = function (test) {
 exports.immed = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/immed.js', 'utf8');
 
-  TestRun(test).test(src, {es3: true});
+  TestRun(test).test(src, {esversion: 3});
 
   TestRun(test)
     .addError(3, 3, "Wrap an immediate function invocation in parens " +
            "to assist the reader in understanding that the expression " +
            "is the result of a function, and not the function itself.")
     .addError(13, 9, "Wrapping non-IIFE function literals in parens is unnecessary.")
-    .test(src, { es3: true, immed: true });
+    .test(src, { esversion: 3, immed: true });
 
   // Regression for GH-900
   TestRun(test)
@@ -1767,7 +1767,7 @@ exports.immed = function (test) {
     .addError(1, 31, "Expected an assignment or function call and instead saw an expression.")
     .addError(1, 31, "Missing semicolon.")
     .addError(1, 32, "Unrecoverable syntax error. (100% scanned).")
-    .test("(function () { if (true) { }());", { es3: true, immed: true });
+    .test("(function () { if (true) { }());", { esversion: 3, immed: true });
 
   test.done();
 };
@@ -1777,18 +1777,18 @@ exports.plusplus = function (test) {
   var ops = [ '++', '--' ];
 
   for (var i = 0, op; op = ops[i]; i += 1) {
-    TestRun(test).test('var i = j' + op + ';', {es3: true});
-    TestRun(test).test('var i = ' + op + 'j;', {es3: true});
+    TestRun(test).test('var i = j' + op + ';', {esversion: 3});
+    TestRun(test).test('var i = ' + op + 'j;', {esversion: 3});
   }
 
   for (i = 0, op = null; op = ops[i]; i += 1) {
     TestRun(test)
       .addError(1, 10, "Unexpected use of '" + op + "'.")
-      .test('var i = j' + op + ';', { es3: true, plusplus: true });
+      .test('var i = j' + op + ';', { esversion: 3, plusplus: true });
 
     TestRun(test)
       .addError(1, 9, "Unexpected use of '" + op + "'.")
-      .test('var i = ' + op + 'j;', { es3: true, plusplus: true });
+      .test('var i = ' + op + 'j;', { esversion: 3, plusplus: true });
   }
 
   test.done();
@@ -1809,7 +1809,7 @@ exports.plusplus = function (test) {
 exports.newcap = function (test) {
   var src = fs.readFileSync(__dirname + '/fixtures/newcap.js', 'utf8');
 
-  TestRun(test).test(src, {es3: true}); // By default, everything is fine
+  TestRun(test).test(src, {esversion: 3}); // By default, everything is fine
 
   // When newcap is true, enforce the conventions
   TestRun(test)
@@ -1817,7 +1817,7 @@ exports.newcap = function (test) {
     .addError(5, 7, "Missing 'new' prefix when invoking a constructor.")
     .addError(10, 15, "A constructor name should start with an uppercase letter.")
     .addError(14, 13, "A constructor name should start with an uppercase letter.")
-    .test(src, { es3: true, newcap: true });
+    .test(src, { esversion: 3, newcap: true });
 
   test.done();
 };
@@ -1826,9 +1826,9 @@ exports.newcap = function (test) {
 exports.sub = function (test) {
   TestRun(test)
     .addError(1, 17, "['prop'] is better written in dot notation.")
-    .test("window.obj = obj['prop'];", {es3: true});
+    .test("window.obj = obj['prop'];", {esversion: 3});
 
-  TestRun(test).test("window.obj = obj['prop'];", { es3: true, sub: true });
+  TestRun(test).test("window.obj = obj['prop'];", { esversion: 3, sub: true });
 
   test.done();
 };
@@ -1843,46 +1843,46 @@ exports.strict = function (test) {
   var src2 = fs.readFileSync(__dirname + '/fixtures/strict_incorrect.js', 'utf8');
   var src3 = fs.readFileSync(__dirname + '/fixtures/strict_newcap.js', 'utf8');
 
-  TestRun(test).test(code, {es3: true});
-  TestRun(test).test(code1, {es3: true});
+  TestRun(test).test(code, {esversion: 3});
+  TestRun(test).test(code1, {esversion: 3});
 
   var run = TestRun(test)
     .addError(1, 20, 'Missing "use strict" statement.');
-  run.test(code, { es3: true, strict: true });
+  run.test(code, { esversion: 3, strict: true });
   run
     .addError(1, 26, 'Missing "use strict" statement.')
-    .test(code, { es3: true, strict: "global" });
+    .test(code, { esversion: 3, strict: "global" });
 
-  TestRun(test).test(code, { es3: true, strict: "implied" });
+  TestRun(test).test(code, { esversion: 3, strict: "implied" });
 
-  TestRun(test).test(code1, { es3: true, strict: true });
-  TestRun(test).test(code1, { es3: true, strict: "global" });
+  TestRun(test).test(code1, { esversion: 3, strict: true });
+  TestRun(test).test(code1, { esversion: 3, strict: "global" });
   TestRun(test)
     .addError(1, 20, 'Unnecessary directive "use strict".')
-    .test(code1, { es3: true, strict: "implied" });
+    .test(code1, { esversion: 3, strict: "implied" });
 
   // Test for strict mode violations
   run = TestRun(test)
     .addError(4, 36, "If a strict mode function is executed using function invocation, its 'this' value will be undefined.")
     .addError(7, 52, 'Strict violation.')
     .addError(8, 52, 'Strict violation.');
-  run.test(src, { es3: true, strict: true });
-  run.test(src, { es3: true, strict: "global" });
+  run.test(src, { esversion: 3, strict: true });
+  run.test(src, { esversion: 3, strict: "global" });
 
   run = TestRun(test)
     .addError(4, 5, 'Expected an assignment or function call and instead saw an expression.')
     .addError(9, 17, 'Missing semicolon.')
     .addError(28, 9, 'Expected an assignment or function call and instead saw an expression.')
     .addError(53, 9, 'Expected an assignment or function call and instead saw an expression.');
-  run.test(src2, { es3: true, strict: false });
+  run.test(src2, { esversion: 3, strict: false });
 
   TestRun(test)
-    .test(src3, {es3 : true});
+    .test(src3, {esversion: 3});
 
-  TestRun(test).test(code2, { es3: true, strict: true });
+  TestRun(test).test(code2, { esversion: 3, strict: true });
   TestRun(test)
     .addError(1, 33, 'Missing "use strict" statement.')
-    .test(code2, { es3: true, strict: "global" });
+    .test(code2, { esversion: 3, strict: "global" });
 
   TestRun(test).test(code3, { strict: "global"});
   run = TestRun(test)
@@ -2011,17 +2011,17 @@ exports.globalstrict = function (test) {
 
   TestRun(test)
     .addError(1, 1, 'Use the function form of "use strict".')
-    .test(code, { es3: true, strict: true });
+    .test(code, { esversion: 3, strict: true });
 
-  TestRun(test).test(code, { es3: true, globalstrict: true });
+  TestRun(test).test(code, { esversion: 3, globalstrict: true });
 
   // Check that globalstrict also enabled strict
   TestRun(test)
     .addError(1, 26, 'Missing "use strict" statement.')
-    .test(code[1], { es3: true, globalstrict: true });
+    .test(code[1], { esversion: 3, globalstrict: true });
 
   // Don't enforce "use strict"; if strict has been explicitly set to false
-  TestRun(test).test(code[1], { es3: true, globalstrict: true, strict: false });
+  TestRun(test).test(code[1], { esversion: 3, globalstrict: true, strict: false });
 
   TestRun(test, "co-occurence with 'strict: global' (via configuration)")
     .addError(0, 0, "Incompatible values for the 'strict' and 'globalstrict' linting options. (0% scanned).")
@@ -2064,7 +2064,7 @@ exports.globalstrict = function (test) {
     ], { globalstrict: false });
 
   TestRun(test, "co-occurence with internally-set 'strict: gobal' (module code)")
-    .test(code, { strict: true, globalstrict: false, esnext: true, module: true });
+    .test(code, { strict: true, globalstrict: false, esversion: 6, module: true });
 
   TestRun(test, "co-occurence with internally-set 'strict: gobal' (Node.js code)")
     .test(code, { strict: true, globalstrict: false, node: true });
@@ -2122,7 +2122,7 @@ exports.laxbreak = function (test) {
     .addError(2, 5, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(3, 3, "Comma warnings can be turned off with 'laxcomma'.")
     .addError(12, 10, "Misleading line break before ','; readers may interpret this as an expression boundary.")
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   var ops = [ '||', '&&', '*', '/', '%', '+', '-', '>=',
         '==', '===', '!=', '!==', '>', '<', '<=', 'instanceof' ];
@@ -2131,17 +2131,17 @@ exports.laxbreak = function (test) {
     code = ['var a = b ', op + ' c;'];
     TestRun(test)
       .addError(2, 1, "Misleading line break before '" + op + "'; readers may interpret this as an expression boundary.")
-      .test(code, { es3: true });
+      .test(code, { esversion: 3 });
 
-    TestRun(test).test(code, { es3: true, laxbreak: true });
+    TestRun(test).test(code, { esversion: 3, laxbreak: true });
   }
 
   code = [ 'var a = b ', '? c : d;' ];
   TestRun(test)
     .addError(2, 1, "Misleading line break before '?'; readers may interpret this as an expression boundary.")
-    .test(code, { es3: true });
+    .test(code, { esversion: 3 });
 
-  TestRun(test).test(code, { es3: true, laxbreak: true });
+  TestRun(test).test(code, { esversion: 3, laxbreak: true });
 
   test.done();
 };
@@ -2153,22 +2153,22 @@ exports.validthis = function (test) {
     .addError(8, 9, "If a strict mode function is executed using function invocation, its 'this' value will be undefined.")
     .addError(9, 19, "If a strict mode function is executed using function invocation, its 'this' value will be undefined.")
     .addError(11, 19, "If a strict mode function is executed using function invocation, its 'this' value will be undefined.")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   src = fs.readFileSync(__dirname + '/fixtures/strict_this2.js', 'utf8');
-  TestRun(test).test(src, {es3: true});
+  TestRun(test).test(src, {esversion: 3});
 
   // Test for erroneus use of validthis
 
   var code = ['/*jshint validthis:true */', 'hello();'];
   TestRun(test)
     .addError(1, 1, "Option 'validthis' can't be used in a global scope.")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   code = ['function x() {', '/*jshint validthis:heya */', 'hello();', '}'];
   TestRun(test)
     .addError(2, 1, "Bad option value.")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   test.done();
 };
@@ -2185,7 +2185,7 @@ exports.strings = function (test) {
     .addError(10, 1, "Unclosed string.")
     .addError(15, 1, "Unclosed string.")
     .addError(25, 16, "Octal literals are not allowed in strict mode.")
-    .test(src, { es3: true, multistr: true });
+    .test(src, { esversion: 3, multistr: true });
 
   TestRun(test)
     .addError(3, 21, "Bad escaping of EOL. Use option multistr if needed.")
@@ -2196,7 +2196,7 @@ exports.strings = function (test) {
     .addError(15, 1, "Unclosed string.")
     .addError(25, 16, "Octal literals are not allowed in strict mode.")
     .addError(29, 36, "Bad escaping of EOL. Use option multistr if needed.")
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   test.done();
 };
@@ -2210,28 +2210,28 @@ exports.quotes = function (test) {
   var src2 = fs.readFileSync(__dirname + '/fixtures/quotes2.js', 'utf8');
 
   TestRun(test)
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   TestRun(test)
     .addError(3, 21, "Mixed double and single quotes.")
-    .test(src, { es3: true, quotmark: true });
+    .test(src, { esversion: 3, quotmark: true });
 
   TestRun(test)
     .addError(3, 21, "Strings must use singlequote.")
-    .test(src, { es3: true, quotmark: 'single' });
+    .test(src, { esversion: 3, quotmark: 'single' });
 
   TestRun(test)
     .addError(2, 21, "Strings must use doublequote.")
-    .test(src, { es3: true, quotmark: 'double' });
+    .test(src, { esversion: 3, quotmark: 'double' });
 
   // test multiple runs (must have the same result)
   TestRun(test)
     .addError(3, 21, "Mixed double and single quotes.")
-    .test(src, { es3: true, quotmark: true });
+    .test(src, { esversion: 3, quotmark: true });
 
   TestRun(test)
     .addError(3, 21, "Mixed double and single quotes.")
-    .test(src2, { es3: true, quotmark: true });
+    .test(src2, { esversion: 3, quotmark: true });
 
   test.done();
 };
@@ -2259,16 +2259,16 @@ exports.quotesAndTemplateLiterals = function (test) {
 
   // With esnext
   TestRun(test)
-    .test(src, {esnext: true});
+    .test(src, {esversion: 6});
 
   // With esnext and single quotemark
   TestRun(test)
-    .test(src, {esnext: true, quotmark: 'single'});
+    .test(src, {esversion: 6, quotmark: 'single'});
 
   // With esnext and double quotemark
   TestRun(test)
     .addError(1, 21, "Strings must use doublequote.")
-    .test(src, {esnext: true, quotmark: 'double'});
+    .test(src, {esversion: 6, quotmark: 'double'});
 
   test.done();
 };
@@ -2288,12 +2288,12 @@ exports.scope.basic = function (test) {
     .addError(42, 5, "'bb' is not defined.")
     .addError(53, 5, "'xx' used out of scope.")
     .addError(54, 5, "'yy' used out of scope.")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   TestRun(test, 2)
     .addError(37, 9, "'cc' is not defined.")
     .addError(42, 5, "'bb' is not defined.")
-    .test(src, { es3: true, funcscope: true });
+    .test(src, { esversion: 3, funcscope: true });
 
   test.done();
 };
@@ -2337,7 +2337,7 @@ exports.esnext = function (test) {
 
   TestRun(test)
     .addError(21, 7, "const 'immutable4' is initialized to 'undefined'.")
-    .test(src, { esnext: true });
+    .test(src, { esversion: 6 });
 
   TestRun(test)
     .addError(21, 7, "const 'immutable4' is initialized to 'undefined'.")
@@ -2346,7 +2346,7 @@ exports.esnext = function (test) {
   TestRun(test)
     .addError(3, 5, "'myConst' has already been declared.")
     .addError(4, 1, "Attempting to override 'foo' which is a constant.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   TestRun(test)
     .addError(3, 5, "'myConst' has already been declared.")
@@ -2388,7 +2388,7 @@ exports.maxlen = function (test) {
     .addError(5, 40, "Line is too long.")
     .addError(6, 46, "Line is too long.")
     // line 7 and more are exceptions and won't trigger the error
-    .test(src, { es3: true, maxlen: 23 });
+    .test(src, { esversion: 3, maxlen: 23 });
 
   test.done();
 };
@@ -2407,7 +2407,7 @@ exports.laxcomma = function (test) {
     .addError(6, 10, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(10, 3, "Misleading line break before '&&'; readers may interpret this as an expression boundary.")
     .addError(15, 9, "Misleading line break before '?'; readers may interpret this as an expression boundary.")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   // Allows bad line breaking, but not on commas.
   TestRun(test)
@@ -2415,16 +2415,16 @@ exports.laxcomma = function (test) {
     .addError(2, 3, "Comma warnings can be turned off with 'laxcomma'.")
     .addError(2, 9, "Misleading line break before ','; readers may interpret this as an expression boundary.")
     .addError(6, 10, "Misleading line break before ','; readers may interpret this as an expression boundary.")
-    .test(src, {es3: true, laxbreak: true });
+    .test(src, {esversion: 3, laxbreak: true });
 
   // Allows comma-first style but warns on bad line breaking
   TestRun(test)
     .addError(10, 3, "Misleading line break before '&&'; readers may interpret this as an expression boundary.")
     .addError(15, 9, "Misleading line break before '?'; readers may interpret this as an expression boundary.")
-    .test(src, {es3: true, laxcomma: true });
+    .test(src, {esversion: 3, laxcomma: true });
 
   // No errors if both laxbreak and laxcomma are turned on
-  TestRun(test).test(src, {es3: true, laxbreak: true, laxcomma: true });
+  TestRun(test).test(src, {esversion: 3, laxbreak: true, laxcomma: true });
 
   test.done();
 };
@@ -2438,7 +2438,7 @@ exports.unnecessarysemicolon = function (test) {
 
   TestRun(test)
     .addError(2, 11, "Unnecessary semicolon.")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   test.done();
 };
@@ -2455,7 +2455,7 @@ exports.blacklist = function (test) {
   ];
 
   // make sure everything is ok
-  TestRun(test).test(src, { es3: true, undef: true, browser: true });
+  TestRun(test).test(src, { esversion: 3, undef: true, browser: true });
 
   // disallow Node in a predef Object
   TestRun(test)
@@ -2479,7 +2479,7 @@ exports.blacklist = function (test) {
     .addError(3, 9, "'event' is not defined.")
     .addError(4, 9, "'foo' is not defined.")
     .addError(5, 9, "'btoa' is not defined.")
-    .test(code, { es3: true, undef: true });
+    .test(code, { esversion: 3, undef: true });
 
   test.done();
 };
@@ -2492,13 +2492,13 @@ exports.maxstatements = function (test) {
 
   TestRun(test)
     .addError(1, 33, "This function has too many statements. (8)")
-    .test(src, { es3: true, maxstatements: 7 });
+    .test(src, { esversion: 3, maxstatements: 7 });
 
   TestRun(test)
-    .test(src, { es3: true, maxstatements: 8 });
+    .test(src, { esversion: 3, maxstatements: 8 });
 
   TestRun(test)
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   test.done();
 };
@@ -2513,17 +2513,17 @@ exports.maxdepth = function (test) {
   TestRun(test)
     .addError(5, 27, "Blocks are nested too deeply. (2)")
     .addError(14, 26, "Blocks are nested too deeply. (2)")
-    .test(src, { es3: true, maxdepth: 1 });
+    .test(src, { esversion: 3, maxdepth: 1 });
 
   TestRun(test)
     .addError(9, 28, "Blocks are nested too deeply. (3)")
-    .test(src, { es3: true, maxdepth: 2 });
+    .test(src, { esversion: 3, maxdepth: 2 });
 
   TestRun(test)
-    .test(src, { es3: true, maxdepth: 3 });
+    .test(src, { esversion: 3, maxdepth: 3 });
 
   TestRun(test)
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   test.done();
 };
@@ -2539,10 +2539,10 @@ exports.maxparams = function (test) {
     .addError(4, 33, "This function has too many parameters. (3)")
     .addError(10, 10, "This function has too many parameters. (3)")
     .addError(16, 11, "This function has too many parameters. (3)")
-    .test(src, { esnext: true, maxparams: 2 });
+    .test(src, { esversion: 6, maxparams: 2 });
 
   TestRun(test)
-    .test(src, { esnext: true, maxparams: 3 });
+    .test(src, { esversion: 6, maxparams: 3 });
 
   TestRun(test)
     .addError(4, 33, "This function has too many parameters. (3)")
@@ -2552,10 +2552,10 @@ exports.maxparams = function (test) {
     .addError(11, 10, "This function has too many parameters. (1)")
     .addError(13, 11, "This function has too many parameters. (2)")
     .addError(16, 11, "This function has too many parameters. (3)")
-    .test(src, {esnext: true, maxparams: 0 });
+    .test(src, {esversion: 6, maxparams: 0 });
 
   TestRun(test)
-    .test(src, { esnext: true });
+    .test(src, { esversion: 6 });
 
   var functions = JSHINT.data().functions;
   test.equal(functions.length, 9);
@@ -2586,13 +2586,13 @@ exports.maxcomplexity = function (test) {
     .addError(47, 44, "This function's cyclomatic complexity is too high. (8)")
     .addError(76, 66, "This function's cyclomatic complexity is too high. (2)")
     .addError(80, 60, "This function's cyclomatic complexity is too high. (2)")
-    .test(src, { es3: true, maxcomplexity: 1 });
+    .test(src, { esversion: 3, maxcomplexity: 1 });
 
   TestRun(test)
-    .test(src, { es3: true, maxcomplexity: 8 });
+    .test(src, { esversion: 3, maxcomplexity: 8 });
 
   TestRun(test)
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   test.done();
 };
@@ -2638,11 +2638,11 @@ exports.ignored = function (test) {
   TestRun(test)
     .addError(4, 12, "A trailing decimal point can be confused with a dot: '12.'.")
     .addError(12, 11, "Missing semicolon.")
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   TestRun(test)
     .addError(12, 11, "Missing semicolon.")
-    .test(src, { es3: true, "-W047": true });
+    .test(src, { esversion: 3, "-W047": true });
 
   test.done();
 };
@@ -2655,7 +2655,7 @@ exports.unignored = function (test) {
 
   TestRun(test)
     .addError(5, 12, "A leading decimal point can be confused with a dot: '.12'.")
-    .test(src, { es3: true });
+    .test(src, { esversion: 3 });
 
   test.done();
 };
@@ -2729,13 +2729,13 @@ exports.nocomma = function (test) {
     .test("return function(a, b) {};", { nocomma: true });
 
   TestRun(test, "avoid nocomma false positives in arrow function expressions")
-    .test("return (a, b) => a;", { esnext: true, nocomma: true });
+    .test("return (a, b) => a;", { esversion: 6, nocomma: true });
 
   TestRun(test, "avoid nocomma false positives in destructuring arrays")
-    .test("var [a, b] = [1, 2];", { esnext: true, nocomma: true });
+    .test("var [a, b] = [1, 2];", { esversion: 6, nocomma: true });
 
   TestRun(test, "avoid nocomma false positives in destructuring objects")
-    .test("var {a, b} = {a:1, b:2};", { esnext: true, nocomma: true });
+    .test("var {a, b} = {a:1, b:2};", { esversion: 6, nocomma: true });
 
   test.done();
 };
@@ -2798,7 +2798,7 @@ exports.esnextPredefs = function (test) {
 
   TestRun(test)
     .addError(3, 16, "Do not use Symbol as a constructor.")
-    .test(code, { esnext: true, undef: true });
+    .test(code, { esversion: 6, undef: true });
 
   test.done();
 };
@@ -3047,7 +3047,7 @@ singleGroups.generatorExpression = function (test) {
 
   TestRun(test)
     .addError(19, 9, "Unnecessary grouping operator.")
-    .test(code, { singleGroups: true, asi: true, esnext: true });
+    .test(code, { singleGroups: true, asi: true, esversion: 6 });
 
   test.done();
 };
@@ -3185,7 +3185,7 @@ singleGroups.arrowFunctions = function (test) {
     .addError(16, 15, "Unnecessary grouping operator.")
     .addError(17, 9, "Unnecessary grouping operator.")
     .addError(18, 9, "Unnecessary grouping operator.")
-    .test(code, { singleGroups: true, esnext: true });
+    .test(code, { singleGroups: true, esversion: 6 });
 
   test.done();
 };
@@ -3353,7 +3353,7 @@ exports.elision = function (test) {
     .addError(2, 12, "Empty array elements require elision=true.")
     .addError(4, 10, "Empty array elements require elision=true.")
     .addError(5, 10, "Empty array elements require elision=true.")
-    .test(code, { elision: false, es3: false });
+    .test(code, { elision: false, esversion: 5 });
 
   TestRun(test, "elision=false ES3")
     .addError(1, 12, "Extra comma. (it breaks older versions of IE)")
@@ -3364,14 +3364,14 @@ exports.elision = function (test) {
     .addError(4, 10, "Extra comma. (it breaks older versions of IE)")
     .addError(5, 10, "Extra comma. (it breaks older versions of IE)")
     .addError(5, 11, "Extra comma. (it breaks older versions of IE)")
-    .test(code, { elision: false, es3: true });
+    .test(code, { elision: false, esversion: 3 });
 
   TestRun(test, "elision=true ES5")
-    .test(code, { elision: true, es3: false });
+    .test(code, { elision: true, esversion: 5 });
 
   TestRun(test, "elision=true ES3")
     .addError(3, 13, "Extra comma. (it breaks older versions of IE)")
-    .test(code, { elision: true, es3: true });
+    .test(code, { elision: true, esversion: 3 });
 
   test.done();
 };
@@ -3431,10 +3431,10 @@ exports.futureHostile = function (test) {
     .addError(18, 5, "'Uint8ClampedArray' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
     .addError(19, 5, "'Float32Array' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
     .addError(20, 5, "'Float64Array' is defined in a future version of JavaScript. Use a different variable name to avoid migration issues.")
-    .test(code, { es3: true, es5: false, futurehostile: false });
+    .test(code, { esversion: 3, futurehostile: false });
 
   TestRun(test, "ES3 with option")
-    .test(code, { es3: true, es5: false });
+    .test(code, { esversion: 3 });
 
   TestRun(test, "ES5 without option")
     .addError(1, 5, "Redefinition of 'JSON'.")
@@ -3489,7 +3489,7 @@ exports.futureHostile = function (test) {
     .addError(18, 5, "Redefinition of 'Uint8ClampedArray'.")
     .addError(19, 5, "Redefinition of 'Float32Array'.")
     .addError(20, 5, "Redefinition of 'Float64Array'.")
-    .test(code, { esnext: true, futurehostile: false });
+    .test(code, { esversion: 6, futurehostile: false });
 
   TestRun(test, "ESNext with option")
     .addError(1, 5, "Redefinition of 'JSON'.")
@@ -3512,11 +3512,11 @@ exports.futureHostile = function (test) {
     .addError(18, 5, "Redefinition of 'Uint8ClampedArray'.")
     .addError(19, 5, "Redefinition of 'Float32Array'.")
     .addError(20, 5, "Redefinition of 'Float64Array'.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   TestRun(test, "ESNext with opt-out")
     .test(code, {
-      esnext: true,
+      esversion: 6,
       futurehostile: false,
       predef: [
         "-JSON",
@@ -3586,11 +3586,11 @@ exports.futureHostile = function (test) {
     .addError(18, 5, "Redefinition of 'Uint8ClampedArray'.")
     .addError(19, 5, "Redefinition of 'Float32Array'.")
     .addError(20, 5, "Redefinition of 'Float64Array'.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   TestRun(test, "ESNext with opt-out")
     .test(code, {
-      esnext: true,
+      esversion: 6,
       futurehostile: false,
       predef: [
         "-JSON",
@@ -3660,11 +3660,11 @@ exports.futureHostile = function (test) {
     .addError(18, 7, "Redefinition of 'Uint8ClampedArray'.")
     .addError(19, 7, "Redefinition of 'Float32Array'.")
     .addError(20, 7, "Redefinition of 'Float64Array'.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   TestRun(test, "ESNext with opt-out")
     .test(code, {
-      esnext: true,
+      esversion: 6,
       futurehostile: false,
       predef: [
         "-JSON",
@@ -3736,7 +3736,7 @@ exports.module.behavior = function(test) {
   TestRun(test)
     .addError(1, 5, "Expected an identifier and instead saw 'package' (a reserved word).")
     .addError(2, 23, "If a strict mode function is executed using function invocation, its 'this' value will be undefined.")
-    .test(code, { module: true, esnext: true });
+    .test(code, { module: true, esversion: 6 });
 
   code = [
     "/* jshint module: true */",
@@ -3750,7 +3750,7 @@ exports.module.behavior = function(test) {
     .addError(3, 23, "If a strict mode function is executed using function invocation, its 'this' value will be undefined.")
     .test(code);
 
-  code[0] = "/* jshint module: true, esnext: true */";
+  code[0] = "/* jshint module: true, esversion: 6 */";
 
   TestRun(test)
     .addError(2, 5, "Expected an identifier and instead saw 'package' (a reserved word).")
@@ -3767,14 +3767,14 @@ exports.module.declarationRestrictions = function( test ) {
       "(function() {",
       "  /* jshint module: true */",
       "})();"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test)
     .addError(2, 1, "The 'module' option cannot be set after any executable code.")
     .test([
       "void 0;",
       "/* jshint module: true */"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test)
     .addError(3, 1, "The 'module' option cannot be set after any executable code.")
@@ -3782,36 +3782,36 @@ exports.module.declarationRestrictions = function( test ) {
       "void 0;",
       "// hide",
       "/* jshint module: true */"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test, "First line (following statement)")
     .addError(1, 20, "The 'module' option cannot be set after any executable code.")
     .test([
       "(function() {})(); /* jshint module: true */"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test, "First line (within statement)")
     .addError(1, 15, "The 'module' option cannot be set after any executable code.")
     .test([
       "(function() { /* jshint module: true */",
       "})();"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test, "First line (before statement)")
     .test([
       "/* jshint module: true */ (function() {",
       "})();"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test, "First line (within expression)")
     .addError(1, 10, "The 'module' option cannot be set after any executable code.")
-    .test("Math.abs(/*jshint module: true */4);", { esnext: true });
+    .test("Math.abs(/*jshint module: true */4);", { esversion: 6 });
 
   TestRun(test, "Following single-line comment")
     .test([
       "// License boilerplate",
       "/* jshint module: true */"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test, "Following multi-line comment")
     .test([
@@ -3819,13 +3819,13 @@ exports.module.declarationRestrictions = function( test ) {
       " * License boilerplate",
       " */",
       "  /* jshint module: true */"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test, "Following shebang")
     .test([
       "#!/usr/bin/env node",
       "/* jshint module: true */"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   TestRun(test, "Not re-applied with every directive (gh-2560)")
     .test([
@@ -3833,7 +3833,7 @@ exports.module.declarationRestrictions = function( test ) {
       "function bar() {",
       "  /* jshint validthis:true */",
       "}"
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   test.done();
 };
@@ -3949,32 +3949,39 @@ exports.esversion = function(test) {
   ];
 
   TestRun(test, "array comprehensions - esversion: 6")
+    .addError("(option 2)", 0, "Option 'esnext' is deprecated. Use 'esversion: 6' instead.")
     .addError(2, 9, "'array comprehension' is only available in Mozilla JavaScript extensions " +
                  "(use moz option).")
-    .test(arrayComprehension, { esversion: 6 });
+    .test(arrayComprehension, { esversion: 6, esnext: true });
 
   TestRun(test, "array comprehensions - esnext: true")
+    .addError("(option 1)", 0, "Option 'esnext' is deprecated. Use 'esversion: 6' instead.")
     .test(arrayComprehension, { esnext: true });
 
-
   TestRun(test, "incompatibility with `es3`") // TODO: Remove in JSHint 3
-    .addError(0, 0, "Incompatible values for the 'esversion' and 'es3' linting options. (0% scanned).")
+    .addError("(option 2)", 0, "Option 'es3' is deprecated. Use 'esversion: 3' instead.")
+    .addError(2, 3, "'computed property names' is only available in ES6 (use 'esversion: 6').")
+    .addError(4, 10, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').")
     .test(es6code, { esversion: 6, es3: true });
 
   TestRun(test, "incompatibility with `es5`") // TODO: Remove in JSHint 3
-    .addError(0, 0, "Incompatible values for the 'esversion' and 'es5' linting options. (0% scanned).")
+    .addError("(option 2)", 0, "Option 'es5' is deprecated. Use 'esversion: 5' instead.")
+    .addError(2, 3, "'computed property names' is only available in ES6 (use 'esversion: 6').")
+    .addError(4, 10, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').")
     .test(es6code, { esversion: 6, es5: true });
 
   TestRun(test, "incompatibility with `esnext`") // TODO: Remove in JSHint 3
-    .addError(0, 0, "Incompatible values for the 'esversion' and 'esnext' linting options. (0% scanned).")
+    .addError("(option 2)", 0, "Option 'esnext' is deprecated. Use 'esversion: 6' instead.")
+    .addError(2, 3, "'computed property names' is only available in ES6 (use 'esversion: 6').")
+    .addError(4, 10, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').")
     .test(es6code, { esversion: 3, esnext: true });
 
-  TestRun(test, "imcompatible option specified in-line")
-    .addError(2, 1, "Incompatible values for the 'esversion' and 'es3' linting options. (66% scanned).")
+  TestRun(test, "incompatible option specified in-line")
+    .addError("(option 1)", 0, "Option 'es3' is deprecated. Use 'esversion: 3' instead.")
     .test(["", "// jshint esversion: 3", ""], { es3: true });
 
   TestRun(test, "incompatible option specified in-line")
-    .addError(2, 1, "Incompatible values for the 'esversion' and 'es3' linting options. (66% scanned).")
+    .addError(0, 0, "Option 'es3' is deprecated. Use 'esversion: 3' instead.")
     .test(["", "// jshint es3: true", ""], { esversion: 3 });
 
   TestRun(test, "compatible option specified in-line")
@@ -3993,7 +4000,9 @@ exports.esversion = function(test) {
   ].concat(es6code);
 
   TestRun(test, "incompatible options specified in-line") // TODO: Remove in JSHint 3
-    .addError(1, 1, "Incompatible values for the 'esversion' and 'esnext' linting options. (20% scanned).")
+    .addError(0, 0, "Option 'esnext' is deprecated. Use 'esversion: 6' instead.")
+    .addError(3, 3, "'computed property names' is only available in ES6 (use 'esversion: 6').")
+    .addError(5, 10, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').")
     .test(code2);
 
   var code3 = [
@@ -4071,7 +4080,7 @@ exports.trailingcomma = function (test) {
     .addError(5, 13, "Extra comma. (it breaks older versions of IE)")
     .addError(8, 14, "Extra comma. (it breaks older versions of IE)")
     .addError(10, 20, "Extra comma. (it breaks older versions of IE)")
-    .test(code, { trailingcomma: true, es3: true });
+    .test(code, { trailingcomma: true, esversion: 3 });
 
   test.done();
 };

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -16,7 +16,7 @@ exports.unsafe = function (test) {
 
   TestRun(test)
     .addError(1, 5, "This character may get silently deleted by one or more browsers.")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   test.done();
 };
@@ -75,13 +75,13 @@ exports.other = function (test) {
     .addError(1, 1, "Unexpected '\\'.")
     .addError(2, 1, "Unexpected early end of program.")
     .addError(2, 1, "Unrecoverable syntax error. (100% scanned).")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   // GH-818
   TestRun(test)
     .addError(1, 15, "Expected an identifier and instead saw ')'.")
     .addError(1, 15, "Unrecoverable syntax error. (100% scanned).")
-    .test("if (product < ) {}", {es3: true});
+    .test("if (product < ) {}", {esversion: 3});
 
   // GH-2506
   TestRun(test)
@@ -111,9 +111,9 @@ exports.confusingOps = function (test) {
     .addError(2, 13, "Confusing plusses.")
     .addError(3, 9, "Confusing minuses.")
     .addError(4, 9, "Confusing plusses.");
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   test.done();
@@ -154,9 +154,9 @@ exports.plusplus = function (test) {
     .addError(3, 12, "Bad assignment.")
     .addError(4, 12, "Unexpected use of '--'.")
     .addError(4, 12, "Bad assignment.");
-  run.test(code, { plusplus: true, es3: true });
+  run.test(code, { plusplus: true, esversion: 3 });
   run.test(code, { plusplus: true }); // es5
-  run.test(code, { plusplus: true, esnext: true });
+  run.test(code, { plusplus: true, esversion: 6 });
   run.test(code, { plusplus: true, moz: true });
 
   run = TestRun(test)
@@ -164,9 +164,9 @@ exports.plusplus = function (test) {
     .addError(2, 9, "Bad assignment.")
     .addError(3, 12, "Bad assignment.")
     .addError(4, 12, "Bad assignment.");
-  run.test(code, { plusplus: false, es3: true });
+  run.test(code, { plusplus: false, esversion: 3 });
   run.test(code, { plusplus: false }); // es5
-  run.test(code, { plusplus: false, esnext: true });
+  run.test(code, { plusplus: false, esversion: 6 });
   run.test(code, { plusplus: false, moz: true });
 
   test.done();
@@ -197,9 +197,9 @@ exports.assignment = function (test) {
     .addError(5, 16, "Bad assignment.")
     .addError(14, 5, "Bad assignment.");
 
-  run.test(code, { plusplus: true, es3: true });
+  run.test(code, { plusplus: true, esversion: 3 });
   run.test(code, { plusplus: true }); // es5
-  run.test(code, { plusplus: true, esnext: true });
+  run.test(code, { plusplus: true, esversion: 6 });
   run.test(code, { plusplus: true, moz: true });
 
   test.done();
@@ -230,9 +230,9 @@ exports.relations = function (test) {
     .addError(8, 10, "Confusing use of '!'.")
     .addError(9, 10, "Confusing use of '!'.")
     .addError(10, 10, "Confusing use of '!'.");
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   test.done();
@@ -272,9 +272,9 @@ exports.options = function (test) {
     .addError(15, 1, "Read only.")
     .addError(16, 1, "Bad option: 'relaxing'.")
     .addError(17, 1, "Bad option: 'toString'.");
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   TestRun(test).test(fs.readFileSync(__dirname + "/fixtures/gh988.js", "utf8"));
@@ -403,9 +403,9 @@ exports.shebang = function (test) {
     .addError(3, 3, "Expected an assignment or function call and instead saw an expression.")
     .addError(3, 3, "Missing semicolon.")
     .addError(3, 7, "Missing semicolon.");
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   test.done();
@@ -464,7 +464,7 @@ exports.numbers = function (test) {
     .addError(17, 9, "Unexpected '1'.")
     .addError(17, 7, "Unexpected early end of program.")
     .addError(17, 9, "Unrecoverable syntax error. (100% scanned).")
-    .test(code, {es3: true});
+    .test(code, {esversion: 3});
 
   // Octals are prohibited in strict mode.
   TestRun(test)
@@ -497,11 +497,11 @@ exports.numbers = function (test) {
       "var d = 0B101;",
       "var e = 0o12345678;",
       "var f = 0b1012;",
-    ], {esnext: true});
+    ], {esversion: 6});
 
   TestRun(test)
     .test([
-      "// jshint esnext: true",
+      "// jshint esversion: 6",
       "var a = 0b0 + 0o0;"
     ]);
 
@@ -519,9 +519,9 @@ exports.comments = function (test) {
   var run = TestRun(test)
     .addError(3, 1, "Unbegun comment.")
     .addError(4, 1, "Unclosed comment.");
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   var src = "/* this is a comment /* with nested slash-start */";
@@ -592,9 +592,9 @@ exports.regexp = function (test) {
     .addError(29, 9, "Unclosed regular expression.")
     .addError(29, 9, "Unrecoverable syntax error. (100% scanned).");
 
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   TestRun(test).test("var a = `${/./}${/./}`;", { esversion: 6 });
@@ -606,46 +606,46 @@ exports.regexp = function (test) {
   // "."
   TestRun(test)
     .addError(1, 12, "A trailing decimal point can be confused with a dot: '10.'.")
-    .test("var y = 10. / 1;", {es3: true});
+    .test("var y = 10. / 1;", {esversion: 3});
   TestRun(test)
     .addError(1, 12, "A trailing decimal point can be confused with a dot: '10.'.")
     .test("var y = 10. / 1;", {}); // es5
   TestRun(test)
     .addError(1, 12, "A trailing decimal point can be confused with a dot: '10.'.")
-    .test("var y = 10. / 1;", {esnext: true});
+    .test("var y = 10. / 1;", {esversion: 6});
   TestRun(test)
     .addError(1, 12, "A trailing decimal point can be confused with a dot: '10.'.")
     .test("var y = 10. / 1;", {moz: true});
 
   // ")"
-  TestRun(test).test("var y = Math.sqrt(16) / 180;", {es3: true});
+  TestRun(test).test("var y = Math.sqrt(16) / 180;", {esversion: 3});
   TestRun(test).test("var y = Math.sqrt(16) / 180;", {}); // es5
-  TestRun(test).test("var y = Math.sqrt(16) / 180;", {esnext: true});
+  TestRun(test).test("var y = Math.sqrt(16) / 180;", {esversion: 6});
   TestRun(test).test("var y = Math.sqrt(16) / 180;", {moz: true});
 
   // "~"
-  TestRun(test).test("var y = ~16 / 180;", {es3: true});
+  TestRun(test).test("var y = ~16 / 180;", {esversion: 3});
   TestRun(test).test("var y = ~16 / 180;", {}); // es5
-  TestRun(test).test("var y = ~16 / 180;", {esnext: true});
+  TestRun(test).test("var y = ~16 / 180;", {esversion: 6});
   TestRun(test).test("var y = ~16 / 180;", {moz: true});
 
 
   // "]" (GH-803)
-  TestRun(test).test("var x = [1]; var y = x[0] / 180;", {es3: true});
+  TestRun(test).test("var x = [1]; var y = x[0] / 180;", {esversion: 3});
   TestRun(test).test("var x = [1]; var y = x[0] / 180;", {}); // es5
-  TestRun(test).test("var x = [1]; var y = x[0] / 180;", {esnext: true});
+  TestRun(test).test("var x = [1]; var y = x[0] / 180;", {esversion: 6});
   TestRun(test).test("var x = [1]; var y = x[0] / 180;", {moz: true});
 
   // "++" (GH-1787)
-  TestRun(test).test("var a = 1; var b = a++ / 10;", {es3: true});
+  TestRun(test).test("var a = 1; var b = a++ / 10;", {esversion: 3});
   TestRun(test).test("var a = 1; var b = a++ / 10;", {}); // es5
-  TestRun(test).test("var a = 1; var b = a++ / 10;", {esnext: true});
+  TestRun(test).test("var a = 1; var b = a++ / 10;", {esversion: 6});
   TestRun(test).test("var a = 1; var b = a++ / 10;", {moz: true});
 
   // "--" (GH-1787)
-  TestRun(test).test("var a = 1; var b = a-- / 10;", {es3: true});
+  TestRun(test).test("var a = 1; var b = a-- / 10;", {esversion: 3});
   TestRun(test).test("var a = 1; var b = a-- / 10;", {}); // es5
-  TestRun(test).test("var a = 1; var b = a-- / 10;", {esnext: true});
+  TestRun(test).test("var a = 1; var b = a-- / 10;", {esversion: 6});
   TestRun(test).test("var a = 1; var b = a-- / 10;", {moz: true});
 
   test.done();
@@ -653,30 +653,30 @@ exports.regexp = function (test) {
 
 exports.testRegexRegressions = function (test) {
   // GH-536
-  TestRun(test).test("str /= 5;", {es3: true}, { str: true });
+  TestRun(test).test("str /= 5;", {esversion: 3}, { str: true });
   TestRun(test).test("str /= 5;", {}, { str: true }); // es5
-  TestRun(test).test("str /= 5;", {esnext: true}, { str: true });
+  TestRun(test).test("str /= 5;", {esversion: 6}, { str: true });
   TestRun(test).test("str /= 5;", {moz: true}, { str: true });
 
-  TestRun(test).test("str = str.replace(/=/g, '');",  {es3: true}, { str: true });
+  TestRun(test).test("str = str.replace(/=/g, '');",  {esversion: 3}, { str: true });
   TestRun(test).test("str = str.replace(/=/g, '');", {}, { str: true }); // es5
-  TestRun(test).test("str = str.replace(/=/g, '');", {esnext: true}, { str: true });
+  TestRun(test).test("str = str.replace(/=/g, '');", {esversion: 6}, { str: true });
   TestRun(test).test("str = str.replace(/=/g, '');", {moz: true}, { str: true });
 
-  TestRun(test).test("str = str.replace(/=abc/g, '');", {es3: true}, { str: true });
+  TestRun(test).test("str = str.replace(/=abc/g, '');", {esversion: 3}, { str: true });
   TestRun(test).test("str = str.replace(/=abc/g, '');", {}, { str: true }); // es5
-  TestRun(test).test("str = str.replace(/=abc/g, '');", {esnext: true}, { str: true });
+  TestRun(test).test("str = str.replace(/=abc/g, '');", {esversion: 6}, { str: true });
   TestRun(test).test("str = str.replace(/=abc/g, '');", {moz: true}, { str: true });
 
   // GH-538
-  TestRun(test).test("var exp = /function(.*){/gi;", {es3: true});
+  TestRun(test).test("var exp = /function(.*){/gi;", {esversion: 3});
   TestRun(test).test("var exp = /function(.*){/gi;", {}); // es5
-  TestRun(test).test("var exp = /function(.*){/gi;", {esnext: true});
+  TestRun(test).test("var exp = /function(.*){/gi;", {esversion: 6});
   TestRun(test).test("var exp = /function(.*){/gi;", {moz: true});
 
-  TestRun(test).test("var exp = /\\[\\]/;", {es3: true});
+  TestRun(test).test("var exp = /\\[\\]/;", {esversion: 3});
   TestRun(test).test("var exp = /\\[\\]/;", {}); // es5
-  TestRun(test).test("var exp = /\\[\\]/;", {esnext: true});
+  TestRun(test).test("var exp = /\\[\\]/;", {esversion: 6});
   TestRun(test).test("var exp = /\\[\\]/;", {moz: true});
 
   test.done();
@@ -726,9 +726,9 @@ exports.strings = function (test) {
     .addError(1, 9, "This character may get silently deleted by one or more browsers.")
     .addError(7, 12, "Unclosed string.")
     .addError(7, 12, "Missing semicolon.");
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   test.done();
@@ -750,9 +750,9 @@ exports.badStrings = function (test) {
     .addError(4, 8, "Unexpected 'u0g00'.")
     .addError(5, 8, "Unexpected 'u00g0'.")
     .addError(6, 8, "Unexpected 'u000g'.");
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   test.done();
@@ -771,9 +771,9 @@ exports.ownProperty = function (test) {
     .addError(2, 20, "'hasOwnProperty' is a really bad name.")
     .addError(3, 23, "'hasOwnProperty' is a really bad name.")
     .addError(3, 4, "['hasOwnProperty'] is better written in dot notation.");
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
   run.test(code, {}); // es5
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   test.done();
@@ -804,9 +804,9 @@ exports.json.dflt = function (test) {
     .addError(4, 16, "Strings must use doublequote.")
     .addError(5, 11, "Avoid EOL escaping.")
     .addError(7, 13, "Avoid 0x-.");
-  run.test(code, {multistr: true, es3: true});
+  run.test(code, {multistr: true, esversion: 3});
   run.test(code, {multistr: true}); // es5
-  run.test(code, {multistr: true, esnext: true});
+  run.test(code, {multistr: true, esversion: 6});
   run.test(code, {multistr: true, moz: true});
 
   test.done();
@@ -828,9 +828,9 @@ exports.json.deep = function (test) {
 
   var run = TestRun(test);
 
-  run.test(code, {multistr: true, es3: true});
+  run.test(code, {multistr: true, esversion: 3});
   run.test(code, {multistr: true}); // es5
-  run.test(code, {multistr: true, esnext: true});
+  run.test(code, {multistr: true, esversion: 6});
   run.test(code, {multistr: true, moz: true});
 
   test.done();
@@ -844,9 +844,9 @@ exports.json.errors = function (test) {
   var run1 = TestRun(test)
     .addError(1, 18, "Unexpected comma.");
 
-  run1.test(objTrailingComma, {multistr: true, es3: true});
+  run1.test(objTrailingComma, {multistr: true, esversion: 3});
   run1.test(objTrailingComma, {multistr: true}); // es5
-  run1.test(objTrailingComma, {multistr: true, esnext: true});
+  run1.test(objTrailingComma, {multistr: true, esversion: 6});
   run1.test(objTrailingComma, {multistr: true, moz: true});
 
   var arrayTrailingComma = [
@@ -858,9 +858,9 @@ exports.json.errors = function (test) {
     .addError(1, 12, "Expected a JSON value.")
     .addError(1, 12, "Unexpected comma.");
 
-  run2.test(arrayTrailingComma, {multistr: true, es3: true});
+  run2.test(arrayTrailingComma, {multistr: true, esversion: 3});
   run2.test(arrayTrailingComma, {multistr: true}); // es5
-  run2.test(arrayTrailingComma, {multistr: true, esnext: true});
+  run2.test(arrayTrailingComma, {multistr: true, esversion: 6});
   run2.test(arrayTrailingComma, {multistr: true, moz: true});
 
   var objMissingComma = [
@@ -871,9 +871,9 @@ exports.json.errors = function (test) {
     .addError(1, 13, "Expected '}' and instead saw 'k2'.")
     .addError(1, 13, "Unrecoverable syntax error. (100% scanned).");
 
-  run3.test(objMissingComma, {multistr: true, es3: true});
+  run3.test(objMissingComma, {multistr: true, esversion: 3});
   run3.test(objMissingComma, {multistr: true}); // es5
-  run3.test(objMissingComma, {multistr: true, esnext: true});
+  run3.test(objMissingComma, {multistr: true, esversion: 6});
   run3.test(objMissingComma, {multistr: true, moz: true});
 
   var arrayMissingComma = [
@@ -884,9 +884,9 @@ exports.json.errors = function (test) {
     .addError(1, 8, "Expected ']' and instead saw 'v2'.")
     .addError(1, 8, "Unrecoverable syntax error. (100% scanned).");
 
-  run4.test(arrayMissingComma, {multistr: true, es3: true});
+  run4.test(arrayMissingComma, {multistr: true, esversion: 3});
   run4.test(arrayMissingComma, {multistr: true}); // es5
-  run4.test(arrayMissingComma, {multistr: true, esnext: true});
+  run4.test(arrayMissingComma, {multistr: true, esversion: 6});
   run4.test(arrayMissingComma, {multistr: true, moz: true});
 
   var objDoubleComma = [
@@ -900,9 +900,9 @@ exports.json.errors = function (test) {
     .addError(1, 19, "Expected '}' and instead saw ':'.")
     .addError(1, 19, "Unrecoverable syntax error. (100% scanned).");
 
-  run5.test(objDoubleComma, {multistr: true, es3: true});
+  run5.test(objDoubleComma, {multistr: true, esversion: 3});
   run5.test(objDoubleComma, {multistr: true}); // es5
-  run5.test(objDoubleComma, {multistr: true, esnext: true});
+  run5.test(objDoubleComma, {multistr: true, esversion: 6});
   run5.test(objDoubleComma, {multistr: true, moz: true});
 
   var arrayDoubleComma = [
@@ -913,9 +913,9 @@ exports.json.errors = function (test) {
     .addError(1, 8, "Illegal comma.")
     .addError(1, 8, "Expected a JSON value.");
 
-  run6.test(arrayDoubleComma, {multistr: true, es3: true});
+  run6.test(arrayDoubleComma, {multistr: true, esversion: 3});
   run6.test(arrayDoubleComma, {multistr: true}); // es5
-  run6.test(arrayDoubleComma, {multistr: true, esnext: true});
+  run6.test(arrayDoubleComma, {multistr: true, esversion: 6});
   run6.test(arrayDoubleComma, {multistr: true, moz: true});
 
   var objUnclosed = [
@@ -926,9 +926,9 @@ exports.json.errors = function (test) {
     .addError(1, 8, "Expected '}' and instead saw ''.")
     .addError(1, 8, "Unrecoverable syntax error. (100% scanned).");
 
-  run7.test(objUnclosed, {multistr: true, es3: true});
+  run7.test(objUnclosed, {multistr: true, esversion: 3});
   run7.test(objUnclosed, {multistr: true}); // es5
-  run7.test(objUnclosed, {multistr: true, esnext: true});
+  run7.test(objUnclosed, {multistr: true, esversion: 6});
   run7.test(objUnclosed, {multistr: true, moz: true});
 
   var arrayUnclosed = [
@@ -939,9 +939,9 @@ exports.json.errors = function (test) {
     .addError(1, 3, "Expected ']' and instead saw ''.")
     .addError(1, 3, "Unrecoverable syntax error. (100% scanned).");
 
-  run8.test(arrayUnclosed, {multistr: true, es3: true});
+  run8.test(arrayUnclosed, {multistr: true, esversion: 3});
   run8.test(arrayUnclosed, {multistr: true}); // es5
-  run8.test(arrayUnclosed, {multistr: true, esnext: true});
+  run8.test(arrayUnclosed, {multistr: true, esversion: 6});
   run8.test(arrayUnclosed, {multistr: true, moz: true});
 
   var objUnclosed2 = [
@@ -952,9 +952,9 @@ exports.json.errors = function (test) {
     .addError(1, 1, "Missing '}' to match '{' from line 1.")
     .addError(1, 1, "Unrecoverable syntax error. (100% scanned).");
 
-  run9.test(objUnclosed2, {multistr: true, es3: true});
+  run9.test(objUnclosed2, {multistr: true, esversion: 3});
   run9.test(objUnclosed2, {multistr: true}); // es5
-  run9.test(objUnclosed2, {multistr: true, esnext: true});
+  run9.test(objUnclosed2, {multistr: true, esversion: 6});
   run9.test(objUnclosed2, {multistr: true, moz: true});
 
   var arrayUnclosed2 = [
@@ -967,9 +967,9 @@ exports.json.errors = function (test) {
     .addError(1, 1, "Expected ']' and instead saw ''.")
     .addError(1, 1, "Unrecoverable syntax error. (100% scanned).");
 
-  run10.test(arrayUnclosed2, {multistr: true, es3: true});
+  run10.test(arrayUnclosed2, {multistr: true, esversion: 3});
   run10.test(arrayUnclosed2, {multistr: true}); // es5
-  run10.test(arrayUnclosed2, {multistr: true, esnext: true});
+  run10.test(arrayUnclosed2, {multistr: true, esversion: 6});
   run10.test(arrayUnclosed2, {multistr: true, moz: true});
 
   var objDupKeys = [
@@ -979,9 +979,9 @@ exports.json.errors = function (test) {
   var run11 = TestRun(test)
     .addError(1, 14, "Duplicate key 'k1'.");
 
-  run11.test(objDupKeys, {multistr: true, es3: true});
+  run11.test(objDupKeys, {multistr: true, esversion: 3});
   run11.test(objDupKeys, {multistr: true}); // es5
-  run11.test(objDupKeys, {multistr: true, esnext: true});
+  run11.test(objDupKeys, {multistr: true, esversion: 6});
   run11.test(objDupKeys, {multistr: true, moz: true});
 
   var objBadKey = [
@@ -991,9 +991,9 @@ exports.json.errors = function (test) {
   var run12 = TestRun(test)
     .addError(1, 3, "Expected a string and instead saw k1.");
 
-  run12.test(objBadKey, {multistr: true, es3: true});
+  run12.test(objBadKey, {multistr: true, esversion: 3});
   run12.test(objBadKey, {multistr: true}); // es5
-  run12.test(objBadKey, {multistr: true, esnext: true});
+  run12.test(objBadKey, {multistr: true, esversion: 6});
   run12.test(objBadKey, {multistr: true, moz: true});
 
   var objBadValue = [
@@ -1005,9 +1005,9 @@ exports.json.errors = function (test) {
     .addError(1, 21, "Expected '}' and instead saw '/$^/'.")
     .addError(1, 21, "Unrecoverable syntax error. (100% scanned).");
 
-  run13.test(objBadValue, {multistr: true, es3: true});
+  run13.test(objBadValue, {multistr: true, esversion: 3});
   run13.test(objBadValue, {multistr: true}); // es5
-  run13.test(objBadValue, {multistr: true, esnext: true});
+  run13.test(objBadValue, {multistr: true, esversion: 6});
   run13.test(objBadValue, {multistr: true, moz: true});
 
   test.done();
@@ -1042,7 +1042,7 @@ exports.comma = function (test) {
     .addError(43, 10, "Expected an assignment or function call and instead saw an expression.")
     .addError(43, 11, "Missing semicolon.")
     .addError(44, 1, "Unexpected '}'.")
-    .test(src, {es3: true});
+    .test(src, {esversion: 3});
 
   // Regression test (GH-56)
   TestRun(test)
@@ -1052,7 +1052,7 @@ exports.comma = function (test) {
   // Regression test (GH-363)
   TestRun(test)
     .addError(1, 11, "Extra comma. (it breaks older versions of IE)")
-    .test("var f = [1,];", {es3: true});
+    .test("var f = [1,];", {esversion: 3});
 
   TestRun(test)
     .addError(3, 6, "Expected an assignment or function call and instead saw an expression.")
@@ -1180,16 +1180,16 @@ exports.withStatement = function (test) {
   run = TestRun(test)
     .addError(5, 1, "Don't use 'with'.")
     .addError(13, 5, "'with' is not allowed in strict mode.");
-  run.test(src, {es3: true});
+  run.test(src, {esversion: 3});
   run.test(src); // es5
-  run.test(src, {esnext: true});
+  run.test(src, {esversion: 6});
   run.test(src, {moz: true});
 
   run = TestRun(test)
     .addError(13, 5, "'with' is not allowed in strict mode.");
-  run.test(src, {withstmt: true, es3: true});
+  run.test(src, {withstmt: true, esversion: 3});
   run.test(src, {withstmt: true}); // es5
-  run.test(src, {withstmt: true, esnext: true});
+  run.test(src, {withstmt: true, esversion: 6});
   run.test(src, {withstmt: true, moz: true});
 
   test.done();
@@ -1201,9 +1201,9 @@ exports.blocks = function (test) {
   var run = TestRun(test)
     .addError(31, 5, "Unmatched \'{\'.")
     .addError(32, 1, "Unrecoverable syntax error. (100% scanned).");
-  run.test(src, {es3: true});
+  run.test(src, {esversion: 3});
   run.test(src, {}); // es5
-  run.test(src, {esnext: true});
+  run.test(src, {esversion: 6});
   run.test(src, {moz: true});
 
   test.done();
@@ -1242,9 +1242,9 @@ exports.exported = function (test) {
     .addError(14, 5, "'unusedExpression' is defined but never used.")
     .addError(17, 12, "'cannotBeExported' is defined but never used.");
 
-  run.test(src, {es3: true, unused: true });
+  run.test(src, {esversion: 3, unused: true });
   run.test(src, {unused: true }); // es5
-  run.test(src, {esnext: true, unused: true });
+  run.test(src, {esversion: 6, unused: true });
   run.test(src, {moz: true, unused: true });
   run.test(src, {unused: true, latedef: true});
 
@@ -1282,7 +1282,7 @@ exports.exported = function (test) {
 exports.testIdentifiers = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/identifiers.js", "utf8");
 
-  TestRun(test).test(src, {es3: true});
+  TestRun(test).test(src, {esversion: 3});
   var run = TestRun(test)
     .addError(1, 5, "'ascii' is defined but never used.")
     .addError(2, 5, "'num1' is defined but never used.")
@@ -1319,9 +1319,9 @@ exports.testIdentifiers = function (test) {
     .addError(33, 5, "'\\u0024\\u200D' is defined but never used.")
     .addError(34, 5, "'\\u0024\\u0024' is defined but never used.")
     .addError(35, 5, "'\\u0024\\u005F' is defined but never used.");
-  run.test(src, {es3: true, unused: true });
+  run.test(src, {esversion: 3, unused: true });
   run.test(src, {unused: true }); // es5
-  run.test(src, {esnext: true, unused: true });
+  run.test(src, {esversion: 6, unused: true });
   run.test(src, {moz: true, unused: true });
 
   test.done();
@@ -1336,9 +1336,9 @@ exports.badIdentifiers = function (test) {
     .addError(1, 5, "Unexpected '\\'.")
     .addError(1, 1, "Expected an identifier and instead saw ''.")
     .addError(1, 5, "Unrecoverable syntax error. (100% scanned).");
-  run.test(badUnicode, {es3: true});
+  run.test(badUnicode, {esversion: 3});
   run.test(badUnicode, {}); // es5
-  run.test(badUnicode, {esnext: true});
+  run.test(badUnicode, {esversion: 6});
   run.test(badUnicode, {moz: true});
 
   var invalidUnicodeIdent = [
@@ -1349,9 +1349,9 @@ exports.badIdentifiers = function (test) {
     .addError(1, 5, "Unexpected '\\'.")
     .addError(1, 1, "Expected an identifier and instead saw ''.")
     .addError(1, 5, "Unrecoverable syntax error. (100% scanned).");
-  run.test(invalidUnicodeIdent, {es3: true});
+  run.test(invalidUnicodeIdent, {esversion: 3});
   run.test(invalidUnicodeIdent, {}); // es5
-  run.test(invalidUnicodeIdent, {esnext: true});
+  run.test(invalidUnicodeIdent, {esversion: 6});
   run.test(invalidUnicodeIdent, {moz: true});
 
   test.done();
@@ -1360,7 +1360,7 @@ exports.badIdentifiers = function (test) {
 exports["regression for GH-878"] = function (test) {
   var src = fs.readFileSync(__dirname + "/fixtures/gh878.js", "utf8");
 
-  TestRun(test).test(src, {es3: true});
+  TestRun(test).test(src, {esversion: 3});
 
   test.done();
 };
@@ -1379,7 +1379,7 @@ exports["regression for GH-910"] = function (test) {
     .addError(1, 43, "Expected an assignment or function call and instead saw an expression.")
     .addError(1, 14, "Unmatched '{'.")
     .addError(1, 44, "Unrecoverable syntax error. (100% scanned).")
-    .test(src, { es3: true, nonew: true });
+    .test(src, { esversion: 3, nonew: true });
   test.done();
 };
 
@@ -1443,7 +1443,7 @@ exports["destructuring var in function scope"] = function (test) {
     .addError(6, 9,  "'o' is defined but never used.")
     .addError(7, 28,  "'d' is defined but never used.")
     .addError(9, 20,  "'bar' is defined but never used.")
-    .test(code, {esnext: true, unused: true, undef: true});
+    .test(code, {esversion: 6, unused: true, undef: true});
 
   test.done();
 };
@@ -1497,7 +1497,7 @@ exports["destructuring var as esnext"] = function (test) {
     .addError(5, 7,  "'o' is defined but never used.")
     .addError(6, 26,  "'d' is defined but never used.")
     .addError(8, 18,  "'bar' is defined but never used.")
-    .test(code, {esnext: true, unused: true, undef: true});
+    .test(code, {esversion: 6, unused: true, undef: true});
 
   test.done();
 };
@@ -1567,7 +1567,7 @@ exports["destructuring var as legacy JS"] = function (test) {
     .addError(5, 7,  "'o' is defined but never used.")
     .addError(6, 26,  "'d' is defined but never used.")
     .addError(8, 18,  "'bar' is defined but never used.")
-    .test(code, {es3: true, unused: true, undef: true});
+    .test(code, {esversion: 3, unused: true, undef: true});
 
   test.done();
 };
@@ -1604,7 +1604,7 @@ exports["destructuring var errors"] = function (test) {
     .addError(5, 7,  "'o' is defined but never used.")
     .addError(6, 26,  "'d' is defined but never used.")
     .addError(8, 18,  "'bar' is defined but never used.")
-    .test(code, {esnext: true, unused: true, undef: true});
+    .test(code, {esversion: 6, unused: true, undef: true});
 
   test.done();
 };
@@ -1680,7 +1680,7 @@ exports["destructuring const as esnext"] = function (test) {
     .addError(9, 2, "Attempting to override 'j' which is a constant.")
     .addError(11, 3, "['a'] is better written in dot notation.")
     .addError(3, 17, "'z' is not defined.")
-    .test(code, {esnext: true, unused: true, undef: true});
+    .test(code, {esversion: 6, unused: true, undef: true});
 
   test.done();
 };
@@ -1780,7 +1780,7 @@ exports["destructuring const as legacy JS"] = function (test) {
     .addError(8, 9, "'j' is defined but never used.")
     .addError(8, 20, "'foobar' is defined but never used.")
     .addError(3, 17, "'z' is not defined.")
-    .test(code, {es3: true, unused: true, undef: true});
+    .test(code, {esversion: 3, unused: true, undef: true});
 
   test.done();
 };
@@ -1817,7 +1817,7 @@ exports["destructuring const errors"] = function (test) {
     .addError(5, 30, "Missing semicolon.")
     .addError(5, 31, "Expected an identifier and instead saw ']'.")
     .addError(5, 31, "Expected an assignment or function call and instead saw an expression.")
-    .test(code, {esnext: true, unused: true, undef: true});
+    .test(code, {esversion: 6, unused: true, undef: true});
 
   test.done();
 };
@@ -1875,7 +1875,7 @@ exports["destructuring globals as esnext"] = function (test) {
     .addError(12, 3, "['b'] is better written in dot notation.")
     .addError(15, 2, "'notDefined1' is not defined.")
     .addError(16, 5, "'notDefined2' is not defined.")
-    .test(code, {esnext: true, unused: true, undef: true});
+    .test(code, {esversion: 6, unused: true, undef: true});
 
   test.done();
 };
@@ -1953,7 +1953,7 @@ exports["destructuring globals as legacy JS"] = function (test) {
     .addError(12, 1, "'destructuring assignment' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(13, 1, "'destructuring assignment' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(13, 3, "'spread/rest operator' is only available in ES6 (use 'esversion: 6').")
-    .test(code, {es3: true, unused: true, undef: true});
+    .test(code, {esversion: 3, unused: true, undef: true});
 
   test.done();
 };
@@ -1985,7 +1985,7 @@ exports["destructuring globals with syntax error"] = function (test) {
     .addError(8, 4, "Bad assignment.")
     .addError(9, 9, "Bad assignment.")
     .addError(2, 11,  "'z' is not defined.")
-    .test(code, {esnext: true, unused: true, undef: true});
+    .test(code, {esversion: 6, unused: true, undef: true});
 
   TestRun(test)
     .addError(1, 6, "Expected ',' and instead saw '['.")
@@ -1999,12 +1999,12 @@ exports["destructuring globals with syntax error"] = function (test) {
     .addError(1, 22, "Expected ',' and instead saw '1'.")
     .addError(1, 24, "Expected an assignment or function call and instead saw an expression.")
     .addError(1, 16, "Expected an identifier and instead saw '='.")
-    .test("[ { a['b'] } ] = [{a:1}];", {esnext: true, unused: true, undef: true});
+    .test("[ { a['b'] } ] = [{a:1}];", {esversion: 6, unused: true, undef: true});
 
   TestRun(test)
     .addError(1, 6, "Expected ',' and instead saw '('.")
     .addError(1, 7, "Expected an identifier and instead saw ')'.")
-    .test("[ { a() } ] = [];", {esnext: true, unused: true, undef: true});
+    .test("[ { a() } ] = [];", {esversion: 6, unused: true, undef: true});
 
   TestRun(test)
     .addError(1, 19, "Extending prototype of native object: 'Number'.")
@@ -2026,7 +2026,7 @@ exports["destructuring globals with syntax error"] = function (test) {
       "  ({ x: null } = {});",
       "  ({ y: [...this] } = {});",
       "  ({ y: [...z] } = {});",
-      "}"], {esnext: true, freeze: true});
+      "}"], {esversion: 6, freeze: true});
 
   test.done();
 };
@@ -2062,7 +2062,7 @@ exports["destructuring assign of empty values as esnext"] = function (test) {
     .addError(2, 10, "'d' is defined but never used.")
     .addError(3, 7, "'e' is defined but never used.")
     .addError(3, 12, "'f' is defined but never used.")
-    .test(code, {esnext: true, unused: true, undef: true, elision: true});
+    .test(code, {esversion: 6, unused: true, undef: true, elision: true});
 
   test.done();
 };
@@ -2105,7 +2105,7 @@ exports["destructuring assign of empty values as JS legacy"] = function (test) {
     .addError(3, 7, "'e' is defined but never used.")
     .addError(3, 12, "'f' is defined but never used.")
     .addError(3, 23, "Extra comma. (it breaks older versions of IE)")
-    .test(code, {es3: true, unused: true, undef: true});
+    .test(code, {esversion: 3, unused: true, undef: true});
 
   test.done();
 };
@@ -2137,7 +2137,7 @@ exports["destructuring assignment default values"] = function (test) {
     .addError(12, 7, "It's not necessary to initialize 'v' to 'undefined'.")
     .addError(13, 10, "It's not necessary to initialize 'x' to 'undefined'.")
     .addError(14, 12, "Expected ']' and instead saw '='.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -2203,7 +2203,7 @@ exports["non-identifier PropertyNames in object destructuring"] = function (test
     .addError(3, 18, "'f' is defined but never used.")
     .addError(3, 26, "'g' is defined but never used.")
     .addError(3, 36, "'h' is defined but never used.")
-    .test(code, { esnext: true, unused: true });
+    .test(code, { esversion: 6, unused: true });
 
   test.done();
 };
@@ -2223,7 +2223,7 @@ exports["empty destructuring"] = function (test) {
     .addError(3, 16, "Empty destructuring: this is unnecessary and can be removed.")
     .addError(4, 10, "Empty destructuring: this is unnecessary and can be removed.")
     .addError(4, 18, "Empty destructuring: this is unnecessary and can be removed.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -2275,7 +2275,7 @@ exports["let statement as esnext"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2321,7 +2321,7 @@ exports["let statement as legacy JS"] = function (test) {
     .addError(1, 1, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(3, 3, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(5, 5, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2369,7 +2369,7 @@ exports["let statement out of scope as esnext"] = function (test) {
     .addError(3, 7, "'y' is defined but never used.")
     .addError(7, 9, "'z' is not defined.")
     .addError(9, 7, "'y' is not defined.")
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2423,7 +2423,7 @@ exports["let statement out of scope as legacy JS"] = function (test) {
     .addError(3, 7, "'y' is defined but never used.")
     .addError(7, 9, "'z' is not defined.")
     .addError(9, 7, "'y' is not defined.")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2467,7 +2467,7 @@ exports["let statement in functions as esnext"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2517,7 +2517,7 @@ exports["let statement in functions as legacy JS"] = function (test) {
     .addError(1, 1, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(3, 3, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(5, 5, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2573,7 +2573,7 @@ exports["let statement not in scope as esnext"] = function (test) {
     .addError(8, 9, "'z' is not defined.")
     .addError(10, 7, "'y' is not defined.")
     .addError(11, 1, "'bar' is not defined.")
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2637,7 +2637,7 @@ exports["let statement not in scope as legacy JS"] = function (test) {
     .addError(8, 9, "'z' is not defined.")
     .addError(10, 7, "'y' is not defined.")
     .addError(11, 1, "'bar' is not defined.")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2689,7 +2689,7 @@ exports["let statement in for loop as esnext"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print", "Iterator"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print", "Iterator"]});
 
   test.done();
 };
@@ -2753,7 +2753,7 @@ exports["let statement in for loop as legacy JS"] = function (test) {
     .addError(8, 6, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(11, 6, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(14, 6, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print", "Iterator"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print", "Iterator"]});
 
   test.done();
 };
@@ -2822,7 +2822,7 @@ exports["let statement in destructured for loop as esnext"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true, unused: true,
+    .test(code, {esversion: 6, unused: true,
            undef: true, predef: ["print"]});
 
   test.done();
@@ -2895,7 +2895,7 @@ exports["let statement in destructured for loop as legacy JS"] = function (test)
   TestRun(test)
     .addError(21, 6, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(21, 6, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -2944,7 +2944,7 @@ exports["let statement (as seen in jetpack) as esnext"] = function (test) {
 
   TestRun(test)
     .addError(3, 5, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {esnext: true, unused: true, undef: true,
+    .test(code, {esversion: 6, unused: true, undef: true,
            predef: ["require", "xferable", "options"]});
   test.done();
 };
@@ -3000,7 +3000,7 @@ exports["let statement (as seen in jetpack) as legacy JS"] = function (test) {
     .addError(1, 1, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(3, 1, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(3, 5, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {es3: true, unused: true, undef: true,
+    .test(code, {esversion: 3, unused: true, undef: true,
            predef: ["require", "xferable", "options"]});
   test.done();
 };
@@ -3035,7 +3035,7 @@ exports["let block and let expression as esnext"] = function (test) {
     .addError(3, 6, "'let block' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(4, 9, "'let expressions' is only available in Mozilla JavaScript extensions " +
       "(use moz option).")
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
   test.done();
 };
 
@@ -3079,7 +3079,7 @@ exports["let block and let expression as legacy JS"] = function (test) {
     .addError(4, 9, "'let expressions' is only available in Mozilla JavaScript extensions " +
       "(use moz option).")
     .addError(4, 12, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
   test.done();
 };
 
@@ -3101,7 +3101,7 @@ exports["make sure let variables are not treated as globals"] = function (test) 
     "}"
   ];
 
-  TestRun(test).test(code, { esnext: true, browser: true });
+  TestRun(test).test(code, { esversion: 6, browser: true });
   test.done();
 };
 
@@ -3130,7 +3130,7 @@ exports["make sure var variables can shadow let variables"] = function (test) {
     .addError(2, 5, "'b' is defined but never used.")
     .addError(3, 5, "'c' is defined but never used.")
     .addError(9, 5, "'d' has already been declared.")
-    .test(code, { esnext: true, unused: true, undef: true, funcscope: true });
+    .test(code, { esversion: 6, unused: true, undef: true, funcscope: true });
 
   test.done();
 };
@@ -3145,7 +3145,7 @@ exports["make sure let variables in the closure of functions shadow predefined g
     "}"
   ];
 
-  TestRun(test).test(code, { esnext: true, predef: { foo: false } });
+  TestRun(test).test(code, { esversion: 6, predef: { foo: false } });
   test.done();
 };
 
@@ -3159,7 +3159,7 @@ exports["make sure let variables in the closure of blocks shadow predefined glob
     "}"
   ];
 
-  TestRun(test).test(code, { esnext: true, predef: { foo: false } });
+  TestRun(test).test(code, { esversion: 6, predef: { foo: false } });
   test.done();
 };
 
@@ -3186,7 +3186,7 @@ exports["test block scope redefines globals only outside of blocks"] = function 
 
   TestRun(test)
     .addError(4, 5, "Redefinition of 'Map'.")
-    .test(code, { esnext: true, browser: true });
+    .test(code, { esversion: 6, browser: true });
   test.done();
 };
 
@@ -3223,7 +3223,7 @@ exports["test destructuring function as esnext"] = function (test) {
     "whois(user);"
   ];
   TestRun(test)
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3265,7 +3265,7 @@ exports["test destructuring function as legacy JS"] = function (test) {
   TestRun(test)
     .addError(1, 16, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(4, 15, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3281,7 +3281,7 @@ exports["destructuring function default values"] = function (test) {
     "let v = ({ w: x = 2, y = 2 }) => {};"
   ];
 
-  TestRun(test).test(code, { esnext: true });
+  TestRun(test).test(code, { esversion: 6 });
 
   test.done();
 };
@@ -3309,7 +3309,7 @@ exports["non var destructuring assignment statement"] = function (test) {
     "c = ([b]) = b;"
   ];
 
-  TestRun(test).test(codeValid, { esnext: true });
+  TestRun(test).test(codeValid, { esversion: 6 });
 
   TestRun(test)
     .addError(2, 2, "Expected an assignment or function call and instead saw an expression.")
@@ -3330,7 +3330,7 @@ exports["non var destructuring assignment statement"] = function (test) {
     .addError(6, 19, "Expected ',' and instead saw '}'.")
     .addError(7, 15, "Bad assignment.")
     .addError(8, 11, "Bad assignment.")
-    .test(codeInvalid, { esnext: true });
+    .test(codeInvalid, { esversion: 6 });
 
   test.done();
 
@@ -3362,7 +3362,7 @@ exports["invalid for each as esnext"] = function (test) {
   TestRun(test)
     .addError(1, 5, "Invalid for each loop.")
     .addError(1, 5, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3395,7 +3395,7 @@ exports["invalid for each as legacy JS"] = function (test) {
     .addError(1, 5, "Invalid for each loop.")
     .addError(1, 5, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(1, 11, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3416,7 +3416,7 @@ exports["esnext generator"] = function (test) {
     "  print(g.next());"
   ];
   TestRun(test)
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3486,7 +3486,7 @@ exports["esnext generator as legacy JS"] = function (test) {
     .addError(1, 9, "'function*' is only available in ES6 (use 'esversion: 6').")
     .addError(4, 5, "'yield' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(5, 5, "'destructuring assignment' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3508,7 +3508,7 @@ exports["esnext generator without yield"] = function (test) {
   ];
   TestRun(test)
     .addError(7, 1, "A generator function should contain at least one yield expression.")
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3520,7 +3520,7 @@ exports["esnext generator without yield and check turned off"] = function (test)
     "emptyGenerator();"
   ];
   TestRun(test)
-    .test(code, {esnext: true, noyield: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, noyield: true, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3540,8 +3540,8 @@ exports["esnext generator with yield delegation, gh-1544"] = function(test) {
     .test(code);
 
 
-  TestRun(test).test(code, {esnext: true, noyield: true});
-  TestRun(test).test(code, {esnext: true, noyield: true, moz: true});
+  TestRun(test).test(code, {esversion: 6, noyield: true});
+  TestRun(test).test(code, {esversion: 6, noyield: true, moz: true});
 
   test.done();
 };
@@ -3583,12 +3583,12 @@ exports["mozilla generator as esnext"] = function (test) {
   TestRun(test)
     .addError(4, 5,
      "Yield expressions may only occur within generator functions.")
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print", "Iterator"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print", "Iterator"]});
 
   TestRun(test)
     .addError(4, 5,
      "Yield expressions may only occur within generator functions.")
-    .test(code, {esnext: true, moz: true});
+    .test(code, {esversion: 6, moz: true});
 
   test.done();
 };
@@ -3608,7 +3608,7 @@ exports["yield expression within try-catch"] = function (test) {
     "  print(g.next());"
   ];
   TestRun(test)
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print", "Iterator"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print", "Iterator"]});
 
   test.done();
 };
@@ -3742,7 +3742,7 @@ exports["mozilla generator as legacy JS"] = function (test) {
     .addError(4, 5, "'yield' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(5, 5, "'destructuring assignment' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(9, 6, "'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print", "Iterator"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print", "Iterator"]});
 
   test.done();
 };
@@ -3765,7 +3765,7 @@ exports["array comprehension"] = function (test) {
     "}());"
   ];
   TestRun(test)
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3784,7 +3784,7 @@ exports["array comprehension unused and undefined"] = function (test) {
     .addError(3, 5, "'b' is defined but never used.")
     .addError(4, 15, "'\\u0024' is defined but never used.")
     .addError(4, 5, "'c' is defined but never used.")
-    .test(code, { esnext: true, unused: true, undef: true });
+    .test(code, { esversion: 6, unused: true, undef: true });
 
   var unused = JSHINT.data().unused;
   test.deepEqual([
@@ -3864,7 +3864,7 @@ exports["array comprehension with for..of"] = function (test) {
     "print('evens:', evens);"
   ];
   TestRun(test)
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3895,7 +3895,7 @@ exports["array comprehension with unused variables"] = function (test) {
   ];
   TestRun(test)
     .addError(1, 22, "'unknown' is not defined.")
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -3931,11 +3931,11 @@ exports["moz-style array comprehension as esnext"] = function (test) {
     .addError(6, 30, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(7, 14, "Expected 'for' and instead saw 'i'.")
     .addError(7, 20, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {esnext: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, unused: true, undef: true, predef: ["print"]});
 
   TestRun(test)
     .addError(3, 5, "Yield expressions may only occur within generator functions.")
-    .test(code, {esnext: true, moz: true});
+    .test(code, {esversion: 6, moz: true});
 
   test.done();
 };
@@ -4009,7 +4009,7 @@ exports["array comprehension as legacy JS"] = function (test) {
     .addError(3, 5, "'yield' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(6, 19, "'array comprehension' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(7, 13, "'array comprehension' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4036,7 +4036,7 @@ exports["moz-style array comprehension as legacy JS"] = function (test) {
     .addError(7, 13, "'array comprehension' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(7, 14, "Expected 'for' and instead saw 'i'.")
     .addError(7, 20, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {es3: true, unused: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, unused: true, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4048,7 +4048,7 @@ exports['array comprehension with dest array at global scope'] = function (test)
     "var destarray_comparray_2 = [for ([i, j] of [[0,0], [1,1], [2,2]]) [i, {i: [i, j]} ]];",
   ];
   TestRun(test)
-    .test(code, {esnext: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4078,7 +4078,7 @@ exports['moz-style array comprehension with dest array at global scope as esnext
     .addError(2, 48, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(3, 31, "Expected 'for' and instead saw '['.")
     .addError(3, 53, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {esnext: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4129,7 +4129,7 @@ exports['array comprehension with dest array at global scope as JS legacy'] = fu
     .addError(1, 1, "'array comprehension' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(2, 29, "'array comprehension' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(3, 29, "'array comprehension' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {es3: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4150,7 +4150,7 @@ exports['moz-style array comprehension with dest array at global scope as JS leg
     .addError(3, 29, "'array comprehension' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(3, 31, "Expected 'for' and instead saw '['.")
     .addError(3, 53, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {es3: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4161,7 +4161,7 @@ exports["array comprehension imbrication with dest array"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4197,7 +4197,7 @@ exports["moz-style array comprehension imbrication with dest array as esnext"] =
     .addError(1, 14, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(1, 31, "Expected 'for' and instead saw '['.")
     .addError(1, 42, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {esnext: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4238,7 +4238,7 @@ exports["array comprehension imbrication with dest array as legacy JS"] = functi
     .addError(1, 31, "Expected 'for' and instead saw '['.")
     .addError(1, 14, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(1, 42, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {es3: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4255,7 +4255,7 @@ exports["moz-style array comprehension imbrication with dest array as legacy JS"
     .addError(1, 31, "Expected 'for' and instead saw '['.")
     .addError(1, 14, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
     .addError(1, 42, "'for each' is only available in Mozilla JavaScript extensions (use moz option).")
-    .test(code, {es3: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4297,7 +4297,7 @@ exports["try catch filters as esnext"] = function (test) {
   TestRun(test)
     .addError(4, 8, "'catch filter' is only available in Mozilla JavaScript extensions " +
       "(use moz option).")
-    .test(code, {esnext: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4331,7 +4331,7 @@ exports["try catch filters as legacy JS"] = function (test) {
   TestRun(test)
     .addError(4, 8, "'catch filter' is only available in Mozilla JavaScript extensions " +
       "(use moz option).")
-    .test(code, {es3: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4343,7 +4343,7 @@ exports["function closure expression"] = function (test) {
     "}"
   ];
   TestRun(test)
-    .test(code, {es3: true, moz: true, undef: true});
+    .test(code, {esversion: 3, moz: true, undef: true});
 
   test.done();
 };
@@ -4356,7 +4356,7 @@ exports["function closure expression as esnext"] = function (test) {
   TestRun(test)
     .addError(2, 22, "'function closure expressions' is only available in Mozilla JavaScript " +
       "extensions (use moz option).")
-    .test(code, {esnext: true, undef: true});
+    .test(code, {esversion: 6, undef: true});
 
   test.done();
 };
@@ -4382,7 +4382,7 @@ exports["function closure expression as legacy JS"] = function (test) {
   TestRun(test)
     .addError(2, 22, "'function closure expressions' is only available in Mozilla JavaScript " +
       "extensions (use moz option).")
-    .test(code, {es3: true, undef: true});
+    .test(code, {esversion: 3, undef: true});
 
   test.done();
 };
@@ -4425,7 +4425,7 @@ exports["for of as esnext"] = function (test) {
     .addError(17, 13, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(18, 17, "Invalid for-of loop left-hand-side: initializer is forbidden.")
     .addError(18, 17, "Invalid for-of loop left-hand-side: more than one ForBinding.")
-    .test(code, {esnext: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, undef: true, predef: ["print"]});
 
   TestRun(test, "Left-hand side as MemberExpression")
     .test([
@@ -4571,7 +4571,7 @@ exports["for of as legacy JS"] = function (test) {
     .addError(17, 17, "Invalid for-of loop left-hand-side: initializer is forbidden.")
     .addError(17, 17, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(17, 6, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(code, {es3: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4587,7 +4587,7 @@ exports["array destructuring for of as esnext"] = function (test) {
   TestRun(test, "basic")
     .addError(1, 7, "Creating global 'for' variable. Should be 'for (var i ...'.")
     .addError(1, 10, "Creating global 'for' variable. Should be 'for (var v ...'.")
-    .test(basic, {esnext: true, undef: true, predef: ["print"]});
+    .test(basic, {esversion: 6, undef: true, predef: ["print"]});
 
   var bad = [
     "for ([i, v] = [1, 2] of [[0, 1],[1, 2],[2, 3],[3, 4]]) print(i + '=' + v);",
@@ -4607,7 +4607,7 @@ exports["array destructuring for of as esnext"] = function (test) {
     .addError(5, 16, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(6, 16, "Invalid for-of loop left-hand-side: initializer is forbidden.")
     .addError(6, 16, "Invalid for-of loop left-hand-side: more than one ForBinding.")
-    .test(bad, {esnext: true, undef: true, predef: ["print"]});
+    .test(bad, {esversion: 6, undef: true, predef: ["print"]});
 
   var bad2 = [
     "for (let [i, v] = [1, 2] of [[0, 1],[1, 2],[2, 3],[3, 4]]) print(i + '=' + v);",
@@ -4626,7 +4626,7 @@ exports["array destructuring for of as esnext"] = function (test) {
     .addError(5, 18, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(6, 18, "Invalid for-of loop left-hand-side: initializer is forbidden.")
     .addError(6, 18, "Invalid for-of loop left-hand-side: more than one ForBinding.")
-    .test(bad2, {esnext: true, undef: true, predef: ["print"]});
+    .test(bad2, {esversion: 6, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -4755,7 +4755,7 @@ exports["array destructuring for of as legacy JS"] = function (test) {
     .addError(4, 19, "'for of' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(4, 6, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(4, 6, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(basic, {es3: true, undef: true, predef: ["print"]}); // es3
+    .test(basic, {esversion: 3, undef: true, predef: ["print"]}); // es3
 
   var bad = [
     "for ([i, v] = [1, 2] of [[0, 1],[1, 2],[2, 3],[3, 4]]) print(i + '=' + v);",
@@ -4791,7 +4791,7 @@ exports["array destructuring for of as legacy JS"] = function (test) {
     .addError(6, 16, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(6, 6, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(6, 16, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(bad, {es3: true, undef: true, predef: ["print"]}); // es3
+    .test(bad, {esversion: 3, undef: true, predef: ["print"]}); // es3
 
   var bad2 = [
     "for (let [i, v] = [1, 2] of [[0, 1],[1, 2],[2, 3],[3, 4]]) print(i + '=' + v);",
@@ -4832,7 +4832,7 @@ exports["array destructuring for of as legacy JS"] = function (test) {
     .addError(6, 6, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(6, 6, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(6, 18, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(bad2, {es3: true, undef: true, predef: ["print"]}); // es3
+    .test(bad2, {esversion: 3, undef: true, predef: ["print"]}); // es3
 
   test.done();
 };
@@ -4851,7 +4851,7 @@ exports["object destructuring for of as esnext"] = function (test) {
   TestRun(test, "basic")
     .addError(4, 7, "Creating global 'for' variable. Should be 'for (var key ...'.")
     .addError(4, 20, "Creating global 'for' variable. Should be 'for (var value ...'.")
-    .test(basic, {esnext: true, undef: true, predef: ["print"]});
+    .test(basic, {esversion: 6, undef: true, predef: ["print"]});
 
   var bad = [
     "var obj1 = { key: 'a', data: { val: 1 } };",
@@ -4874,7 +4874,7 @@ exports["object destructuring for of as esnext"] = function (test) {
     .addError(8, 28, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(9, 28, "Invalid for-of loop left-hand-side: initializer is forbidden.")
     .addError(9, 28, "Invalid for-of loop left-hand-side: more than one ForBinding.")
-    .test(bad, {esnext: true, undef: true, predef: ["print"]});
+    .test(bad, {esversion: 6, undef: true, predef: ["print"]});
 
   var bad2 = [
     "var obj1 = { key: 'a', data: { val: 1 } };",
@@ -4897,7 +4897,7 @@ exports["object destructuring for of as esnext"] = function (test) {
     .addError(8, 30, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(9, 30, "Invalid for-of loop left-hand-side: initializer is forbidden.")
     .addError(9, 30, "Invalid for-of loop left-hand-side: more than one ForBinding.")
-    .test(bad2, {esnext: true, undef: true, predef: ["print"]});
+    .test(bad2, {esversion: 6, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -5039,7 +5039,7 @@ exports["object destructuring for of as legacy JS"] = function (test) {
     .addError(7, 36, "'for of' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(7, 6, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(7, 6, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(basic, {es3: true, undef: true, predef: ["print"]}); // es3
+    .test(basic, {esversion: 3, undef: true, predef: ["print"]}); // es3
 
   var bad = [
     "var obj1 = { key: 'a', data: { val: 1 } };",
@@ -5078,7 +5078,7 @@ exports["object destructuring for of as legacy JS"] = function (test) {
     .addError(9, 28, "Invalid for-of loop left-hand-side: more than one ForBinding.")
     .addError(9, 6, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(9, 28, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(bad, {es3: true, undef: true, predef: ["print"]}); // es3
+    .test(bad, {esversion: 3, undef: true, predef: ["print"]}); // es3
 
   var bad2 = [
     "var obj1 = { key: 'a', data: { val: 1 } };",
@@ -5123,7 +5123,7 @@ exports["object destructuring for of as legacy JS"] = function (test) {
     .addError(9, 6, "'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(9, 6, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(9, 30, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
-    .test(bad2, {es3: true, undef: true, predef: ["print"]}); // es3
+    .test(bad2, {esversion: 3, undef: true, predef: ["print"]}); // es3
 
   test.done();
 };
@@ -5161,7 +5161,7 @@ exports["try multi-catch as esnext"] = function (test) {
   TestRun(test)
     .addError(5, 3, "'multiple catch blocks' is only available in Mozilla JavaScript extensions " +
       "(use moz option).")
-    .test(code, {esnext: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 6, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -5202,7 +5202,7 @@ exports["try multi-catch as legacy JS"] = function (test) {
   TestRun(test)
     .addError(5, 3, "'multiple catch blocks' is only available in Mozilla JavaScript extensions " +
       "(use moz option).")
-    .test(code, {es3: true, undef: true, predef: ["print"]});
+    .test(code, {esversion: 3, undef: true, predef: ["print"]});
 
   test.done();
 };
@@ -5265,7 +5265,7 @@ exports["no const not directly within a block"] = function (test) {
     .addError(8, 12, "Const declaration not directly within block.")
     .addError(8, 40, "Const declaration not directly within block.")
     .addError(8, 58, "Const declaration not directly within block.")
-    .test(code, {predef: ["print"], esnext: true});
+    .test(code, {predef: ["print"], esversion: 6});
 
   test.done();
 };
@@ -5278,7 +5278,7 @@ exports["test: let declared directly within block"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   code = [
     "for (let i;;)",
@@ -5286,7 +5286,7 @@ exports["test: let declared directly within block"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   test.done();
 };
@@ -5300,7 +5300,7 @@ exports["test: let is directly within nested block"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   code   = [
     "if(true)",
@@ -5309,7 +5309,7 @@ exports["test: let is directly within nested block"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   code   = [
     "if(true) {",
@@ -5320,7 +5320,7 @@ exports["test: let is directly within nested block"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   test.done();
 };
@@ -5374,9 +5374,9 @@ exports.ASI.gh950 = function (test) {
     .addError(11, 1, "Expected an assignment or function call and instead saw an expression.")
     .addError(14, 1, "Expected an assignment or function call and instead saw an expression.");
 
-  run.test(code, {es3: true, asi: true});
+  run.test(code, {esversion: 3, asi: true});
   run.test(code, {asi: true}); // es5
-  run.test(code, {esnext: true, asi: true});
+  run.test(code, {esversion: 6, asi: true});
   run.test(code, {moz: true, asi: true});
 
   run = TestRun(test)
@@ -5396,9 +5396,9 @@ exports.ASI.gh950 = function (test) {
     .addError(14, 2, "Missing semicolon.")
     .addError(16, 2, "Missing semicolon.");
 
-  run.test(code, {es3: true, asi: false});
+  run.test(code, {esversion: 3, asi: false});
   run.test(code, {asi: false}); // es5
-  run.test(code, {esnext: true, asi: false});
+  run.test(code, {esversion: 6, asi: false});
   run.test(code, {moz: true, asi: false});
 
   test.done();
@@ -5488,7 +5488,7 @@ exports["fat arrows support"] = function (test) {
     .addError(9, 9, "'j' is not defined.")
     .addError(8, 13, "'z' is not defined.");
 
-  run.test(code, { undef: true, esnext: true });
+  run.test(code, { undef: true, esversion: 6 });
 
   run = TestRun(test)
     .addError(1, 14, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').")
@@ -5556,7 +5556,7 @@ exports["fat arrows support"] = function (test) {
     .addError(26, 29, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').");
 
   run.test(code); // es5
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
 
   test.done();
 };
@@ -5588,14 +5588,14 @@ exports["fat arrow nested function scoping"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   test.done();
 };
 
 exports["default arguments in fat arrow functions"] = function (test) {
   TestRun(test)
-    .test("(x = 0) => { return x; };", { expr: true, unused: true, esnext: true });
+    .test("(x = 0) => { return x; };", { expr: true, unused: true, esversion: 6 });
 
   test.done();
 };
@@ -5603,7 +5603,7 @@ exports["default arguments in fat arrow functions"] = function (test) {
 exports["expressions in place of arrow function parameters"] = function (test) {
   TestRun(test)
     .addError(1, 2, "Expected an identifier and instead saw '1'.")
-    .test("(1) => {};", { expr: true, esnext: true });
+    .test("(1) => {};", { expr: true, esversion: 6 });
 
   test.done();
 };
@@ -5632,7 +5632,7 @@ conciseMethods.basicSupport = function (test) {
   ];
 
   var run = TestRun(test);
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   run = TestRun(test)
@@ -5642,7 +5642,7 @@ conciseMethods.basicSupport = function (test) {
     .addError(6, 5, "'yield' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).");
 
   run.test(code); // es5
-  run.test(code, {es3: true});
+  run.test(code, {esversion: 3});
 
   test.done();
 };
@@ -5660,7 +5660,7 @@ conciseMethods.getAndSet = function (test) {
     "};"
   ];
 
-  TestRun(test).test(code, {esnext: true});
+  TestRun(test).test(code, {esversion: 6});
 
   test.done();
 };
@@ -5675,7 +5675,7 @@ conciseMethods.getWithoutSet = function (test) {
     "};"
   ];
 
-  TestRun(test).test(code, {esnext: true});
+  TestRun(test).test(code, {esversion: 6});
 
   test.done();
 };
@@ -5690,7 +5690,7 @@ conciseMethods.setWithoutGet = function (test) {
     "};"
   ];
 
-  TestRun(test).test(code, {esnext: true});
+  TestRun(test).test(code, {esversion: 6});
 
   test.done();
 };
@@ -5704,7 +5704,7 @@ conciseMethods.nameIsNotLocalVar = function (test) {
     "};"
   ];
 
-  TestRun(test).test(code, {esnext: true});
+  TestRun(test).test(code, {esversion: 6});
 
   test.done();
 };
@@ -5720,7 +5720,7 @@ exports["object short notation: basic"] = function (test) {
     "};"
   ];
 
-  TestRun(test, 1).test(code, {esnext: true});
+  TestRun(test, 1).test(code, {esversion: 6});
 
   TestRun(test, 2)
     .addError(2, 12, "'object short notation' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
@@ -5740,7 +5740,7 @@ exports["object short notation: mixed"] = function (test) {
     "var o2 = {b, a: 1, c};"
   ].join("\n");
 
-  TestRun(test).test(code, { esnext: true });
+  TestRun(test).test(code, { esversion: 6 });
 
   TestRun(test)
     .addError(2, 17, "'object short notation' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
@@ -5777,7 +5777,7 @@ exports["object ComputedPropertyName"] = function (test) {
 
   TestRun(test)
     .addError(19, 17, "Setter is defined without getter.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   TestRun(test)
     .addError(6, 1, "'computed property names' is only available in ES6 (use 'esversion: 6').")
@@ -5839,7 +5839,7 @@ exports["spread & rest operator support"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   TestRun(test)
     .addError(1, 5, "'spread/rest operator' is only available in ES6 (use 'esversion: 6').")
@@ -5919,7 +5919,7 @@ exports["parameter destructuring with rest"] = function (test) {
   ];
 
   var run = TestRun(test);
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
 
   run = TestRun(test)
     .addError(1, 19, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').")
@@ -5983,9 +5983,9 @@ exports["test for GH-1010"] = function (test) {
   ];
 
   var run = TestRun(test);
-  run.test(code, {expr: true, es3: true});
+  run.test(code, {expr: true, esversion: 3});
   run.test(code, {expr: true}); // es5
-  run.test(code, {expr: true, esnext: true});
+  run.test(code, {expr: true, esversion: 6});
   run.test(code, {expr: true, moz: true});
 
   test.done();
@@ -6101,7 +6101,7 @@ exports.classes = function (test) {
     .addError(cexprAssn + 7, 27, "Reassignment of 'Foo18', which is is a class. Use 'var' or 'let' to declare bindings that may change.")
     .addError(cexprAssn + 7, 49, "Reassignment of 'Foo17', which is is a class. Use 'var' or 'let' to declare bindings that may change.");
 
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
   run.test(code, {moz: true});
 
   run
@@ -6117,7 +6117,7 @@ exports.classes = function (test) {
     .addError(cexpr + 4, 15, "'package' is defined but never used.");
 
   code[0] = "'use strict';" + code[0];
-  run.test(code, {unused: true, globalstrict: true, esnext: true});
+  run.test(code, {unused: true, globalstrict: true, esversion: 6});
   run.test(code, {unused: true, globalstrict: true, moz: true});
 
   test.done();
@@ -6190,7 +6190,7 @@ exports["class and method naming"] = function (test) {
     .addError(30, 7, "Setter is defined without getter.")
     .addError(31, 7, "Setter is defined without getter.");
 
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
 
   test.done();
 };
@@ -6212,7 +6212,7 @@ exports["computed class methods aren't duplicate"] = function (test) {
 
   // JSHint shouldn't throw a "Duplicate class method" warning with computed method names
   // GH-2350
-  TestRun(test).test(code, { esnext: true });
+  TestRun(test).test(code, { esversion: 6 });
 
   test.done();
 };
@@ -6234,7 +6234,7 @@ exports["class method this"] = function (test) {
 
   TestRun(test)
     .addError(10, 39, "If a strict mode function is executed using function invocation, its 'this' value will be undefined.")
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   test.done();
 };
@@ -6278,7 +6278,7 @@ exports.classExpression = function (test) {
     .addError(6, 20, "Reassignment of 'MyClass', which is is a class. Use 'var' or 'let' to declare bindings that may change.")
     .addError(7, 15, "Reassignment of 'MyClass', which is is a class. Use 'var' or 'let' to declare bindings that may change.")
     .addError(9, 6, "'MyClass' is not defined.")
-    .test(code, { esnext: true, undef: true });
+    .test(code, { esversion: 6, undef: true });
 
   test.done();
 };
@@ -6518,7 +6518,7 @@ exports.classExpressionThis = function (test) {
   ];
 
   TestRun(test)
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -6542,7 +6542,7 @@ exports.classElementEmpty = function (test) {
     .addError(6, 3, "Unnecessary semicolon.")
     .addError(6, 4, "Unnecessary semicolon.")
     .addError(8, 3, "Unnecessary semicolon.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -6552,7 +6552,7 @@ exports.invalidClasses = function (test) {
   TestRun(test)
     .addError(1, 11, "Class properties must be methods. Expected '(' but instead saw ''.")
     .addError(1, 11, "Unrecoverable syntax error. (100% scanned).")
-    .test("class a { b", { esnext: true });
+    .test("class a { b", { esversion: 6 });
 
   // Regression test for GH-2339
   TestRun(test)
@@ -6565,7 +6565,7 @@ exports.invalidClasses = function (test) {
         "  constructor: {",
         "  }",
         "}"
-      ], { esnext: true });
+      ], { esversion: 6 });
 
   test.done();
 };
@@ -6728,7 +6728,7 @@ exports["test 'yield' in compound expressions."] = function (test) {
     .addError(84, 11, "Bad operand.")
     .addError(84, 19, "Bad operand.")
     .addError(84, 43, "Bad operand.")
-    .test(code, {maxerr: 1000, expr: true, esnext: true});
+    .test(code, {maxerr: 1000, expr: true, esversion: 6});
 
   run = TestRun(test)
     .addError(22, 15, "Did you mean to return a conditional instead of an assignment?")
@@ -6936,7 +6936,7 @@ exports["test for line breaks with 'yield'"] = function (test) {
     .addError(13, 22, "Missing semicolon.")
     .addError(14, 7, "Expected an assignment or function call and instead saw an expression.");
 
-  run.test(code, {esnext: true});
+  run.test(code, {esversion: 6});
 
   // Mozilla assumes the statement has ended if there is a line break
   // following a `yield`. This naturally causes havoc with the subsequent
@@ -6989,12 +6989,12 @@ exports["test for line breaks with 'yield'"] = function (test) {
 
   TestRun(test, "gh-2530 (asi: true)")
     .addError(5, 3, "Misleading line break before 'fn'; readers may interpret this as an expression boundary.")
-    .test(code2, { esnext: true, undef: false, asi: true });
+    .test(code2, { esversion: 6, undef: false, asi: true });
 
   TestRun(test, "gh-2530 (asi: false)")
     .addError(2, 8, "Missing semicolon.")
     .addError(5, 3, "Misleading line break before 'fn'; readers may interpret this as an expression boundary.")
-    .test(code2, { esnext: true, undef: false });
+    .test(code2, { esversion: 6, undef: false });
 
   test.done();
 };
@@ -7464,7 +7464,7 @@ exports["test destructuring function parameters as legacy JS"] = function (test)
     .addError(30, 22, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').")
     .addError(31, 7, "'destructuring binding' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).")
     .addError(31, 24, "'arrow function syntax (=>)' is only available in ES6 (use 'esversion: 6').")
-    .test(src, {es3: true, unused: true, undef: true, maxerr: 100});
+    .test(src, {esversion: 3, unused: true, undef: true, maxerr: 100});
 
   test.done();
 };
@@ -7477,7 +7477,7 @@ exports["test for parentheses in odd-numbered token"] = function (test) {
   ];
 
   TestRun(test)
-    .test(code, {esnext: true});
+    .test(code, {esversion: 6});
 
   test.done();
 };
@@ -7501,7 +7501,7 @@ exports["make sure we don't throw errors on removed options"] = function (test) 
 
 exports["'for of' shouldn't be subject to 'for in' rules"] = function (test) {
   TestRun(test)
-    .test("for (let x of [1, 2, 3]) { console.log(x); }", { forin: true, esnext: true });
+    .test("for (let x of [1, 2, 3]) { console.log(x); }", { forin: true, esversion: 6 });
   test.done();
 };
 
@@ -7589,7 +7589,7 @@ exports.testES6UnusedExports = function (test) {
   TestRun(test)
     .addError(24, 5, "'letDefinedLater' was used before it was declared, which is illegal for 'let' variables.")
     .addError(25, 7, "'constDefinedLater' was used before it was declared, which is illegal for 'const' variables.")
-    .test(code, { esnext: true, unused: true });
+    .test(code, { esversion: 6, unused: true });
 
   test.done();
 };
@@ -7635,7 +7635,7 @@ exports.testES6BlockExports = function (test) {
     .addError(17, 3, "Export declarations are only allowed at the top level of module scope.")
     .addError(17, 10, "Function declarations should not be placed in blocks. Use a function expression or move the statement to the top of the outer function.")
     .addError(18, 3, "Export declarations are only allowed at the top level of module scope.")
-    .test(code, { esnext: true, unused: true });
+    .test(code, { esversion: 6, unused: true });
 
   test.done();
 };
@@ -7739,24 +7739,24 @@ exports.testStrictDirectiveASI = function (test) {
 
   TestRun(test, 16)
     .addError(1, 9, "Missing \"use strict\" statement.")
-    .test("(() => 1)();", { strict: true, esnext: true });
+    .test("(() => 1)();", { strict: true, esversion: 6 });
 
   TestRun(test, 17)
-    .test("(() => { \"use strict\"; })();", { strict: true, esnext: true });
+    .test("(() => { \"use strict\"; })();", { strict: true, esversion: 6 });
 
   TestRun(test, 18)
-    .test("(() => {})();", { strict: true, esnext: true });
+    .test("(() => {})();", { strict: true, esversion: 6 });
 
   TestRun(test, 19)
     .addError(1, 10, "Missing \"use strict\" statement.")
-    .test("(() => { return 1; })();", { strict: true, esnext: true });
+    .test("(() => { return 1; })();", { strict: true, esversion: 6 });
 
   TestRun(test, 20)
     .addError(1, 1, "Use the function form of \"use strict\".")
     .test([
       "'use strict';",
       "(() => { return 1; })();"],
-    { strict: true, esnext: true });
+    { strict: true, esversion: 6 });
 
   test.done();
 };
@@ -7779,7 +7779,7 @@ exports.trailingCommaInObjectBindingPattern = function (test) {
   ];
 
   TestRun(test)
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -7792,7 +7792,7 @@ exports.trailingCommaInObjectBindingPatternParameters = function (test) {
   ];
 
   TestRun(test)
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -7807,7 +7807,7 @@ exports.trailingCommaInArrayBindingPattern = function (test) {
   ];
 
   TestRun(test)
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -7820,7 +7820,7 @@ exports.trailingCommaInArrayBindingPatternParameters = function (test) {
   ];
 
   TestRun(test)
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -7853,7 +7853,7 @@ exports.commaAfterRestElementInArrayBindingPattern = function (test) {
   TestRun(test)
     .addError(2, 18, "Invalid element after rest element.")
     .addError(3, 12, "Invalid element after rest element.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -7870,7 +7870,7 @@ exports.commaAfterRestElementInArrayBindingPatternParameters = function (test) {
   TestRun(test)
     .addError(1, 24, "Invalid element after rest element.")
     .addError(2, 19, "Invalid element after rest element.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -7887,7 +7887,7 @@ exports.commaAfterRestParameter = function (test) {
   TestRun(test)
     .addError(1, 23, "Invalid parameter after rest parameter.")
     .addError(2, 18, "Invalid parameter after rest parameter.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
@@ -7905,47 +7905,47 @@ exports.restParameterWithDefault = function (test) {
 exports.extraRestOperator = function (test) {
   TestRun(test)
     .addError(1, 23, "Unexpected '...'.")
-    .test('function fn([a, b, ......c]) { }', { esnext: true });
+    .test('function fn([a, b, ......c]) { }', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 18, "Unexpected '...'.")
-    .test('function fn2([......c]) { }', { esnext: true });
+    .test('function fn2([......c]) { }', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 23, "Unexpected '...'.")
     // The reported column number for this parsing error is incorrect.
     .addError(1, 23, "Unexpected ')'.")
-    .test('function fn3(a, b, ......) { }', { esnext: true });
+    .test('function fn3(a, b, ......) { }', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 17, "Unexpected '...'.")
     // The reported column number for this parsing error is incorrect.
     .addError(1, 17, "Unexpected ')'.")
-    .test('function fn4(......) { }', { esnext: true });
+    .test('function fn4(......) { }', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 9, "Unexpected '...'.")
-    .test('var [......a] = [1, 2, 3];', { esnext: true });
+    .test('var [......a] = [1, 2, 3];', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 16, "Unexpected '...'.")
-    .test('var [a, b, ... ...c] = [1, 2, 3];', { esnext: true });
+    .test('var [a, b, ... ...c] = [1, 2, 3];', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 17, "Unexpected '...'.")
-    .test('var arrow = (......a) => a;', { esnext: true });
+    .test('var arrow = (......a) => a;', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 24, "Unexpected '...'.")
-    .test('var arrow2 = (a, b, ......c) => c;', { esnext: true });
+    .test('var arrow2 = (a, b, ......c) => c;', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 19, "Unexpected '...'.")
-    .test('var arrow3 = ([......a]) => a;', { esnext: true });
+    .test('var arrow3 = ([......a]) => a;', { esversion: 6 });
 
   TestRun(test)
     .addError(1, 25, "Unexpected '...'.")
-    .test('var arrow4 = ([a, b, ......c]) => c;', { esnext: true });
+    .test('var arrow4 = ([a, b, ......c]) => c;', { esversion: 6 });
 
   test.done();
 };
@@ -7984,41 +7984,41 @@ exports.restOperatorWithoutIdentifier = function (test) {
     .addError(8, 21, "Unexpected ')'.")
     .addError(9, 16, "Unexpected ']'.")
     .addError(10, 22, "Unexpected ']'.")
-    .test(code, { esnext: true });
+    .test(code, { esversion: 6 });
 
   test.done();
 };
 
 exports.getAsIdentifierProp = function (test) {
   TestRun(test)
-    .test('var get; var obj = { get };', { esnext: true });
+    .test('var get; var obj = { get };', { esversion: 6 });
 
   TestRun(test)
-    .test('var set; var obj = { set };', { esnext: true });
+    .test('var set; var obj = { set };', { esversion: 6 });
 
   TestRun(test)
-    .test('var get, set; var obj = { get, set };', { esnext: true });
+    .test('var get, set; var obj = { get, set };', { esversion: 6 });
 
   TestRun(test)
-    .test('var get, set; var obj = { set, get };', { esnext: true });
+    .test('var get, set; var obj = { set, get };', { esversion: 6 });
 
   TestRun(test)
-    .test('var get; var obj = { a: null, get };', { esnext: true });
+    .test('var get; var obj = { a: null, get };', { esversion: 6 });
 
   TestRun(test)
-    .test('var get; var obj = { a: null, get, b: null };', { esnext: true });
+    .test('var get; var obj = { a: null, get, b: null };', { esversion: 6 });
 
   TestRun(test)
-    .test('var get; var obj = { get, b: null };', { esnext: true });
+    .test('var get; var obj = { get, b: null };', { esversion: 6 });
 
   TestRun(test)
-    .test('var get; var obj = { get, get a() {} };', { esnext: true });
+    .test('var get; var obj = { get, get a() {} };', { esversion: 6 });
 
   TestRun(test)
     .test([
       'var set;',
       'var obj = { set, get a() {}, set a(_) {} };'
-    ], { esnext: true });
+    ], { esversion: 6 });
 
   test.done();
 };
@@ -8027,7 +8027,7 @@ exports.invalidParams = function (test) {
   TestRun(test)
     .addError(1, 11, "Expected an identifier and instead saw '!'.")
     .addError(1, 11, "Unrecoverable syntax error. (100% scanned).")
-    .test("(function(!", { esnext: true });
+    .test("(function(!", { esversion: 6 });
 
   test.done();
 };
@@ -8058,7 +8058,7 @@ exports.nonGeneratorAfterGenerator = function (test) {
   ];
 
   run = TestRun(test);
-  run.test(code, { esnext: true });
+  run.test(code, { esversion: 6 });
 
   test.done();
 };
@@ -8077,7 +8077,7 @@ exports["new.target"] = function (test) {
     .addError(3, 15, "'new.target' is only available in ES6 (use 'esversion: 6').")
     .test(code);
 
-  TestRun(test, "only in ES6").test(code, { esnext: true });
+  TestRun(test, "only in ES6").test(code, { esversion: 6 });
 
   var code2 = [
     "var a = new.target;",
@@ -8107,7 +8107,7 @@ exports["new.target"] = function (test) {
     .addError(1, 12, "'new.target' must be in function scope.")
     .addError(4, 15, "'new.target' must be in function scope.")
     .addError(6, 13, "'new.target' must be in function scope.")
-    .test(code2, { esnext: true });
+    .test(code2, { esversion: 6 });
 
   var code3 = [
     "var x = new.meta;"
@@ -8135,7 +8135,7 @@ exports["new.target"] = function (test) {
     .addError(5, 16, "Bad assignment.")
     .addError(6, 15, "Bad assignment.")
     .addError(7, 5, "Bad assignment.")
-    .test(code4, { esnext: true });
+    .test(code4, { esversion: 6 });
 
   test.done();
 };


### PR DESCRIPTION
When the options "es3", "es5" or "esnext" are use, emit a warning that
the option is deprecated, and that you should use "esversion: <X>"
instead.

Previously, if you used "esnext" (or other deprecated options) in
addition to "esversion", jshint would refuse to valiate your code, and
quit instantly after reporting a weird error message that doesn't really
explain the change. The new error message, and warning-rather-than-quit
behaviour, should hopefully be easier for users to digest.

(Related to discussion on #2991)