### PR TITLE
[[FIX]] Correct parsing of RegExp character sets

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -1582,6 +1582,11 @@ Lexer.prototype = {
         continue;
       }
 
+      if (isCharSet) {
+        index += 1;
+        continue;
+      }
+
       if (char === "{" && !hasInvalidQuantifier) {
         hasInvalidQuantifier = !checkQuantifier();
       }

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -866,6 +866,12 @@ exports.regexp.regressions = function (test) {
   TestRun(test).test("var exp = /\\[\\]/;", {esnext: true});
   TestRun(test).test("var exp = /\\[\\]/;", {moz: true});
 
+  // GH-3356
+  TestRun(test).test("void /[/]/;");
+  TestRun(test).test("void /[{]/u;", {esversion: 6});
+  TestRun(test).test("void /[(?=)*]/u;", {esversion: 6});
+  TestRun(test).test("void /[(?!)+]/u;", {esversion: 6});
+
   test.done();
 };
 


### PR DESCRIPTION
Do not interpret RegExp syntax characters using their specialized
semantics when they appear within a character set.

This is intended to resolve gh-3356