### PR TITLE
[[FIX]] Recognize ES2020 globals

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -242,6 +242,10 @@ var JSHINT = (function() {
       combine(predefined, vars.ecmaIdentifiers[8]);
     }
 
+    if (state.inES11()) {
+      combine(predefined, vars.ecmaIdentifiers[11]);
+    }
+
     /**
      * Use `in` to check for the presence of any explicitly-specified value for
      * `globalstrict` because both `true` and `false` should trigger an error.

--- a/src/options.js
+++ b/src/options.js
@@ -1053,7 +1053,8 @@ exports.val = {
    *    Notable additions: optional catch bindings.
    *  - `11` - To enable language features introduced by ECMAScript 11. Notable
    *    additions: "export * as ns from 'module'", `import.meta`, the nullish
-   *    coalescing operator, and optional chaining, and dynamic import.
+   *    coalescing operator, the BigInt type, the `globalThis` binding,
+   *    optional chaining, and dynamic import.
    */
   esversion: 5
 };

--- a/src/vars.js
+++ b/src/vars.js
@@ -68,7 +68,8 @@ exports.ecmaIdentifiers = {
     SharedArrayBuffer  : false
   },
   11: {
-    BigInt             : false
+    BigInt             : false,
+    globalThis         : false
   }
 };
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -2582,3 +2582,26 @@ exports.constWithoutInit = function(test) {
 
   test.done();
 };
+
+// regression test for gh-3595
+exports.bigIntCtor = function(test) {
+  var code = [
+    "void BigInt;",
+    "void globalThis;"
+  ];
+
+  TestRun(test)
+    .addError(1, 6, "'BigInt' is not defined.")
+    .addError(2, 6, "'globalThis' is not defined.")
+    .test(code, { undef: true });
+
+  TestRun(test)
+    .addError(1, 6, "'BigInt' is not defined.")
+    .addError(2, 6, "'globalThis' is not defined.")
+    .test(code, { undef: true, esversion: 10 });
+
+  TestRun(test)
+    .test(code, { undef: true, esversion: 11 });
+
+  test.done();
+};


### PR DESCRIPTION
Include `globalThis` in the set of global bindings available in
ES2020-compliant runtimes. Add the instructions necessary to apply this
set. Extend the document of the `esversion` option to mention these
features.