### PR TITLE
[FEAT] Allow fetching reporters directly from module resolver

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -146,7 +146,7 @@ function loadNpmConfig(file) {
  */
 function loadReporter(fp) {
   try {
-    return require(fp).reporter;
+    return require(require.resolve(fp, { paths: [process.cwd(),], })).reporter;
   } catch (err) {
     return null;
   }
@@ -733,15 +733,11 @@ var exports = {
     case options["show-non-errors"]:
       options.reporter = "./reporters/non_error.js";
       break;
-
-    // Custom reporter
-    case options.reporter !== undefined:
-      options.reporter = path.resolve(process.cwd(), options.reporter);
     }
 
     var reporter;
     if (options.reporter) {
-      reporter = loadReporter(options.reporter);
+      reporter = loadReporter(options.reporter) || loadReporter(path.resolve(process.cwd(), options.reporter));
 
       if (reporter === null) {
         cli.error("Can't load reporter file: " + options.reporter);

--- a/src/cli.js
+++ b/src/cli.js
@@ -146,7 +146,7 @@ function loadNpmConfig(file) {
  */
 function loadReporter(fp) {
   try {
-    return require(require.resolve(fp, { paths: [process.cwd(),], })).reporter;
+    return require(require.resolve(fp)).reporter;
   } catch (err) {
     return null;
   }
@@ -737,7 +737,8 @@ var exports = {
 
     var reporter;
     if (options.reporter) {
-      reporter = loadReporter(options.reporter) || loadReporter(path.resolve(process.cwd(), options.reporter));
+      reporter = loadReporter(options.reporter) ||
+        loadReporter(path.resolve(process.cwd(), options.reporter));
 
       if (reporter === null) {
         cli.error("Can't load reporter file: " + options.reporter);


### PR DESCRIPTION
This PR allows jshint to find reporters via the module resolver, as well as falling back to the existing search relative to the current path.

If the `package.json` has a `main` clause that points to the reporter (see e.g. https://github.com/riverglide/jshint-junit-reporter.git ), then the reporter can be specified as just the module name (e.g. `jshint --reporter @riverglide/jshint-junit-reporter` vs `jshint --reporter node_modules/@riverglide/jshint-junit-reporter/reporter.js`)