### PR TITLE
[[FIX]] Warn on reassignment of async functions

### DIFF
--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -345,7 +345,7 @@ var scopeManager = function(state, predefined, exported, declared) {
 
           isFunction = usedLabelType === "function" ||
             usedLabelType === "generator function" ||
-            usedLabelType === "async fuction";
+            usedLabelType === "async function";
 
           // check for re-assigning a function declaration
           if ((isFunction || usedLabelType === "class") && usage["(reassigned)"]) {

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -6992,6 +6992,20 @@ exports.functionReassignment = function (test) {
     .addError(10, 3, "Reassignment of 'h', which is a function. Use 'var' or 'let' to declare bindings that may change.")
     .test(src);
 
+  TestRun(test, "generator functions")
+    .addError(2, 1, "Reassignment of 'g', which is a generator function. Use 'var' or 'let' to declare bindings that may change.")
+    .test([
+      "function * g () { yield; }",
+      "g = null;"
+    ], { esversion: 6 });
+
+  TestRun(test, "async functions")
+    .addError(2, 1, "Reassignment of 'a', which is a async function. Use 'var' or 'let' to declare bindings that may change.")
+    .test([
+      "async function a () {}",
+      "a = null;"
+    ], { esversion: 8 });
+
   test.done();
 };
 


### PR DESCRIPTION
Correct typo to promote consistency in enforcement of linting rule.

---

@rwaldron since the typo shipped in version 2.10.0, fixing it is technically a breaking change. However, I think this is pretty unambiguously a bug fix, so waiting for the next major doesn't seem appropriate. What do you think?