### PR TITLE
[[FIX]] Correct restriction on function name

### DIFF
--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -3679,17 +3679,49 @@ exports["strict violation - use of arguments and eval"] = function (test) {
   TestRun(test, "as function declaration binding (invalid)")
     .addError(1, 10, "Strict violation.")
     .addError(2, 10, "Strict violation.")
+    .addError(5, 12, "Strict violation.")
+    .addError(6, 12, "Strict violation.")
+    .addError(10, 12, "Strict violation.")
+    .addError(10, 26, "Unnecessary directive \"use strict\".")
+    .addError(11, 12, "Strict violation.")
+    .addError(11, 21, "Unnecessary directive \"use strict\".")
     .test([
       "function arguments() { 'use strict'; }",
-      "function eval() { 'use strict'; }"
+      "function eval() { 'use strict'; }",
+      "(function() {",
+      "  'use strict';",
+      "  function arguments() {}",
+      "  function eval() {}",
+      "}());",
+      "(function() {",
+      "  'use strict';",
+      "  function arguments() { 'use strict'; }",
+      "  function eval() { 'use strict'; }",
+      "}());"
     ]);
 
   TestRun(test, "as function expression binding (invalid)")
     .addError(1, 15, "Strict violation.")
     .addError(2, 15, "Strict violation.")
+    .addError(5, 17, "Strict violation.")
+    .addError(6, 17, "Strict violation.")
+    .addError(10, 17, "Strict violation.")
+    .addError(10, 31, "Unnecessary directive \"use strict\".")
+    .addError(11, 17, "Strict violation.")
+    .addError(11, 26, "Unnecessary directive \"use strict\".")
     .test([
       "void function arguments() { 'use strict'; };",
-      "void function eval() { 'use strict'; };"
+      "void function eval() { 'use strict'; };",
+      "(function() {",
+      "  'use strict';",
+      "  void function arguments() {};",
+      "  void function eval() {};",
+      "}());",
+      "(function() {",
+      "  'use strict';",
+      "  void function arguments() { 'use strict'; };",
+      "  void function eval() { 'use strict'; };",
+      "}());"
     ]);
 
   test.done();


### PR DESCRIPTION
The ECMAScript specification details the following early error for
function-defining productions:

> - If the source code matching this production is strict mode code, it
>   is a Syntax Error if BindingIdentifier is present and the
>   StringValue of BindingIdentifier is "eval" or "arguments".

There were two bugs in the original implementation of this error:

- violations from function expressions with empty bodies would not be
  detected
- violations from function declarations contained within strict mode
  code would be reported twice

Correct the first issue by ensuring that the "(isStrict)" property is
accurately set for functions with empty bodies. Correct the second issue
by re-locating the error detection logic to within the processing logic
for expressions and declarations and inserting an additional condition
within the latter.

(This correction does not require modification to the Test262 whitelist
file, although that test suite does offer coverage for this behavior. At
the revision in use by JSHint, the relevant tests are expressed using
`eval` and therefore unusable by parsers. Those tests have since been
reformatted to correct this; they will be incorporated when JSHint next
updates its reference to Test262.)