### PR TITLE
[[CHORE]] Verify integration with jshint.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ demo.js
 .idea
 
 coverage/
+
+# The following directory is created when validating the project website using
+# the command `npm run test-website`
+tests/jshint.com/

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,7 @@ matrix:
       env: CMD=test-262
     - node_js: 10
       env: CMD=test-browser
+    - node_js: 10
+      env: CMD=test-website
   fast_finish: true
 sudo: false

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 # Command-line Interface
 
-The JSHint CLI can be installed via npm (see [the Installation page](/install)
-for instructions).
+The JSHint CLI can be installed via npm (see [the Installation
+page](https://jshint.com/install/) for instructions).
 
 Contents: [Specifying Input](#specifying-input) · [Specifying Linting
 Options](#specifying-linting-options) · [Special Options](#special-options) ·
@@ -45,9 +45,9 @@ If a file path is a dash (`-`) then JSHint will read from standard input.
 
 ### Specifying Linting Options
 
-The `jshint` executable is capable of applying [linting options](/docs/options)
-specified in an external [JSON](http://json.org/)-formatted file. Such a file
-might look like this:
+The `jshint` executable is capable of applying [linting
+options](https://jshint.com/docs/options) specified in an external
+[JSON](http://json.org/)-formatted file. Such a file might look like this:
 
     {
       "curly": true,
@@ -71,7 +71,8 @@ If this search yields no results, `jshint` will lint the input code as if no
 linting rules had been enabled.
 
 The command-line interface offers some [special options](#special-options) in
-addition to [the ones available in other contexts](/docs/options)
+addition to [the ones available in other
+contexts](https://jshint.com/docs/options)
 
 <a name="special-options"></a>
 
@@ -88,7 +89,7 @@ the current file.
 
 For example, you might define a `.jshintrc` file in the top-level directory of
 your project (say, `./.jshintrc') to specify the [linting
-options](/docs/options) you would like to use in your entire project:
+options](https://jshint.com/docs/options) you would like to use in your entire project:
 
     {
       "undef": true,
@@ -116,8 +117,9 @@ Specify options that should only be applied to files matching a given path
 pattern.
 
 The following configuration file [disallows variable
-shadowing](/docs/options#shadow) for *all* files and [allows expressions as
-statements](/docs/options#expr) for only those files ending in `-test.js`:
+shadowing](https://jshint.com/docs/options#shadow) for *all* files and [allows
+expressions as statements](https://jshint.com/docs/options#expr) for only those
+files ending in `-test.js`:
 
     {
       "shadow": false,
@@ -182,7 +184,8 @@ CheckStyle XML.
       </file>
     </checkstyle>
 
-See also: [Writing your own JSHint reporter](/docs/reporters/).
+See also: [Writing your own JSHint
+reporter](https://jshint.com/docs/reporters/).
 
 #### `--verbose`
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test-node": "npm run test-unit && npm run test-cli && npm run test-regression",
     "test-regression": "nodeunit tests/regression",
     "test-unit": "nodeunit tests/unit tests/unit/unstable",
+    "test-website": "node tests/website.js",
     "test": "npm run test-node && npm run test-browser"
   },
   "main": "./src/jshint.js",

--- a/tests/website.js
+++ b/tests/website.js
@@ -1,0 +1,34 @@
+/**
+ * The jshint.com project website generates some content based on the state of
+ * this repository. Changes in this repository could therefore interfere with
+ * the website. This script verifies that when the website is configured to use
+ * the current codebase, it builds successfully and passes its own test suite.
+ */
+"use strict";
+
+var execSync = require("child_process").execSync;
+var path = require("path");
+var fs = require("fs");
+
+var repository = "https://github.com/jshint/jshint.github.io.git";
+var websiteDir = path.join(__dirname, "jshint.com");
+var linkName = path.join(websiteDir, "res", "jshint");
+
+function execInSite(command) {
+  execSync(command, { stdio: "inherit", cwd: websiteDir });
+}
+
+fs.mkdirSync(websiteDir, {recursive: true});
+
+execInSite("git init");
+execInSite("git pull " + repository + " dev");
+execInSite("git rm -rf --ignore-unmatch res/jshint");
+
+try {
+  fs.unlinkSync(linkName);
+} catch (error) {}
+
+fs.symlinkSync(path.join(__dirname, ".."), linkName);
+
+execInSite("npm install");
+execInSite("npm test");


### PR DESCRIPTION
The jshint.com project website generates some content based on the state
of this repository. Changes in this repository could therefore interfere
with the website. This script verifies that when the website is
configured to use the current codebase, it builds successfully and
passes its own test suite.

---

@rwaldron This seems easier for folks to discover and better for the project history (that is: synchronizing changes to the source with changes to the docs). I've taken the initiative to [move the docs from the website](https://github.com/jshint/jshint/commit/2bf827844a7c9f03762001dddf5c7759ff179a54) to this repository and [introduce some automated tests there](https://github.com/jshint/jshint.github.io/commit/3f9dd950a803852387954f76943b2eeae08e35d0). For this last part, I'm suggesting we ensure that patches submitted to JSHint don't interfere with jshint.com. What do you think?