### PR TITLE
[[Fix]] Update Lodash to latest 4.17.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "console-browserify": "1.1.x",
     "exit": "0.1.x",
     "htmlparser2": "3.8.x",
-    "lodash": "~4.17.11",
+    "lodash": "~4.17.19",
     "minimatch": "~3.0.2",
     "shelljs": "0.3.x",
     "strip-json-comments": "1.0.x"


### PR DESCRIPTION
Address vulnerability of type "Prototype Pollution in lodash" https://github.com/advisories/GHSA-p6mc-m468-83gw

It is not sure whether this is at all relevant for jshint, but at the moment, GitHub's Dependabot sends vulnerability alerts to all respositories with a dependency to jshint, e.g.
https://github.com/alexandrainst/node-red-contrib-parser-ini/network/alert/package-lock.json/lodash/closed

So it would be nice to issue a new jshint release ASAP to offer an easy way forward for those projects with a (dev) dependency to jshint.

https://github.com/lodash/lodash/wiki/Changelog