### PR TITLE
[[TEST]] Improve coverage

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -5549,9 +5549,7 @@ var JSHINT = (function() {
           advance("}");
           break;
         } else {
-          /* istanbul ignore next */
           error("E024", state.tokens.next, state.tokens.next.value);
-          /* istanbul ignore next */
           break;
         }
       }

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -928,6 +928,19 @@ exports.testES6Modules = function (test) {
       "import afterLabelImported from 'elsewhere';"
     ], { esversion: 6 });
 
+  TestRun(test, "invalid ImportsList")
+    .addError(1, 12, "Unexpected 'y'.")
+    .addError(1, 12, "Expected 'from' and instead saw 'y'.")
+    .addError(1, 14, "Expected '(string)' and instead saw '}'.")
+    .addError(1, 15, "Missing semicolon.")
+    .addError(1, 16, "Expected an assignment or function call and instead saw an expression.")
+    .addError(1, 20, "Missing semicolon.")
+    .addError(1, 21, "Expected an assignment or function call and instead saw an expression.")
+    .addError(1, 16, "'from' is not defined.")
+    .test([
+      "import { x y } from 'elsewhere';"
+    ], { esversion: 6, module: true });
+
   TestRun(test, "async as Identifier")
     .test([
       "var async;",


### PR DESCRIPTION
Add test for handling of invalid ImportsList (without the branch under
test, no error would be reported when ImportSpecifiers are not
delineated by a comma).