### PR TITLE
[[FIX]] Interpret "object rest" ident as a binding

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4135,12 +4135,13 @@ var JSHINT = (function() {
 
           // Due to visual symmetry with the array rest property (and the early
           // design of the language feature), developers may mistakenly assume
-          // any expression is valid in this position.  Parse an expression and
-          // issue an error in order to recover more gracefully from this
-          // condition.
-          expr = expression(context, 10);
-
-          if (expr.type !== "(identifier)") {
+          // any expression is valid in this position. If the next token is not
+          // an identifier, attempt to parse an expression and issue an error.
+          // order to recover more gracefully from this condition.
+          if (state.tokens.next.type === "(identifier)") {
+            id = identifier(context);
+          } else {
+            expr = expression(context, 10);
             error("E030", expr, expr.value);
           }
         } else {

--- a/tests/unit/objrestspread.js
+++ b/tests/unit/objrestspread.js
@@ -115,5 +115,9 @@ exports.rest = function (test) {
     .addError(1, 7, "Expected an identifier and instead saw '{'.")
     .test("({ ...{} } = {});", { esversion: 9 });
 
+  TestRun(test, "gh-3377 - identifier interpreted as new binding, not reference")
+    .addError(1, 10, "'x' is defined but never used.")
+    .test("var { ...x } = {};", { esversion: 9, unused: true, undef: true });
+
   test.done();
 };


### PR DESCRIPTION
Previously, JSHint interpreted token sequences following the "object
rest" operator as expressions. As noted in the in-line comment, this was
done to improve the chance of recovery in response to a common
programming error. Unfortunately, it also caused valid syntax to be
misinterpreted--the expected identifier was treated as a
IdentifierReference instead of a BindingIdentifier.

Update the parsing strategy to use the expression parsing fallback only
when the input is known to be invalid.

This should resolve gh-3377