### PR TITLE
Reduce package size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: node_js
 after_success: npm run coverage && cat ./coverage/lcov.info | coveralls
+before_install:
+  # These packages cannot be installed in legacy versions of Node.js. Because
+  # they are only needed to verify correctness in a browser-like environment,
+  # they can be removed (and the tests skipped) without effecting coverage.
+  - if [[ $(node --version) != v6* ]] ; then
+      node scripts/remove-dev-dependencies.js phantom phantomjs-prebuilt;
+    fi
 script:
   - npm run pretest
   - npm run test-node

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - git submodule update --init --recursive
+  # These packages cannot be installed in legacy versions of Node.js. Because
+  # they are only needed to verify correctness in a browser-like environment,
+  # they can be removed (and the tests skipped) without effecting coverage.
+  - if NOT "%nodejs_version%" == "6" node scripts/remove-dev-dependencies.js phantom phantomjs-prebuilt
   - npm install
 
 build: off

--- a/package.json
+++ b/package.json
@@ -59,15 +59,13 @@
     "jscs": "1.11.x",
     "mock-stdin": "0.3.x",
     "nodeunit": "0.9.x",
+    "phantom": "~4.0.1",
+    "phantomjs-prebuilt": "~2.1.7",
     "regenerate": "1.2.x",
     "results-interpreter": "~1.0.0",
     "sinon": "1.12.x",
     "test262-stream": "~1.1.0",
     "unicode-11.0.0": "0.7.x"
-  },
-  "optionalDependencies": {
-    "phantom": "~4.0.1",
-    "phantomjs-prebuilt": "~2.1.7"
   },
   "license": "(MIT AND JSON)",
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "lodash": "~4.17.10",
     "minimatch": "~3.0.2",
     "shelljs": "0.3.x",
-    "strip-json-comments": "1.0.x",
-    "unicode-5.2.0": "^0.7.5"
+    "strip-json-comments": "1.0.x"
   },
   "devDependencies": {
     "async": "~2.1.2",
@@ -65,6 +64,7 @@
     "results-interpreter": "~1.0.0",
     "sinon": "1.12.x",
     "test262-stream": "~1.1.0",
+    "unicode-5.2.0": "^0.7.5",
     "unicode-11.0.0": "0.7.x"
   },
   "license": "(MIT AND JSON)",

--- a/scripts/generate-identifier-data.js
+++ b/scripts/generate-identifier-data.js
@@ -4,10 +4,7 @@
 
 var regenerate = require('regenerate');
 
-// Which Unicode version should be used?
-var pkg = require('../package.json');
-var dependencies = Object.keys(pkg.devDependencies);
-var unicodeVersion = dependencies.find((name) => /^unicode-\d/.test(name));
+var unicodeVersion = 'unicode-11.0.0';
 var oldUnicodeVersion = 'unicode-5.2.0';
 
 // Shorthand functions.

--- a/scripts/remove-dev-dependencies.js
+++ b/scripts/remove-dev-dependencies.js
@@ -1,0 +1,37 @@
+"use strict"
+/**
+ * Some of this project's development dependencies cannot be successfully
+ * installed in legacy versions of Node.js. This module removes development
+ * dependencies from the project's npm package manifest so that the `npm`
+ * utility does not attempt to install them in a subsequent execution of `npm
+ * install. Although the `npm` utility offers a "remove" command, that command
+ * can remove only one package per invocation and triggers installation of all
+ * other packages. This script allows mutliple packages to be removed prior to
+ * installation.
+ */
+
+var path = require("path");
+var fs = require("fs");
+var manifestLocation = path.join(__dirname, "..", "package.json");
+var manifest = require(manifestLocation);
+var packageNames = process.argv.slice(2);
+var newContents;
+
+packageNames.forEach(function(packageName) {
+  if (!manifest.devDependencies[packageName]) {
+    throw new Error("Could not locate development dependency named \"" + packageName + "\"");
+  }
+
+  delete manifest.devDependencies[packageName];
+});
+
+newContents = JSON.stringify(manifest, null, 2);
+
+fs.writeFile(manifestLocation, newContents, function(err) {
+  if (err) {
+    throw new Error(err);
+  }
+
+  console.log("Successfully removed packages. New contents:");
+  console.log(newContents.replace(/(^|\n)/g, "$1> "));
+});


### PR DESCRIPTION
We've received a couple reports (gh-3316 and gh-3318) that the installation size of JSHint increased drastically in the recently-released version 2.9.6.  This is easily verified using npm's `--production` flag:

    mkdir nodemods
    git checkout 2.9.5
    npm install --production
    mv node_modules nodemods/2.9.5
    git checkout -- package.json
    git checkout 2.9.6
    npm install --production
    mv node_modules nodemods/2.9.6
    du -h -d 0 nodemods/*

Output:

    9.9M    nodemods/2.9.5
    277M    nodemods/2.9.6

Two independent commits contributed to this 20-fold increase in side. This patch addresses each of them in turn. You can verify using the same technique:

    git checkout shrink-deps~
    npm install --production
    mv node_modules nodemods/2.9.6-phantom
    git checkout -- package.json
    git checkout shrink-deps
    npm install --production
    mv node_modules nodemods/2.9.6-phantom-unicode
    du -h -d 0 nodemods/*

Output:

    9.9M    nodemods/2.9.5
    277M    nodemods/2.9.6
    149M    nodemods/2.9.6-phantom
    18M     nodemods/2.9.6-phantom-unicode

The final size is still twice that of the prior release, but that is due to the upgrade to Lodash 4 (gh-3260 and gh-3283).

    9.9M    nodemods/2.9.6-phantom-unicode-lodash

Since that was motivated by security concerns, I'm more willing to accept the size increase. If this continues to be a concern for our consumers, we can consider instead relying on Lodash's sub-components.

Also of interest: the `remove-dev-dependencies.js` introduced here is not technically necessary on TravisCI because JSHint can now be successfully be installed in TravisCI on Node 0.8 and 0.10. That's surprising because this was all motivated by failures in TravisCI back in November. At first, I thought that maybe the maintainers of `requests` had changed their tune, but [no such luck](https://github.com/request/request/issues/2772). TravisCI now pre-installs PhantomJS, so the offending ES2015 code (used to fetch the binary) is no longer evaluated on any GNU/Linux build. However, we're not so lucky in the AppVeyor-provided Windows environment (and even if we were, we probably shouldn't rely on implicit aspects of the build environments). That's why I've written a script to manually remove the offending packages prior to installation in CI.

I'd like to release a new version (i.e. 2.9.7) for this changeset so that we can help our consumers avoid the inefficiency as soon as possible.