### PR TITLE
[[FIX]] Correct error message

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -21,7 +21,7 @@ var errors = {
 
   // Constants
   E011: "'{a}' has already been declared.",
-  E012: "const '{a}' is initialized to 'undefined'.",
+  E012: "Missing initializer for constant '{a}'.",
   E013: "Attempting to override '{a}' which is a constant.",
 
   // Regular expressions

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -1165,8 +1165,8 @@ exports.testES6ModulesNamedExportsAffectUnused = function (test) {
   ];
 
   TestRun(test)
-    .addError(19, 14, "const 'c1u' is initialized to 'undefined'.")
-    .addError(19, 19, "const 'c2u' is initialized to 'undefined'.")
+    .addError(19, 14, "Missing initializer for constant 'c1u'.")
+    .addError(19, 19, "Missing initializer for constant 'c2u'.")
     .test(src1, {
       esnext: true,
       unused: true
@@ -2565,7 +2565,7 @@ exports.constWithoutVar = function(test) {
 
 exports.constWithoutInit = function(test) {
   TestRun(test, "single binding")
-    .addError(1, 6, "const 'x' is initialized to 'undefined'.")
+    .addError(1, 6, "Missing initializer for constant 'x'.")
     .test([
       "for (const x; ;) {",
       "  void x;",
@@ -2573,7 +2573,7 @@ exports.constWithoutInit = function(test) {
     ], { esversion: 6 });
 
   TestRun(test, "multiple bindings")
-    .addError(1, 6, "const 'y' is initialized to 'undefined'.")
+    .addError(1, 6, "Missing initializer for constant 'y'.")
     .test([
       "for (const y, z; ;) {",
       "  void (y, z);",

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -2488,11 +2488,11 @@ exports.esnext = function (test) {
   ];
 
   TestRun(test)
-    .addError(21, 7, "const 'immutable4' is initialized to 'undefined'.")
+    .addError(21, 7, "Missing initializer for constant 'immutable4'.")
     .test(src, { esnext: true });
 
   TestRun(test)
-    .addError(21, 7, "const 'immutable4' is initialized to 'undefined'.")
+    .addError(21, 7, "Missing initializer for constant 'immutable4'.")
     .test(src, { moz: true });
 
   TestRun(test)


### PR DESCRIPTION
With the exception of `for..of` and `for..in` heads, constant binding declarations which lack an initializer are syntactically invalid. Despite this, the warning emitted for the construction suggests that the problem lies in runtime behavior. In fact, the constant is not initialized to any value because the code is never evaluated.

Rephrase the warning to more accurately describe the issue.