### PR TITLE
Drop `exit` dependencie

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "cli": "~1.0.0",
     "console-browserify": "1.1.x",
-    "exit": "0.1.x",
     "htmlparser2": "3.8.x",
     "lodash": "~4.17.21",
     "minimatch": "~3.0.2",

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,6 @@ var cli               = require("cli");
 var path              = require("path");
 var minimatch         = require("minimatch");
 var htmlparser        = require("htmlparser2");
-var exit              = require("exit");
 var stripJsonComments = require("strip-json-comments");
 var JSHINT            = require("./jshint.js").JSHINT;
 var defReporter       = require("./reporters/default").reporter;
@@ -509,7 +508,7 @@ function lint(code, results, config, data, file) {
 
 var exports = {
   extract: extract,
-  exit: exit,
+  exit: process.exit,
 
   /**
    * Returns a configuration file or nothing, if it can't be found.


### PR DESCRIPTION
According to nodejs/node-v0.x-archive#3584
this was fixed with nodejs/node-v0.x-archive@20176a9 in 2014.