### PR TITLE
[[CHORE]] Remove unused internal variable

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -86,8 +86,6 @@ var JSHINT = (function() {
     membersOnly,
     predefined,    // Global variables defined by option
 
-    urls,
-
     extraModules = [],
     emitter = new events.EventEmitter();
 
@@ -6336,7 +6334,6 @@ var JSHINT = (function() {
     });
 
     functions = [state.funct];
-    urls = [];
     member = {};
     membersOnly = null;
     inblock = false;
@@ -6532,11 +6529,6 @@ var JSHINT = (function() {
     var impliedGlobals = state.funct["(scope)"].getImpliedGlobals();
     if (impliedGlobals.length > 0) {
       data.implieds = impliedGlobals;
-    }
-
-    if (urls.length > 0) {
-      /* istanbul ignore next */
-      data.urls = urls;
     }
 
     globals = state.funct["(scope)"].getUsedOrDefinedGlobals();


### PR DESCRIPTION
The `urls` variable was included in the initial release of JSLint [1]. It was
later removed via [1], before the first public release of JSHint. JSHint has
never used this value.

[1] ca120a731db548c0014320fa0c196edc613536ae
[2] 528bd2e1406eebc44eb6387648d9b63291d3b027