### PR TITLE
Re-implement directive processing logic

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -477,8 +477,8 @@ var JSHINT = (function() {
     if (directiveToken.type === "globals") {
       body.forEach(function(g, idx) {
         g = g.split(":");
-        var key = g[0].trim();
-        var val = (g[1] || "").trim();
+        var key = g[0];
+        var val = g[1];
 
         if (key === "-" || !key.length) {
           // Ignore trailing comma

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -475,10 +475,9 @@ var JSHINT = (function() {
     }
 
     if (directiveToken.type === "globals") {
-      body.forEach(function(g, idx) {
-        g = g.split(":");
-        var key = g[0];
-        var val = g[1];
+      body.forEach(function(item, idx) {
+        var parts = item.split(":");
+        var key = parts[0].trim();
 
         if (key === "-" || !key.length) {
           // Ignore trailing comma
@@ -491,12 +490,11 @@ var JSHINT = (function() {
 
         if (key.charAt(0) === "-") {
           key = key.slice(1);
-          val = false;
 
           JSHINT.blacklist[key] = key;
           delete predefined[key];
         } else {
-          predef[key] = (val === "true");
+          predef[key] = parts.length > 1 && parts[1].trim() === "true";
         }
       });
 
@@ -553,10 +551,11 @@ var JSHINT = (function() {
 
     if (directiveToken.type === "jshint" || directiveToken.type === "jslint" ||
       directiveToken.type === "jshint.unstable") {
-      body.forEach(function(g) {
-        g = g.split(":");
-        var key = g[0].trim();
-        var val = (g[1] || "").trim();
+      body.forEach(function(item) {
+        var parts = item.split(":");
+        var key = parts[0].trim();
+        var val = parts.length > 1 ? parts[1].trim() : "";
+        var numberVal;
 
         if (!checkOption(key, directiveToken.type !== "jshint.unstable", directiveToken)) {
           return;
@@ -565,14 +564,15 @@ var JSHINT = (function() {
         if (numvals.indexOf(key) >= 0) {
           // GH988 - numeric options can be disabled by setting them to `false`
           if (val !== "false") {
-            val = +val;
+            numberVal = +val;
 
-            if (typeof val !== "number" || !isFinite(val) || val <= 0 || Math.floor(val) !== val) {
-              error("E032", directiveToken, g[1].trim());
+            if (typeof numberVal !== "number" || !isFinite(numberVal) ||
+              numberVal <= 0 || Math.floor(numberVal) !== numberVal) {
+              error("E032", directiveToken, val);
               return;
             }
 
-            state.option[key] = val;
+            state.option[key] = numberVal;
           } else {
             state.option[key] = key === "indent" ? 4 : false;
           }


### PR DESCRIPTION
@caitp @rwaldron This is the latest in the series of rewrites (the prior patches along these lines were 6759ac9, gh-3419, gh-3427, and gh-3434).

Since the first commit intentionally regresses functionality, we should definitely use a merge commit to land this branch.

Commit messages:

> [[FIX]] Support spaces in /*global ... */
>
> Re-implement the improvements reverted by the previous commit. Use
> distinct logic to differentiate this new implementation, including the
> following substantive improvements:
>
> - Improve local variable name
> - Avoid variable reassignment
> - Remove unnecessary value assignment
> - Defer value calculation until necessary
>
> Update related directive processing logic to match.

> [[CHORE]] Revert "Support spaces in /*global ... */"
>
> JSHint's sanitization of the "globals" linting directive is derived from
> code first contributed by Lapo Luchini <lapo@lapo.it>. That contributor
> could not be reached to sign JSHint's Contributor License Agreement.
> Revert the user's contribution to the application logic (preserving the
> corresponding MIT-licensed test code) so that it may be re-written under
> the terms of the Contributor License Agreement.
>
> Revert the changes introduced by
> a17ae9ed1e01ba465487b97066fdc2ba65ce109a

