### PR TITLE
Add support for typeof bigint === "bigint". Fixes #3331

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1227,7 +1227,7 @@ var JSHINT = (function() {
     "undefined", "boolean", "number", "string", "function", "object",
   ];
   typeofValues.es3 = typeofValues.es3.concat(typeofValues.legacy);
-  typeofValues.es6 = typeofValues.es3.concat("symbol");
+  typeofValues.es6 = typeofValues.es3.concat("symbol", "bigint");
 
   // Checks whether the 'typeof' operator is used with the correct
   // value. For docs on 'typeof' see:

--- a/tests/unit/fixtures/typeofcomp.js
+++ b/tests/unit/fixtures/typeofcomp.js
@@ -11,6 +11,7 @@ if (typeof func === 'string') {}
 if (typeof func === 'function') {}
 if (typeof func === 'unknown') {}
 if (typeof func === 'symbol') {}
+if (typeof func === 'bigint') {}
 if (typeof func === "xml") {}
 if (typeof func === "object") {}
 if ("undefined" === typeof func) {}

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -311,6 +311,7 @@ exports.notypeof = function (test) {
     .addError(3, 17, "Invalid typeof value 'bool'")
     .addError(4, 11, "Invalid typeof value 'obj'")
     .addError(13, 17, "Invalid typeof value 'symbol'")
+    .addError(14, 17, "Invalid typeof value 'bigint'")
     .test(src);
 
   TestRun(test)


### PR DESCRIPTION
Limitation: This PR fixes `Invalid typeof value 'bigint'`, but does NOT support `BigInt64Array` nor `BigUint64Array` still.

```
$ echo 'var a = "bigint" === typeof {};' | node bin/jshint -
stdin: line 1, col 18, Invalid typeof value 'bigint'
1 error

$ echo '/* jshint esnext: true */ var a = "bigint" === typeof {};' | node bin/jshint - && echo OK
OK
```