### PR TITLE
[[CHORE]] Align value with variable name

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2247,11 +2247,11 @@ var JSHINT = (function() {
       // ...it should not be considered as a variable in the current scope. It
       // will be added to the scope of the new function when the next token is
       // parsed, so it can be safely ignored for now.
-      var isLoneArrowParam = state.tokens.next.id !== "=>";
+      var isLoneArrowParam = state.tokens.next.id === "=>";
 
       if (isReserved(context, this)) {
         warning("W024", this, v);
-      } else if (isLoneArrowParam && !state.funct["(comparray)"].check(v)) {
+      } else if (!isLoneArrowParam && !state.funct["(comparray)"].check(v)) {
         state.funct["(scope)"].block.use(v, state.tokens.curr);
       }
 


### PR DESCRIPTION
The name `isLoneArrowParam` implies a value that is `true` when the
identifier in question is a parameter for an arrow function. Update the
value and the subsquent reference to align with this name.