### PR TITLE
[[FEAT]] Implement `regexpu` option

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -236,6 +236,15 @@ var JSHINT = (function() {
       }
     }
 
+    if (state.option.regexpu) {
+      /**
+       * TODO: Extend this restriction to *all* ES6-specific options.
+       */
+      if (!state.inES6()) {
+        warning("W134", state.tokens.next, "regexpu", 6);
+      }
+    }
+
     if (state.option.couch) {
       combine(predefined, vars.couch);
     }

--- a/src/lex.js
+++ b/src/lex.js
@@ -1717,6 +1717,14 @@ Lexer.prototype = {
       index += 1;
     }
 
+    if (flags.indexOf("u") === -1) {
+      this.triggerAsync("warning", {
+        code: "W146",
+        line: this.line,
+        character: this.char
+      }, checks, function() { return state.option.regexpu; });
+    }
+
     // Check regular expression for correctness.
 
     try {

--- a/src/messages.js
+++ b/src/messages.js
@@ -236,7 +236,8 @@ var warnings = {
   W143: "Assignment to properties of a mapped arguments object may cause " +
     "unexpected changes to formal parameters.",
   W144: "'{a}' is a non-standard language feature. Enable it using the '{b}' unstable option.",
-  W145: "Superfluous 'case' clause."
+  W145: "Superfluous 'case' clause.",
+  W146: "Regular expressions should include the 'u' flag."
 };
 
 var info = {

--- a/src/options.js
+++ b/src/options.js
@@ -208,6 +208,15 @@ exports.bool = {
     nonew       : true,
 
     /**
+     * This option enables warnings for regular expressions which do not
+     * include the "u" flag. The "u" flag extends support for Unicode and also
+     * enables more strict parsing rules. JSHint will enforce these rules even
+     * if it is executed in a JavaScript engine which does not support the "u"
+     * flag.
+     */
+    regexpu     : true,
+
+    /**
      * This option prohibits the use of explicitly undeclared variables. This
      * option is very useful for spotting leaking and mistyped variables.
      *
@@ -1075,5 +1084,6 @@ exports.removed = {
 // `enforceall`.
 exports.noenforceall = {
   varstmt: true,
-  strict: true
+  strict: true,
+  regexpu: true
 };

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2788,6 +2788,9 @@ exports.enforceall = function (test) {
   TestRun(test)
     .test(src, { enforceall: true, nonbsp: false, bitwise: false, sub: true, undef: false, unused: false, asi:true });
 
+  TestRun(test, "Does not enable 'regexpu'.")
+    .test('void /./;', { enforceall: true });
+
   test.done();
 };
 
@@ -4358,6 +4361,50 @@ exports.leanswitch = function (test) {
   TestRun(test, "non-empty default clause followed by case")
     .addError(3, 11, "Expected a 'break' statement before 'case'.")
     .test(code, { leanswitch: true });
+
+  test.done();
+};
+
+exports.regexpu = function (test) {
+  TestRun(test, "restricted outside of ES6 - via API")
+    .addError(0, 0, "The 'regexpu' option is only available when linting ECMAScript 6 code.")
+    .test("void 0;", { regexpu: true })
+
+  TestRun(test, "restricted outside of ES6 - via directive")
+    .addError(1, 1, "The 'regexpu' option is only available when linting ECMAScript 6 code.")
+    .test([
+      "// jshint regexpu: true",
+      "void 0;"
+    ]);
+
+  TestRun(test, "missing")
+    .addError(1, 6, "Regular expressions should include the 'u' flag.")
+    .addError(2, 6, "Regular expressions should include the 'u' flag.")
+    .addError(3, 6, "Regular expressions should include the 'u' flag.")
+    .test([
+      "void /./;",
+      "void /./g;",
+      "void /./giym;",
+    ], { regexpu: true, esversion: 6 });
+
+  TestRun(test, "in use")
+    .test([
+      "void /./u;",
+      "void /./ugiym;",
+      "void /./guiym;",
+      "void /./giuym;",
+      "void /./giyum;",
+      "void /./giymu;"
+    ], { esversion: 6 });
+
+  TestRun(test, "missing - option set when parsing precedes option enablement")
+    .addError(3, 8, "Regular expressions should include the 'u' flag.")
+    .test([
+      "(function() {",
+      "  // jshint regexpu: true",
+      "  void /./;",
+      "}());"
+    ], { esversion: 6 });
 
   test.done();
 };


### PR DESCRIPTION
@caitp thought you might be interested in this since it's in a similar vein to [the `varstatement` option you implemented](https://github.com/jshint/jshint/pull/2234). It could probably use a better name, though.