### PR TITLE
[[FIX]] Enforce restrictions on `new` operand

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -2364,11 +2364,14 @@ var JSHINT = (function() {
 
     return this;
   });
-  reserve("super", function() {
+
+  (function(superSymbol) {
+    superSymbol.rbp = 161;
+  })(reserve("super", function() {
     superNud.call(state.tokens.curr, this);
 
     return this;
-  });
+  }));
 
   assignop("=", "assign");
   assignop("+=", "assignadd");
@@ -2697,7 +2700,12 @@ var JSHINT = (function() {
     });
     if (mp) { return mp; }
 
+    var opening = state.tokens.next;
     var c = expression(context, 155), i;
+    if (!c.paren && c.rbp > 160) {
+      error("E024", opening, opening.value);
+    }
+
     if (c && c.id !== "function") {
       if (c.identifier) {
         switch (c.value) {
@@ -3268,7 +3276,7 @@ var JSHINT = (function() {
     return ret;
   });
 
-  application("=>");
+  application("=>").rbp = 161;
 
   infix("[", function(context, left, that) {
     var e, s, canUseDot;

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -249,6 +249,15 @@ exports.testNewNonNativeObject = function (test) {
   test.done();
 };
 
+exports.testNewArrowFn = function (test) {
+  TestRun(test)
+    .addError(1, 5, "Unexpected '('.")
+    .addError(1, 12, "Bad constructor.")
+    .addError(1, 12, "Missing '()' invoking a constructor.")
+    .test("new () => {};", {esversion: 6});
+
+  test.done();
+};
 
 /**
  * Test that JSHint allows `undefined` to be a function parameter.

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -7440,6 +7440,16 @@ exports.super.superCall = function (test) {
       "}"
     ], { esversion: 8 });
 
+  TestRun(test, "as operand to `new`")
+    .addError(3, 9, "Unexpected 'super'.")
+    .test([
+      "class C {",
+      "  constructor() {",
+      "    new super();",
+      "  }",
+      "}"
+    ], { esversion: 6 });
+
   test.done();
 };
 


### PR DESCRIPTION
These restrictions are imposed implicitly by precedence in the
ECMAScript grammar rather than any explicit "early error" rule.

---

I'm surprised that the Pratt parser doesn't enforce this kind of restriction automatically. Maybe I'm misunderstanding something though--I'm a bit rusty here. @rwaldron / @caitp: could I get a second opinion?

If this kind of explicit guard *is* necessary, then I suspect we're missing a lot of others.