### PR TITLE
Correct parsing of block binding declarations in C-style for loops

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4334,7 +4334,7 @@ var JSHINT = (function() {
       // Bindings are not immediately initialized in for-in and for-of
       // statements. As with `const` initializers (described above), the `for`
       // statement parsing logic includes
-      if (!noin) {
+      if (state.tokens.next.value !== "in" && state.tokens.next.value !== "of") {
         for (t in tokens) {
           if (tokens.hasOwnProperty(t)) {
             t = tokens[t];

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4284,8 +4284,9 @@ var JSHINT = (function() {
       // head of for-in and for-of statements. If this binding list is being
       // parsed as part of a `for` statement of any kind, allow the initializer
       // to be omitted. Although this may erroneously allow such forms from
-      // "C-style" `for` statements (i.e. `for (;;) {}`, the `for` statement
-      // logic includes dedicated logic to issue the error for such cases.
+      // "C-style" `for` statements (i.e. `for (const x;;) {}`, the `for`
+      // statement logic includes dedicated logic to issue the error for such
+      // cases.
       if (!noin && isConst && state.tokens.next.id !== "=") {
         warning("E012", state.tokens.curr, state.tokens.curr.value);
       }
@@ -5123,6 +5124,10 @@ var JSHINT = (function() {
       nolinebreak(state.tokens.curr);
       advance(";");
       if (decl) {
+        if (decl.value === "const"  && !decl.hasInitializer) {
+          warning("E012", decl, decl.first[0].value);
+        }
+
         decl.first.forEach(function(token) {
           state.funct["(scope)"].initialize(token.value);
         });

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2338,3 +2338,23 @@ exports.initializeCStyle = function(test) {
 
   test.done();
 };
+
+exports.constWithoutInit = function(test) {
+  TestRun(test, "single binding")
+    .addError(1, 6, "const 'x' is initialized to 'undefined'.")
+    .test([
+      "for (const x; ;) {",
+      "  void x;",
+      "}"
+    ], { esversion: 6 });
+
+  TestRun(test, "multiple bindings")
+    .addError(1, 6, "const 'y' is initialized to 'undefined'.")
+    .test([
+      "for (const y, z; ;) {",
+      "  void (y, z);",
+      "}"
+    ], { esversion: 6 });
+
+  test.done();
+};

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2327,3 +2327,14 @@ exports["TDZ within for in/of head"] = function(test) {
 
   test.done();
 };
+
+// regression test for gh-3370
+exports.initializeCStyle = function(test) {
+  TestRun(test)
+    .test([
+      "for (let x, y = x; ;) {}",
+      "for (const x = 0, y = x; ;) {}"
+    ], { esversion: 6 });
+
+  test.done();
+};


### PR DESCRIPTION
The first commit is intended to resolve gh-3370. The second fixes an as-yet unreported bug.