### PR TITLE
[[FIX]] Do not warn about non-ambiguous linebreaks

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -885,15 +885,6 @@ var JSHINT = (function() {
     if (state.tokens.next.id === "(end)")
       error("E006", state.tokens.curr);
 
-    var isDangerous =
-      state.option.asi &&
-      state.tokens.prev.line !== startLine(state.tokens.curr) &&
-      _.includes(["]", ")"], state.tokens.prev.id) &&
-      _.includes(["[", "("], state.tokens.curr.id);
-
-    if (isDangerous)
-      warning("W014", state.tokens.curr, state.tokens.curr.id);
-
     advance();
 
     if (initial) {
@@ -2359,6 +2350,11 @@ var JSHINT = (function() {
       warning("W062");
     }
 
+    if (state.option.asi && checkPunctuators(state.tokens.prev, [")", "]"]) &&
+      state.tokens.prev.line !== startLine(state.tokens.curr)) {
+      warning("W014", state.tokens.curr, state.tokens.curr.id);
+    }
+
     var n = 0;
     var p = [];
 
@@ -2555,8 +2551,14 @@ var JSHINT = (function() {
   application("=>");
 
   infix("[", function(left, that) {
-    var e = expression(10);
-    var s, canUseDot;
+    var e, s, canUseDot;
+
+    if (state.option.asi && checkPunctuators(state.tokens.prev, [")", "]"]) &&
+      state.tokens.prev.line !== startLine(state.tokens.curr)) {
+      warning("W014", state.tokens.curr, state.tokens.curr.id);
+    }
+
+    e = expression(10);
 
     if (e && e.type === "(string)") {
       if (!state.option.evil && (e.value === "eval" || e.value === "execScript")) {

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -631,6 +631,21 @@ exports.safeasi = function (test) {
     .addError(10, 9, "Missing semicolon.")
     .test(src, { asi: true });
 
+  var afterBracket = [
+    'x = []',
+    '[1];',
+    'x[0]',
+    '(2);'
+  ];
+
+  TestRun(test, 'following bracket (asi: false)')
+    .test(afterBracket);
+
+  TestRun(test, 'following bracket (asi: true)')
+    .addError(2, 1, "Misleading line break before '['; readers may interpret this as an expression boundary.")
+    .addError(4, 1, "Misleading line break before '('; readers may interpret this as an expression boundary.")
+    .test(afterBracket, { asi: true });
+
   test.done();
 };
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -653,7 +653,7 @@ exports.safeasi = function (test) {
     '  [x] = [0];',
     'while (false)',
     '  ({x} = {});',
-    'while (fale)',
+    'while (false)',
     '  [x] = [0];'
   ];
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -646,6 +646,24 @@ exports.safeasi = function (test) {
     .addError(4, 1, "Misleading line break before '('; readers may interpret this as an expression boundary.")
     .test(afterBracket, { asi: true });
 
+  var asClause = [
+    'if (true)',
+    '  ({x} = {});',
+    'if (true)',
+    '  [x] = [0];',
+    'while (false)',
+    '  ({x} = {});',
+    'while (fale)',
+    '  [x] = [0];'
+  ];
+
+  // Regression tests for gh-3304
+  TestRun(test, 'as clause (asi: false)')
+    .test(asClause, { esversion: 6 });
+
+  TestRun(test, 'as clause (asi: true)')
+    .test(asClause, { esversion: 6, asi: true });
+
   test.done();
 };
 


### PR DESCRIPTION
Resolve gh-3304. Commit message:

Warning W014 was implemented to alert users of potentially-confusing
formatting resulting from reliance on ASI.

The original heuristic was applied for every expression and simply
referenced token values. It assumed that when the previous token was a
closing parenthesis or bracket, this always signified a line of code
where the newline could be interpreted as a statement boundary, e.g.

    x = 3 * (2 + 1)
    [0]

However, this heuristic was susceptible to false positives, where the
closing punctuator would not be interpreted as the end of a statement:

    if (true)
      [x] = []

Re-implement the code that detects the warning condition from the
general "expression" function to the specific "infix" parsing logic
(used only when the "(" and "[" tokens have been identified as
components of an exiting expression).

(The first commit adds a few tests for existing behavior to ensure that the fix doesn't regress existing functionality.)