### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -153,7 +153,7 @@ function loadReporter(fp) {
 
 // Storage for memoized results from find file
 // Should prevent lots of directory traversal &
-// lookups when liniting an entire project
+// lookups when linting an entire project
 var findFileResults = {};
 
 /**

--- a/src/jshint.js
+++ b/src/jshint.js
@@ -43,7 +43,7 @@ var scopeManager = require("./scope-manager.js");
 var prodParams   = require("./prod-params.js");
 
 // We need this module here because environments such as IE and Rhino
-// don't necessarilly expose the 'console' API and browserify uses
+// don't necessarily expose the 'console' API and browserify uses
 // it to log things. It's a sad state of affair, really.
 var console = require("console-browserify");
 
@@ -6130,7 +6130,7 @@ var JSHINT = (function() {
   function computedPropertyName(context) {
     advance("[");
 
-    // Explicitly reclassify token as a delimeter to prevent its later
+    // Explicitly reclassify token as a delimiter to prevent its later
     // interpretation as an "infix" operator.
     state.tokens.curr.delim = true;
     state.tokens.curr.lbp = 0;


### PR DESCRIPTION
There are small typos in:
- src/cli.js
- src/jshint.js

Fixes:
- Should read `necessarily` rather than `necessarilly`.
- Should read `linting` rather than `liniting`.
- Should read `delimiter` rather than `delimeter`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md