### PR TITLE
[[CHORE]] Remove unreachable branch

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1735,11 +1735,6 @@ var JSHINT = (function() {
       }
     }
 
-    if (val === "undefined") {
-      /* istanbul ignore next */
-      return val;
-    }
-
     warning("W024", state.tokens.curr, state.tokens.curr.id);
     return val;
   }


### PR DESCRIPTION
A prior commit [1] refactored the token `undefined` to be interpreted as
an identifier rather than a reserved word. This correction made a branch
in the `optionalidentifier` function unreachable, but the branch was
mistakenly persisted. Remove the branch as it cannot influence
JSHint's behavior.

[1] a11d6310c5448304d56be081dc02b4c2a1ff7377