### PR TITLE
Honor `globals` config in JavaScript API

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -5324,8 +5324,6 @@ var JSHINT = (function() {
     combine(predefined, vars.ecmaIdentifiers[3]);
     combine(predefined, vars.reservedVars);
 
-    combine(predefined, g || {});
-
     declared = Object.create(null);
     var exported = Object.create(null); // Variables that live outside the current file
 

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -5338,18 +5338,21 @@ var JSHINT = (function() {
     }
 
     if (o) {
-      each(o.predef || null, function(item) {
-        var slice, prop;
 
-        if (item[0] === "-") {
-          slice = item.slice(1);
-          JSHINT.blacklist[slice] = slice;
-          // remove from predefined if there
-          delete predefined[slice];
-        } else {
-          prop = Object.getOwnPropertyDescriptor(o.predef, item);
-          predefined[item] = prop ? prop.value : false;
-        }
+      each([o.predef, o.globals], function(dict) {
+        each(dict, function(item) {
+          var slice, prop;
+
+          if (item[0] === "-") {
+            slice = item.slice(1);
+            JSHINT.blacklist[slice] = slice;
+            // remove from predefined if there
+            delete predefined[slice];
+          } else {
+            prop = Object.getOwnPropertyDescriptor(dict, item);
+            predefined[item] = prop ? prop.value : false;
+          }
+        });
       });
 
       each(o.exported || null, function(item) {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -38,6 +38,33 @@ exports.testCustomGlobals = function (test) {
     .addError(3, 1, "Read only.")
     .test(code, { es3: true, unused: true, predef: { foo: false }});
 
+  JSHINT("x = null;", { undef: true, globals: { x: true } });
+
+  test.ok(!JSHINT.data().errors);
+
+  JSHINT("x = null;", { undef: true, globals: { x: false } });
+
+  test.equal(JSHINT.data().errors.length, 1);
+
+  JSHINT("parseInt('');", { undef: true, globals: { "-parseInt": true } });
+
+  test.equal(JSHINT.data().errors.length, 1);
+
+  JSHINT('x = null;', { undef: true, globals: { x: false } }, { x: true });
+
+  test.ok(
+    !JSHINT.data().errors,
+    "`predef` parameter takes precedence over `globals` option"
+  );
+
+  JSHINT("x = null;", { undef: true, globals: { x: true } }, { x: false });
+
+  test.equal(
+    JSHINT.data().errors.length,
+    1,
+    "`predef` parameter takes precedence over `globals` option"
+  );
+
   test.done();
 };
 


### PR DESCRIPTION
- [[CHORE]] Remove superfluous statement
- [[FIX]] Honor `globals` config in JavaScript API

  Prior to this commit, the `globals` configuration value was not
  considered for invocations of the JavaScript API. Ensure that option is
  consistently interpreted according to the project documentation. Ensure
  that globals defined by the more specific `predef` option of the API
  take precedence over globals defined using this configuration option.

(Owing to a change in indentation, this changeset is best reviewed with git's `-w` flag.)

This should resolve gh-3321