### PR TITLE
[[DOCS]] Remove david-dm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 [![NPM version](https://img.shields.io/npm/v/jshint.svg?style=flat)](https://www.npmjs.com/package/jshint)
 [![Linux Build Status](https://img.shields.io/travis/jshint/jshint/master.svg?style=flat&label=Linux%20build)](https://travis-ci.org/jshint/jshint)
 [![Windows Build status](https://img.shields.io/appveyor/ci/jshint/jshint/master.svg?style=flat&label=Windows%20build)](https://ci.appveyor.com/project/jshint/jshint/branch/master)
-[![Dependency Status](https://img.shields.io/david/jshint/jshint.svg?style=flat)](https://david-dm.org/jshint/jshint)
-[![devDependency Status](https://img.shields.io/david/dev/jshint/jshint.svg?style=flat)](https://david-dm.org/jshint/jshint#info=devDependencies)
 [![Coverage Status](https://img.shields.io/coveralls/jshint/jshint.svg?style=flat)](https://coveralls.io/r/jshint/jshint?branch=master)
 
 JSHint is a community-driven tool that detects errors and potential problems in


### PR DESCRIPTION
The site is down, from archive.org it seems since October or November: https://web.archive.org/web/*/david-dm.org . The [last snapshot](https://web.archive.org/web/20211002064243/https://david-dm.org/) shows the most announcement was 2016, so it seems the service has not been maintained in a while.