### PR TITLE
[[FIX]] Track FutureReservedWords as idnts in ES5+

### DIFF
--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -624,8 +624,6 @@ exports.testReserved = function (test) {
 
   TestRun(test)
     .addError(1, 1, "Expected an identifier and instead saw 'volatile' (a reserved word).")
-    .addError(5, 5, "Expected an identifier and instead saw 'let' (a reserved word).")
-    .addError(10, 7, "Expected an identifier and instead saw 'let' (a reserved word).")
     .addError(13, 13, "Expected an identifier and instead saw 'class' (a reserved word).")
     .addError(14, 5, "Expected an identifier and instead saw 'else' (a reserved word).")
     .addError(15, 5, "Expected an identifier and instead saw 'protected' (a reserved word).")

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -1020,6 +1020,40 @@ exports.unused.basic = function (test) {
   test.done();
 };
 
+// Regression test for gh-3362
+exports.unused.es3Reserved = function (test) {
+  TestRun(test)
+    .addError(1, 5, "'abstract' is defined but never used.")
+    .addError(1, 15, "'boolean' is defined but never used.")
+    .addError(1, 24, "'byte' is defined but never used.")
+    .addError(1, 30, "'char' is defined but never used.")
+    .addError(1, 36, "'double' is defined but never used.")
+    .addError(1, 44, "'final' is defined but never used.")
+    .addError(1, 51, "'float' is defined but never used.")
+    .addError(1, 58, "'goto' is defined but never used.")
+    .addError(1, 64, "'int' is defined but never used.")
+    .addError(2, 5, "'long' is defined but never used.")
+    .addError(2, 11, "'native' is defined but never used.")
+    .addError(2, 19, "'short' is defined but never used.")
+    .addError(2, 26, "'synchronized' is defined but never used.")
+    .addError(2, 40, "'transient' is defined but never used.")
+    .addError(2, 51, "'volatile' is defined but never used.")
+    .test([
+      "var abstract, boolean, byte, char, double, final, float, goto, int;",
+      "var long, native, short, synchronized, transient, volatile;",
+    ], {unused: true});
+
+  TestRun(test)
+    .test([
+      "var abstract, boolean, byte, char, double, final, float, goto, int;",
+      "var long, native, short, synchronized, transient, volatile;",
+      "void (abstract + boolean + byte + char + double + final + float + loat + goto + int);",
+      "void (long + native + short + synchronized + transient + volatile);"
+    ], {unused: true});
+
+  test.done();
+};
+
 // Regression test for gh-2784
 exports.unused.usedThroughShadowedDeclaration = function (test) {
   var code = [
@@ -4087,6 +4121,7 @@ exports.module.await = function(test) {
 
   TestRun(test)
     .addError(1, 1, "Expected an assignment or function call and instead saw an expression.")
+    .addError(1, 1, "Expected an identifier and instead saw 'await' (a reserved word).")
     .addError(1, 6, "Missing semicolon.")
     .addError(1, 1, "Unrecoverable syntax error. (100% scanned).")
     .test("await: while (false) {}", { esversion: 6, module: true });

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -6577,6 +6577,8 @@ exports.classes = function (test) {
     .addError(cexpr + 3, 20, "Expected an identifier and instead saw 'protected' (a reserved word).")
     .addError(cdecl + 4, 15, "Expected an identifier and instead saw 'package' (a reserved word).")
     .addError(cexpr + 4, 15, "Expected an identifier and instead saw 'package' (a reserved word).")
+    .addError(cdecl + 6, 20, "Expected an identifier and instead saw 'interface' (a reserved word).")
+    .addError(cexpr + 6, 27, "Expected an identifier and instead saw 'interface' (a reserved word).")
     .addError(cdeclAssn + 4, 21, "Reassignment of 'Foo15', which is a class. Use 'var' or 'let' to declare bindings that may change.")
     .addError(cdeclAssn + 7, 21, "Reassignment of 'Foo18', which is a class. Use 'var' or 'let' to declare bindings that may change.")
     .addError(cdeclAssn + 7, 43, "Reassignment of 'Foo17', which is a class. Use 'var' or 'let' to declare bindings that may change.")


### PR DESCRIPTION
ES5 allowed a number identifiers which were previously classified as
FutureReserve to be used as binding identifiers. Ensure that when input
code defines such identifiers, usage counting operates as expected.

Although this patch is intended to correct a regression introduced by
commit f80e049c, it exposes a previously-existing bug. Prior to this
patch, JSHint did not flag FutureReservedWords when used as
IdentifierReferences. Correct this behavior since deferring a correction
to a dedicated commit would require additional and ultimately useless
logic.

---

@rwaldron JSHint creates dedicated entries in the symbol table for each of
ES3's FutureReservedWords. I'd like to lex them as identifiers and attach a
special property. Or maybe just create on symbol for them all to share. Either
change would be more than I'm comfortable making in a patch release, so I
limited the solution to something that we can get out as part of the regression
fix.

This is intended to resolve gh-3362