### PR TITLE
[[CHORE]] Remove unreachable branch

### DIFF
--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -121,33 +121,20 @@ var scopeManager = function(state, predefined, exported, declared) {
    * Check the current scope for unused identifiers
    */
   function _checkForUnused() {
-    // function parameters are validated by a dedicated function
-    // assume that parameters are the only thing declared in the param scope
-    if (_current["(type)"] === "functionparams") {
-      _checkParams();
-      return;
-    }
-    var currentBindings = _current["(bindings)"];
-    for (var bindingName in currentBindings) {
-      if (currentBindings[bindingName]["(type)"] !== "exception" &&
-        currentBindings[bindingName]["(unused)"]) {
-        _warnUnused(bindingName, currentBindings[bindingName]["(token)"], "var");
+    if (_current["(type)"] !== "functionparams") {
+      var currentBindings = _current["(bindings)"];
+      for (var bindingName in currentBindings) {
+        if (currentBindings[bindingName]["(type)"] !== "exception" &&
+          currentBindings[bindingName]["(unused)"]) {
+          _warnUnused(bindingName, currentBindings[bindingName]["(token)"], "var");
+        }
       }
-    }
-  }
-
-  /**
-   * Check the current scope for unused parameters and issue warnings as
-   * necessary. This function may only be invoked when the current scope is a
-   * "function parameter" scope.
-   */
-  function _checkParams() {
-    var params = _current["(params)"];
-
-    if (!params) {
-      /* istanbul ignore next */
       return;
     }
+
+    // Check the current scope for unused parameters and issue warnings as
+    // necessary.
+    var params = _current["(params)"];
 
     var param = params.pop();
     var unused_opt;


### PR DESCRIPTION
The `_checkParams` function included a guard to ensure it was only
invoked in appropriate situations. Because its one and only call site
was itself guarded by an equivalent condition, the branch in
`_checkParams` was unreachable.

Although this situation made the internal guard of `_checkParams` safe
to remove, doing so would have made the function more dangerous in
general since anyone introducing new invocations in the future would
have to take care to perform a similar check.

To avoid introducing such a dangerous interface, remove the function
entirely and inline its body at its only call site.