### PR TITLE
[[FIX]] Tolerate late definition of async function

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -1850,8 +1850,9 @@ var JSHINT = (function() {
       if (t.reach) {
         return;
       }
+
       if (t.id !== "(endline)") {
-        if (t.id === "function") {
+        if (isFunction(t, i)) {
           if (state.option.latedef === true) {
             warning("W026", t);
           }
@@ -1860,6 +1861,16 @@ var JSHINT = (function() {
 
         warning("W027", t, t.value, controlToken.value);
         break;
+      }
+    }
+
+    function isFunction(t, i) {
+      if (t.id === "function") {
+        return true;
+      }
+      if (t.id === "async") {
+        t = peek(i);
+        return t.id === "function";
       }
     }
   }

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -8268,7 +8268,53 @@ exports.unreachable = {
       .test(src);
 
     test.done();
-  }
+  },
+  'async function': function (test) {
+    var src = [
+      "(function() {",
+      "  return f(4);",
+      "  async function f(p) {",
+      "    return p + 1;",
+      "  }",
+      "}());"
+    ];
+
+    TestRun(test)
+      .test(src, { esversion: 8, latedef: 'nofunc' });
+
+    test.done();
+  },
+  "async identifier": function (test) {
+    var src = [
+      "(function() {",
+      "  return f(4);",
+      "  async();",
+      "}());"
+    ];
+
+    TestRun(test)
+      .addError(3, 3, "Unreachable 'async' after 'return'.")
+      .test(src, { esversion: 8, latedef: "nofunc" });
+
+    test.done();
+  },
+   "async asi": function (test) {
+    var src = [
+      "(function() {",
+      "  return f(4);",
+      "  async",
+      "  function f(p) {",
+      "    return p + 1;",
+      "  }",
+      "}());"
+    ];
+
+    TestRun(test)
+      .addError(3, 3, "Unreachable 'async' after 'return'.")
+      .test(src, { esversion: 8, latedef: "nofunc", asi: true, expr: true });
+
+    test.done();
+  },
 };
 
 exports["test for 'break' in switch case + curly braces"] = function (test) {


### PR DESCRIPTION
We used to mark `async function` as unreachable instead of treating it as any other late function definition. This change makes jshint react to `async` keyword in the same way as it reacted to `function` keyword.