### PR TITLE
[[FIX]] Tolerate keyword in object shorthand

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4072,8 +4072,10 @@ var JSHINT = (function() {
             warning("W104", state.tokens.next, "object short notation", "6");
           }
           t = expression(context, 10);
-          i = t.value;
-          saveProperty(props, i, t);
+          i = t && t.value;
+          if (t) {
+            saveProperty(props, i, t);
+          }
 
         } else if (peek().id !== ":" && (nextVal === "get" || nextVal === "set")) {
           advance(nextVal);

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -10617,3 +10617,21 @@ exports.loneNew = function (test) {
 
   test.done();
 };
+
+// gh-3571: "Cannot read properties of undefined at Object.e.nud"
+exports.keywordAsShorthandObjectProperty = function (test) {
+  TestRun(test, "as reported")
+    .addError(1, 12, "Expected an identifier and instead saw 'do'.")
+    .addError(1, 15, "Missing semicolon.")
+    .test("const a = {do}", {esversion: 6});
+
+  TestRun(test, "simplified")
+    .addError(1, 7, "Expected an identifier and instead saw 'do'.")
+    .test("void {do};", {esversion: 6});
+
+  TestRun(test, "alternate - penultimate member")
+    .addError(1, 7, "Expected an identifier and instead saw 'for'.")
+    .test("void {for, baz};", {esversion: 6});
+
+  test.done();
+};


### PR DESCRIPTION
Ensure that JSHint reports a syntax error rather than crashing.

This resolves gh-3571.