### PR TITLE
[[FIX]] change escape-sequence handler for double quotes (\")

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -1115,7 +1115,6 @@ Lexer.prototype = {
       char = "\\\\";
       break;
     case "\"":
-      char = "\\\"";
       break;
     case "/":
       break;

--- a/src/lex.js
+++ b/src/lex.js
@@ -1114,8 +1114,6 @@ Lexer.prototype = {
     case "\\":
       char = "\\\\";
       break;
-    case "\"":
-      break;
     case "/":
       break;
     case "":

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2314,6 +2314,17 @@ exports.duplicateProto = function (test) {
 
   src = [
     "void {",
+    "  '\"': null,",
+    "  \"\\\"\": null",
+    "};"
+  ];
+
+  TestRun(test, "Duplicate keys (data)")
+    .addError(3, 7, "Duplicate key '\"'.")
+    .test(src);
+
+  src = [
+    "void {",
     "  __proto__: null,",
     "  get __proto__() {}",
     "};"

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2319,7 +2319,7 @@ exports.duplicateProto = function (test) {
     "};"
   ];
 
-  TestRun(test, "Duplicate keys (data)")
+  TestRun(test, "Duplicate keys (backslash)")
     .addError(3, 7, "Duplicate key '\"'.")
     .test(src);
 


### PR DESCRIPTION
Changes the handling of escape sequence case for `\"` in the **lex.js** file. Earlier, it converted `\"` into `\\\"`, which is not the correct js equivalent for the case as it should be `"` only. This was causing issue #3315 as `\" != "` that is why jshint considers them different strings.

Fixes and Closes #3315