### PR TITLE
[[FIX]] Enforce UniqueFormalParameters for methods

### DIFF
--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -551,6 +551,10 @@ var scopeManager = function(state, predefined, exported, declared) {
       // >   FormalParameterList is false and BoundNames of FormalParameterList
       // >   contains any duplicate elements.
       var isSimple = state.funct['(hasSimpleParams)'];
+      // Method definitions are defined in terms of UniqueFormalParameters, so
+      // they cannot support duplicate parameter names regardless of strict
+      // mode.
+      var isMethod = state.funct["(method)"];
 
       if (!currentFunctParamScope["(params)"]) {
         return;
@@ -560,7 +564,7 @@ var scopeManager = function(state, predefined, exported, declared) {
         var label = currentFunctParamScope["(labels)"][labelName];
 
         if (label.duplicated) {
-          if (isStrict || isArrow || !isSimple) {
+          if (isStrict || isArrow || isMethod || !isSimple) {
             warning("E011", label["(token)"], labelName);
           } else if (state.option.shadow !== true) {
             warning("W004", label["(token)"], labelName);

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -6105,6 +6105,18 @@ conciseMethods.nameIsNotLocalVar = function (test) {
   test.done();
 };
 
+conciseMethods.uniqueFormalParameters = function (test) {
+  TestRun(test, "adjacent")
+    .addError(1, 15, "'a' has already been declared.")
+    .test("void { method(a, a) {} };", { esversion: 6 });
+
+  TestRun(test, "separated")
+    .addError(1, 15, "'b' has already been declared.")
+    .test("void { method(b, c, b) {} };", { esversion: 6 });
+
+  test.done();
+};
+
 exports["object short notation: basic"] = function (test) {
   var code = [
     "var foo = 42;",
@@ -6608,6 +6620,18 @@ exports["computed class methods aren't duplicate"] = function (test) {
   // JSHint shouldn't throw a "Duplicate class method" warning with computed method names
   // GH-2350
   TestRun(test).test(code, { esnext: true });
+
+  test.done();
+};
+
+exports["class method UniqueFormalParameters"] = function (test) {
+  TestRun(test, "adjacent")
+    .addError(1, 18, "'a' has already been declared.")
+    .test("class C { method(a, a) {} }", { esversion: 6 });
+
+  TestRun(test, "separated")
+    .addError(1, 18, "'b' has already been declared.")
+    .test("class C { method(b, c, b) {} }", { esversion: 6 });
 
   test.done();
 };


### PR DESCRIPTION
That this correction does not require a modification to the Test262
expectations file is an indication of missing coverage in that project.
New tests have been submitted there, as well [1].

[1] https://github.com/tc39/test262/pull/2043