### PR TITLE
[[DOCS]] Correct project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 JSHint is a community-driven tool that detects errors and potential problems in
 JavaScript code. Since JSHint is so flexible, you can easily adjust it in 
-the environment you expect your code to execute. JSHint is open source and
-will always stay this way.
+the environment you expect your code to execute. JSHint is publicly available
+and will always stay this way.
 
 ## Our goal
 


### PR DESCRIPTION
The terms of the JSON license [1] disqualify JSHint from the distinction
of "open source" software [2].

[1] https://www.gnu.org/licenses/license-list.html#JSON
[2] https://opensource.org/faq#evil