### PR TITLE
docs: Fix simple typo, overriden -> overridden

### DIFF
--- a/tests/cli.js
+++ b/tests/cli.js
@@ -299,7 +299,7 @@ exports.group = {
     ]);
     test.ok(rep.reporter.args[0][0].length === 0);
 
-    // Test overriden, failed file
+    // Test overridden, failed file
     cli.interpret([
       "node", "jshint", "bar.js", "--config", "config.json", "--reporter", "reporter.js"
     ]);
@@ -344,7 +344,7 @@ exports.group = {
     ]);
     test.ok(rep.reporter.args[0][0].length === 0);
 
-    // Test overriden, failed file
+    // Test overridden, failed file
     cli.interpret([
       "node", "jshint", "src/bar.js", "--config", "config.json", "--reporter", "reporter.js"
     ]);
@@ -389,7 +389,7 @@ exports.group = {
     ]);
     test.ok(rep.reporter.args[0][0].length === 0);
 
-    // Test overriden, failed file
+    // Test overridden, failed file
     cli.interpret([
       "node", "jshint", "./src/bar.js", "--config", "config.json", "--reporter", "reporter.js"
     ]);
@@ -1515,7 +1515,7 @@ exports.useStdin = {
       test.done();
     },
 
-    // Test overriden, failed file
+    // Test overridden, failed file
     failure: function(test) {
       cli.interpret([
         "node", "jshint", "--filename", "bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"
@@ -1570,7 +1570,7 @@ exports.useStdin = {
       test.done();
     },
 
-    // Test overriden, failed file
+    // Test overridden, failed file
     failure: function(test) {
       cli.interpret([
         "node", "jshint", "--filename", "src/bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"
@@ -1625,7 +1625,7 @@ exports.useStdin = {
       test.done();
     },
 
-    // Test overriden, failed file
+    // Test overridden, failed file
     failure: function(test) {
       cli.interpret([
         "node", "jshint", "--filename", "./src/bar.js", "--config", "config.json", "--reporter", "reporter.js", "-"

--- a/tests/regression/libs/backbone.js
+++ b/tests/regression/libs/backbone.js
@@ -274,7 +274,7 @@
     },
 
     // Fetch the model from the server. If the server's representation of the
-    // model differs from its current attributes, they will be overriden,
+    // model differs from its current attributes, they will be overridden,
     // triggering a `"change"` event.
     fetch : function(options) {
       options || (options = {});

--- a/tests/regression/libs/backbone.js
+++ b/tests/regression/libs/backbone.js
@@ -274,7 +274,7 @@
     },
 
     // Fetch the model from the server. If the server's representation of the
-    // model differs from its current attributes, they will be overridden,
+    // model differs from its current attributes, they will be overriden,
     // triggering a `"change"` event.
     fetch : function(options) {
       options || (options = {});


### PR DESCRIPTION
There is a small typo in tests/cli.js, tests/regression/libs/backbone.js.

Should read `overridden` rather than `overriden`.

