### PR TITLE
[[DOCS]] Improve message for warning W067

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -155,7 +155,7 @@ var warnings = {
   W064: "Missing 'new' prefix when invoking a constructor.",
   W065: "Missing radix parameter.",
   W066: "Implied eval. Consider passing a function instead of a string.",
-  W067: "Bad invocation.",
+  W067: "Unorthodox function invocation.",
   W068: "Wrapping non-IIFE function literals in parens is unnecessary.",
   W069: "['{a}'] is better written in dot notation.",
   W070: "Extra comma. (it breaks older versions of IE)",

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -8591,7 +8591,7 @@ exports.testStrictDirectiveASI = function (test) {
     .test("'use strict';function fn() {} fn();", options);
 
   TestRun(test, 4)
-    .addError(2, 1, "Bad invocation.")
+    .addError(2, 1, "Unorthodox function invocation.")
     .addError(2, 21, "Missing \"use strict\" statement.")
     .test("'use strict'\n(function fn() {})();", options);
 


### PR DESCRIPTION
The message "Bad invocation" is overly vague, forcing users to guess
about its intent and its status as a recommendation. Reword the message
to more specifically describe the concern: that the pattern is uncommon.