### PR TITLE
[[CHORE]] Add regression test for code from `quit`

### DIFF
--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -415,7 +415,9 @@ exports.argsInCatchReused = function (test) {
 exports.testRawOnError = function (test) {
   JSHINT(';', { maxerr: 1 });
   test.equal(JSHINT.errors[0].raw, 'Unnecessary semicolon.');
+  test.equal(JSHINT.errors[0].code, 'W032');
   test.equal(JSHINT.errors[1].raw, 'Too many errors.');
+  test.equal(JSHINT.errors[1].code, 'E043');
   test.equal(JSHINT.errors[2], null);
 
   test.done();


### PR DESCRIPTION
This functionality was introduced by "Add codes to errors generated by
quit()" [1], but no tests were included. Add a test in order to prevent
regressions.

[1] 537dcbd4be49f5b52ede08e98b23e49bbc5e4bbc