### PR TITLE
[[FIX]] Don't warn when Function() is used without 'new'.

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3048,7 +3048,7 @@ var JSHINT = (function() {
       if (left.type === "(identifier)") {
         var newcapRe = /^[A-Z]([A-Z0-9_$]*[a-z][A-Za-z0-9_$]*)?$/;
         var newcapIgnore = [
-          "Array", "Boolean", "Date", "Error", "Number",
+          "Array", "Boolean", "Date", "Error", "Function", "Number",
           "Object", "RegExp", "String", "Symbol"
         ];
         if (newcapRe.test(left.value) && newcapIgnore.indexOf(left.value) === -1) {

--- a/tests/unit/fixtures/newcap.js
+++ b/tests/unit/fixtures/newcap.js
@@ -22,6 +22,9 @@ Array();
 Boolean();
 Date();
 Error();
+/*jshint -W061 */
+Function();
+/*jshint +W061 */
 Number();
 /*jshint -W010 */
 Object();


### PR DESCRIPTION
https://262.ecma-international.org/#sec-function-constructor
...
the function call Function(…) is equivalent to the object creation
expression new Function(…) with the same arguments
...