### PR TITLE
Fixes #3455

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -5219,7 +5219,7 @@ var JSHINT = (function() {
       }
       nolinebreak(state.tokens.curr);
       advance(";");
-      if (decl) {
+      if (decl && decl.first && decl.first[0]) {
         if (decl.value === "const"  && !decl.hasInitializer) {
           warning("E012", decl, decl.first[0].value);
         }

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2354,6 +2354,20 @@ exports.initializeCStyle = function(test) {
   test.done();
 };
 
+// regression test for gh-3455
+exports.constWithoutVar = function(test) {
+  TestRun(test)
+    .addError(1, 11, "Expected an identifier and instead saw ';'.")
+    .addError(1, 12, "Expected an identifier and instead saw ')'.")
+    .addError(1, 12, "Expected ';' and instead saw ''.")
+    .addError(1, 12, "Unrecoverable syntax error. (100% scanned).")
+    .test([
+      "for (const;)"
+    ], { esversion: 6 });
+
+  test.done();
+};
+
 exports.constWithoutInit = function(test) {
   TestRun(test, "single binding")
     .addError(1, 6, "const 'x' is initialized to 'undefined'.")


### PR DESCRIPTION
[[FIX]] E012 TypeError accessing 'value' of undefined

Make sure that 'decl.first[0]' is defined before accessing its 'value' attribute.

No breaking changes.

Fixes #3455