### PR TITLE
[[Fix]] Don't warn when RegExp() is used without 'new'.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3046,14 +3046,17 @@ var JSHINT = (function() {
 
     if (left) {
       if (left.type === "(identifier)") {
-        if (left.value.match(/^[A-Z]([A-Z0-9_$]*[a-z][A-Za-z0-9_$]*)?$/)) {
-          if ("Array Number String Boolean Date Object Error Symbol".indexOf(left.value) === -1) {
-            if (left.value === "Math") {
-              /* istanbul ignore next */
-              warning("W063", left);
-            } else if (state.option.newcap) {
-              warning("W064", left);
-            }
+        var newcapRe = /^[A-Z]([A-Z0-9_$]*[a-z][A-Za-z0-9_$]*)?$/;
+        var newcapIgnore = [
+          "Array", "Boolean", "Date", "Error", "Number",
+          "Object", "RegExp", "String", "Symbol"
+        ];
+        if (newcapRe.test(left.value) && newcapIgnore.indexOf(left.value) === -1) {
+          if (left.value === "Math") {
+            /* istanbul ignore next */
+            warning("W063", left);
+          } else if (state.option.newcap) {
+            warning("W064", left);
           }
         }
       }

--- a/tests/unit/fixtures/newcap.js
+++ b/tests/unit/fixtures/newcap.js
@@ -19,8 +19,13 @@ bat = myAnimal();
 
 // Make sure we don't warn on Error, Number, etc.
 Array();
+Boolean();
+Date();
 Error();
 Number();
+/*jshint -W010 */
+Object();
+/*jshint +W010 */
+RegExp();
 String();
-Boolean();
 Symbol();


### PR DESCRIPTION
https://262.ecma-international.org/#sec-regexp-constructor
...
function call RegExp(…) is equivalent
to the object creation expression new RegExp(…)
with the same arguments
...