### PR TITLE
feat: update globals for node up to v20

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -526,7 +526,28 @@ exports.node = {
   setImmediate   : true, // v0.9.1+
   clearImmediate : true, // v0.9.1+
   URL            : true, // v10.0.0+
-  URLSearchParams: true  // v10.0.0+
+  URLSearchParams: true, // v10.0.0+
+  TextDecoder    : true, // v11.0.0+
+  TextEncoder    : true, // v11.0.0+
+  AbortController: true, // v15.4.0+
+  Event          : true, // v15.4.0+
+  EventTarget    : true, // v15.4.0+
+  atob           : true, // v16.0.0+
+  btoa           : true, // v16.0.0+
+  structuredClone: true, // v17.0.0+
+  Blob           : true, // v18.0.0+
+  CompressionStream: true, // v18.0.0+
+  DecompressionStream: true, // v18.0.0+
+  FormData       : true, // v18.0.0+
+  Headers        : true, // v18.0.0+
+  ReadableStream : true, // v18.0.0+
+  Request        : true, // v18.0.0+
+  Response       : true, // v18.0.0+
+  TransformStream: true, // v18.0.0+
+  WritableStream : true, // v18.0.0+
+  fetch          : true, // v18.0.0+
+  CustomEvent    : true, // v19.0.0+
+  crypto         : true  // v19.0.0+
 };
 
 exports.browserify = {


### PR DESCRIPTION
Updated by searching https://nodejs.org/docs/latest-v20.x/api/globals.html for `browser-compatible`.

There's still about a dozen esoteric ones that I didn't include because they're implementation specific and I don't think they're likely to be used (and it's tedious).

Re:
- https://github.com/jshint/jshint/issues/2008
- https://github.com/jshint/jshint/issues/2757