### PR TITLE
[[FIX]] Allow initializing const bindings to undef

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -4499,7 +4499,7 @@ var JSHINT = (function() {
         var id = state.tokens.prev;
         value = expression(context, 10);
         if (value) {
-          if (value.identifier && value.value === "undefined") {
+          if (!isConst && value.identifier && value.value === "undefined") {
             warning("W080", id, id.value);
           }
           if (!lone) {

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -847,15 +847,20 @@ exports.testUndefinedAssignment = function (test) {
 
   TestRun(test)
     .addError(1, 5, "It's not necessary to initialize 'x' to 'undefined'.")
-    .addError(2, 7, "It's not necessary to initialize 'y' to 'undefined'.")
     .addError(3, 5, "It's not necessary to initialize 'z' to 'undefined'.")
     .addError(4, 9, "It's not necessary to initialize 'a' to 'undefined'.")
-    .addError(6, 9, "It's not necessary to initialize 'c' to 'undefined'.")
     .addError(7, 7, "It's not necessary to initialize 'd' to 'undefined'.")
     .addError(9, 9, "It's not necessary to initialize 'f' to 'undefined'.")
-    .addError(10, 11, "It's not necessary to initialize 'g' to 'undefined'.")
     .addError(11, 9, "It's not necessary to initialize 'h' to 'undefined'.")
     .test(src, {esnext: true});
+
+  TestRun(test)
+    .addError(1, 8, "It's not necessary to initialize 'x' to 'undefined'.")
+    .addError(2, 8, "It's not necessary to initialize 'y' to 'undefined'.")
+    .test([
+      "const {x = undefined} = {};",
+      "const [y = undefined] = [];",
+    ], {esversion: 6});
 
   test.done();
 };


### PR DESCRIPTION
Warning W080 is inappropriate for constant bindings because, unlike `var` and `let` declarations, `const` requires an initializer.

Relax the emission of W080 to allow initializing constant bindings with `undefined`. Add unit tests to verify that the warning continues to be emitted for constant bindings declared in ES2015 destructuring patterns.