### PR TITLE
[[FIX]] Use relative paths with `--filename` when recieving from stdin

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -611,15 +611,24 @@ var exports = {
     }
 
     var filename;
+    var lintStdinFile;
 
     // There is an if(filename) check in the lint() function called below.
     // passing a filename of undefined is the same as calling the function
     // without a filename.  If there is no opts.filename, filename remains
     // undefined and lint() is effectively called with 4 parameters.
     if (opts.filename) {
-      filename = path.resolve(opts.filename);
+      filename = opts.filename;
+      var ignores = !opts.ignores ? loadIgnores({ cwd: opts.cwd }) :
+                                  opts.ignores.map(function(target) {
+                                    return path.resolve(target);
+                                  });
+      lintStdinFile = (opts.useStdin && !isIgnored(filename, ignores));
+    } else {
+      lintStdinFile = opts.useStdin;
     }
-    if (opts.useStdin && opts.ignores.indexOf(filename) === -1) {
+
+    if (lintStdinFile) {
       cli.withStdin(function(code) {
         var config = opts.config;
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -303,7 +303,7 @@ exports.group = {
     cli.interpret([
       "node", "jshint", "bar.js", "--config", "config.json", "--reporter", "reporter.js"
     ]);
-    test.ok(rep.reporter.args[1][0].length > 0, "Error was expected but not thrown");
+    test.ok(rep.reporter.args[1][0].length === 1, "Error was expected but not thrown");
     test.equal(rep.reporter.args[1][0][0].error.code, "W033");
 
     test.done();
@@ -348,7 +348,7 @@ exports.group = {
     cli.interpret([
       "node", "jshint", "src/bar.js", "--config", "config.json", "--reporter", "reporter.js"
     ]);
-    test.ok(rep.reporter.args[1][0].length > 0, "Error was expected but not thrown");
+    test.ok(rep.reporter.args[1][0].length === 1, "Error was expected but not thrown");
     test.equal(rep.reporter.args[1][0][0].error.code, "W033");
 
     test.done();
@@ -393,7 +393,7 @@ exports.group = {
     cli.interpret([
       "node", "jshint", "./src/bar.js", "--config", "config.json", "--reporter", "reporter.js"
     ]);
-    test.ok(rep.reporter.args[1][0].length > 0, "Error was expected but not thrown");
+    test.ok(rep.reporter.args[1][0].length === 1, "Error was expected but not thrown");
     test.equal(rep.reporter.args[1][0][0].error.code, "W033");
 
     test.done();
@@ -1522,7 +1522,7 @@ exports.useStdin = {
       ]);
       this.stdin.send("a()");
       this.stdin.end();
-      test.ok(this.rep.reporter.args[0][0].length > 0, "Error was expected but not thrown");
+      test.ok(this.rep.reporter.args[0][0].length === 1, "Error was expected but not thrown");
       test.equal(this.rep.reporter.args[0][0][0].error.code, "W033");
 
       test.done();
@@ -1577,7 +1577,7 @@ exports.useStdin = {
       ]);
       this.stdin.send("a()");
       this.stdin.end();
-      test.ok(this.rep.reporter.args[0][0].length > 0, "Error was expected but not thrown");
+      test.ok(this.rep.reporter.args[0][0].length === 1, "Error was expected but not thrown");
       test.equal(this.rep.reporter.args[0][0][0].error.code, "W033");
 
       test.done();
@@ -1632,7 +1632,7 @@ exports.useStdin = {
       ]);
       this.stdin.send("a()");
       this.stdin.end();
-      test.ok(this.rep.reporter.args[0][0].length > 0, "Error was expected but not thrown");
+      test.ok(this.rep.reporter.args[0][0].length === 1, "Error was expected but not thrown");
       test.equal(this.rep.reporter.args[0][0][0].error.code, "W033");
 
       test.done();

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1476,142 +1476,166 @@ exports.useStdin = {
   },
 
   // Overrides should work when the passed stdin filename is in the current directoy
-  testOverridesFromStdin: function (test) {
-    var dir = __dirname + "/../examples/";
-    var rep = require("../examples/reporter.js");
-    var config = {
-      "asi": true,
-      "overrides": {
-        "bar.js": {
-          "asi": false
+  testOverridesFromStdin: {
+    setUp: function(done) {
+      var dir = __dirname + "/../examples/";
+      this.rep = require("../examples/reporter.js");
+      var config = {
+        "asi": true,
+        "overrides": {
+          "bar.js": {
+            "asi": false
+          }
         }
-      }
-    };
+      };
 
-    this.sinon.stub(process, "cwd").returns(dir);
-    this.sinon.stub(rep, "reporter");
-    this.sinon.stub(shjs, "cat")
-      .withArgs(sinon.match(/config\.json$/))
-        .returns(JSON.stringify(config));
+      this.sinon.stub(process, "cwd").returns(dir);
+      this.sinon.stub(this.rep, "reporter");
+      this.sinon.stub(shjs, "cat")
+        .withArgs(sinon.match(/config\.json$/))
+          .returns(JSON.stringify(config));
 
-    this.sinon.stub(shjs, "test")
-      .withArgs("-e", sinon.match(/config\.json$/)).returns(true);
+      this.sinon.stub(shjs, "test")
+        .withArgs("-e", sinon.match(/config\.json$/)).returns(true);
 
-    cli.exit.withArgs(0).returns(true)
-      .withArgs(1).throws("ProcessExit");
+      cli.exit.withArgs(0).returns(true)
+        .withArgs(1).throws("ProcessExit");
+
+      done();
+    },
 
     // Test successful file
-    cli.interpret([
-      "node", "jshint", "--filename", "foo.js", "--config", "config.json", "--reporter", "reporter.js", "-"
-    ]);
-    this.stdin.send("a()");
-    this.stdin.end();
-    this.stdin.reset(true);
-    test.ok(rep.reporter.args[0][0].length === 0);
+    success: function(test) {
+      cli.interpret([
+        "node", "jshint", "--filename", "foo.js", "--config", "config.json", "--reporter", "reporter.js", "-"
+      ]);
+      this.stdin.send("a()");
+      this.stdin.end();
+      test.ok(this.rep.reporter.args[0][0].length === 0);
+      test.done();
+    },
 
     // Test overriden, failed file
-    cli.interpret([
-      "node", "jshint", "--filename", "bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"
-    ]);
-    this.stdin.send("a()");
-    this.stdin.end();
-    test.ok(rep.reporter.args[1][0].length > 0, "Error was expected but not thrown");
-    test.equal(rep.reporter.args[1][0][0].error.code, "W033");
+    failure: function(test) {
+      cli.interpret([
+        "node", "jshint", "--filename", "bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"
+      ]);
+      this.stdin.send("a()");
+      this.stdin.end();
+      test.ok(this.rep.reporter.args[0][0].length > 0, "Error was expected but not thrown");
+      test.equal(this.rep.reporter.args[0][0][0].error.code, "W033");
 
-    test.done();
-   },
+      test.done();
+    }
+  },
 
   // Override behaviour for implicit relative paths (without a leading ./) should be the same
   // for stdin as for file
-  testOverridesMatchesImplicitRelativePathsFromStdin: function (test) {
-    var dir = __dirname + "/../examples/";
-    var rep = require("../examples/reporter.js");
-    var config = {
-      "asi": true,
-      "overrides": {
-        "src/bar.js": {
-          "asi": false
+  testOverridesMatchesImplicitRelativePathsFromStdin: {
+    setUp: function (done) {
+      var dir = __dirname + "/../examples/";
+      this.rep = require("../examples/reporter.js");
+      var config = {
+        "asi": true,
+        "overrides": {
+          "src/bar.js": {
+            "asi": false
+          }
         }
-      }
-    };
+      };
 
-    this.sinon.stub(process, "cwd").returns(dir);
-    this.sinon.stub(rep, "reporter");
-    this.sinon.stub(shjs, "cat")
-      .withArgs(sinon.match(/config\.json$/))
-        .returns(JSON.stringify(config));
+      this.sinon.stub(process, "cwd").returns(dir);
+      this.sinon.stub(this.rep, "reporter");
+      this.sinon.stub(shjs, "cat")
+        .withArgs(sinon.match(/config\.json$/))
+          .returns(JSON.stringify(config));
 
-    this.sinon.stub(shjs, "test")
-      .withArgs("-e", sinon.match(/config\.json$/)).returns(true);
+      this.sinon.stub(shjs, "test")
+        .withArgs("-e", sinon.match(/config\.json$/)).returns(true);
 
-    cli.exit.withArgs(0).returns(true)
-      .withArgs(1).throws("ProcessExit");
+      cli.exit.withArgs(0).returns(true)
+        .withArgs(1).throws("ProcessExit");
+
+      done();
+    },
 
     // Test successful file
-    cli.interpret([
-      "node", "jshint", "--filename", "src/foo.js", "--config", "config.json", "--reporter", "reporter.js", "-"
-    ]);
-    this.stdin.send("a()");
-    this.stdin.end();
-    this.stdin.reset(true);
-    test.ok(rep.reporter.args[0][0].length === 0);
+    success: function(test) {
+      cli.interpret([
+        "node", "jshint", "--filename", "src/foo.js", "--config", "config.json", "--reporter", "reporter.js", "-"
+      ]);
+      this.stdin.send("a()");
+      this.stdin.end();
+      test.ok(this.rep.reporter.args[0][0].length === 0);
+      test.done();
+    },
 
     // Test overriden, failed file
-    cli.interpret([
-      "node", "jshint", "--filename", "src/bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"
-    ]);
-    this.stdin.send("a()");
-    this.stdin.end();
-    test.ok(rep.reporter.args[1][0].length > 0, "Error was expected but not thrown");
-    test.equal(rep.reporter.args[1][0][0].error.code, "W033");
+    failure: function(test) {
+      cli.interpret([
+        "node", "jshint", "--filename", "src/bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"
+      ]);
+      this.stdin.send("a()");
+      this.stdin.end();
+      test.ok(this.rep.reporter.args[0][0].length > 0, "Error was expected but not thrown");
+      test.equal(this.rep.reporter.args[0][0][0].error.code, "W033");
 
-    test.done();
+      test.done();
+    }
   },
 
   // Override behaviour for explicit relative paths (with a leading ./) should be the same
   // for stdin as for file
-  testOverridesMatchesExplicitRelativePathsFromStdin: function (test) {
-    var dir = __dirname + "/../examples/";
-    var rep = require("../examples/reporter.js");
-    var config = {
-      "asi": true,
-      "overrides": {
-        "src/bar.js": {
-          "asi": false
+  testOverridesMatchesExplicitRelativePathsFromStdin: {
+    setUp: function(done) {
+      var dir = __dirname + "/../examples/";
+      this.rep = require("../examples/reporter.js");
+      var config = {
+        "asi": true,
+        "overrides": {
+          "src/bar.js": {
+            "asi": false
+          }
         }
-      }
-    };
+      };
 
-    this.sinon.stub(process, "cwd").returns(dir);
-    this.sinon.stub(rep, "reporter");
-    this.sinon.stub(shjs, "cat")
-      .withArgs(sinon.match(/config\.json$/))
-        .returns(JSON.stringify(config));
+      this.sinon.stub(process, "cwd").returns(dir);
+      this.sinon.stub(this.rep, "reporter");
+      this.sinon.stub(shjs, "cat")
+        .withArgs(sinon.match(/config\.json$/))
+          .returns(JSON.stringify(config));
 
-    this.sinon.stub(shjs, "test")
-      .withArgs("-e", sinon.match(/config\.json$/)).returns(true);
+      this.sinon.stub(shjs, "test")
+        .withArgs("-e", sinon.match(/config\.json$/)).returns(true);
 
-    cli.exit.withArgs(0).returns(true)
-      .withArgs(1).throws("ProcessExit");
+      cli.exit.withArgs(0).returns(true)
+        .withArgs(1).throws("ProcessExit");
+
+      done();
+    },
 
     // Test successful file
-    cli.interpret([
-      "node", "jshint", "--filename", "./src/foo.js", "--config", "config.json", "--reporter", "reporter.js", "-"
-    ]);
-    this.stdin.send("a()");
-    this.stdin.end();
-    this.stdin.reset(true);
-    test.ok(rep.reporter.args[0][0].length === 0);
+    success: function(test) {
+      cli.interpret([
+        "node", "jshint", "--filename", "./src/foo.js", "--config", "config.json", "--reporter", "reporter.js", "-"
+      ]);
+      this.stdin.send("a()");
+      this.stdin.end();
+      test.ok(this.rep.reporter.args[0][0].length === 0);
+      test.done();
+    },
 
     // Test overriden, failed file
-    cli.interpret([
-      "node", "jshint", "--filename", "./src/bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"
-    ]);
-    this.stdin.send("a()");
-    this.stdin.end();
-    test.ok(rep.reporter.args[1][0].length > 0, "Error was expected but not thrown");
-    test.equal(rep.reporter.args[1][0][0].error.code, "W033");
+    failure: function(test) {
+      cli.interpret([
+        "node", "jshint", "--filename", "./src/bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"
+      ]);
+      this.stdin.send("a()");
+      this.stdin.end();
+      test.ok(this.rep.reporter.args[0][0].length > 0, "Error was expected but not thrown");
+      test.equal(this.rep.reporter.args[0][0][0].error.code, "W033");
 
-    test.done();
+      test.done();
+    }
   }
 };

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -323,21 +323,31 @@ exports.group = {
     this.sinon.stub(process, "cwd").returns(dir);
     this.sinon.stub(rep, "reporter");
     this.sinon.stub(shjs, "cat")
+      .withArgs(sinon.match(/foo\.js$/)).returns("a()")
       .withArgs(sinon.match(/bar\.js$/)).returns("a()")
       .withArgs(sinon.match(/config\.json$/))
         .returns(JSON.stringify(config));
 
     this.sinon.stub(shjs, "test")
+      .withArgs("-e", sinon.match(/foo\.js$/)).returns(true)
       .withArgs("-e", sinon.match(/bar\.js$/)).returns(true)
       .withArgs("-e", sinon.match(/config\.json$/)).returns(true);
 
     cli.exit.withArgs(0).returns(true)
       .withArgs(1).throws("ProcessExit");
 
+    // Test successful file
+    cli.interpret([
+      "node", "jshint", "./src/foo.js", "--config", "config.json", "--reporter", "reporter.js"
+    ]);
+    test.ok(rep.reporter.args[0][0].length === 0);
+
+    // Test overriden, failed file
     cli.interpret([
       "node", "jshint", "./src/bar.js", "--config", "config.json", "--reporter", "reporter.js"
     ]);
-    test.ok(rep.reporter.args[0][0].length === 1);
+    test.ok(rep.reporter.args[1][0].length > 0, "Error was expected but not thrown");
+    test.equal(rep.reporter.args[1][0][0].error.code, "W033");
 
     test.done();
   },


### PR DESCRIPTION
When linting stdin with the `--filename` option set, config overrides
that were relative to the current directory had no effect. This fixes that
issue, but existing workarounds will still work.

Fixes 2536 (Extra comment at the bottom)

This has been live-tested to fixup the issue identified in the test repo at https://github.com/bostrom/jshint-filename-test.