### PR TITLE
Missing well-known globals

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -422,6 +422,7 @@ exports.browser = {
   TimeEvent            : false,
   top                  : false,
   URL                  : false,
+  URLSearchParams      : false,
   WebGLActiveInfo      : false,
   WebGLBuffer          : false,
   WebGLContextEvent    : false,
@@ -513,17 +514,18 @@ exports.node = {
   // These globals are writeable because Node allows the following
   // usage pattern: var Buffer = require("buffer").Buffer;
 
-  Buffer        : true,
-  console       : true,
-  exports       : true,
-  process       : true,
-  setTimeout    : true,
-  clearTimeout  : true,
-  setInterval   : true,
-  clearInterval : true,
-  setImmediate  : true, // v0.9.1+
-  clearImmediate: true, // v0.9.1+
-  URL           : true  // v6.13.0+
+  Buffer         : true,
+  console        : true,
+  exports        : true,
+  process        : true,
+  setTimeout     : true,
+  clearTimeout   : true,
+  setInterval    : true,
+  clearInterval  : true,
+  setImmediate   : true, // v0.9.1+
+  clearImmediate : true, // v0.9.1+
+  URL            : true,  // v6.13.0+
+  URLSearchParams: true  // v6.13.0+
 };
 
 exports.browserify = {

--- a/src/vars.js
+++ b/src/vars.js
@@ -66,6 +66,9 @@ exports.ecmaIdentifiers = {
   8: {
     Atomics            : false,
     SharedArrayBuffer  : false
+  },
+  11: {
+    BigInt             : false
   }
 };
 
@@ -505,6 +508,7 @@ exports.node = {
   global        : false,
   module        : false,
   require       : false,
+  Intl          : false,
 
   // These globals are writeable because Node allows the following
   // usage pattern: var Buffer = require("buffer").Buffer;
@@ -761,10 +765,12 @@ exports.mocha = {
   // BDD
   describe    : false,
   xdescribe   : false,
-  it          : false,
-  xit         : false,
   context     : false,
   xcontext    : false,
+  it          : false,
+  xit         : false,
+  specify     : false,
+  xspecify    : false,
   before      : false,
   after       : false,
   beforeEach  : false,


### PR DESCRIPTION
Hello,

I have no idea why this hasn't been noticed before, but some well-known globals are missing from `vars.js`. Here's what I've added:
- _BigInt_ for ES 11
- _Intl_ for node
- _specify_ and it's counterpart _xspecify_ for mocha
- _URLSearchParams_ for browser and node

This change is really easy to merge and I'm looking forward to seeing it in the next release.