### PR TITLE
[[CHORE]] Remove unreachable code

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1549,10 +1549,6 @@ var JSHINT = (function() {
       if (nativeObject)
         warning("W121", left, nativeObject);
     }
-    if (checkPunctuator(left, "...")) {
-      /* istanbul ignore next */
-      left = left.right;
-    }
 
     if (left.identifier && !left.isMetaProperty) {
       // The `reassign` method also calls `modify`, but we are specific in


### PR DESCRIPTION
The function `checkLeftSideAssign` validates assignment targets and
includes a branch for targets which are applications of the spread/rest
operator. Although the symbol table includes an entry for the `...`
token, its definition as an "infix" operator is incomplete and cannot be
used to advance through an expression (e.g. the invalid code `0 ... 1`).
Instead, the operator is explicitly consumed in the productions where it
is allowed through the use of the internal `spreadrest` function. This
means the token is not used to build an expression. Therefore, the
branch in `checkLeftSideAssign` accommodates a condition that cannot
occur, and it may be removed without altering the behavior of JSHint.

---

@rwaldron One down, sixty to go...