### PR TITLE
[[FIX]] Allow optional chaining call as satement

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -3070,6 +3070,7 @@ var JSHINT = (function() {
       that.left = left;
       advance();
       that.right = state.tokens.curr.led(context, left);
+      that.exps = true;
     } else {
       state.syntax["."].led.call(that, context, left);
     }

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -10547,10 +10547,6 @@ exports.optionalChaining = function (test) {
     );
 
   TestRun(test, "arguments")
-    .addError(1, 10, "Expected an assignment or function call and instead saw an expression.")
-    .addError(2, 14, "Expected an assignment or function call and instead saw an expression.")
-    .addError(3, 20, "Expected an assignment or function call and instead saw an expression.")
-    .addError(4, 15, "Expected an assignment or function call and instead saw an expression.")
     .test([
         "true.x?.();",
         "true.x?.(true);",


### PR DESCRIPTION
Take care to only disable warning W030 for the "function call" form of
the optional chaining feature; the warning is still relevant for
property access.